### PR TITLE
v0 ship W2: rebuild .pkg with full payload (closes #11)

### DIFF
--- a/v0/build/build-pkg.sh
+++ b/v0/build/build-pkg.sh
@@ -20,42 +20,103 @@ trap 'rm -rf "$WORK"' EXIT
 # ---------------------------------------------------------------------------
 # Artifact resolution
 # ---------------------------------------------------------------------------
-resolve_artifact() {
-    # $1 = filename (optionally with glob characters)
-    # $2 = "required" | "optional"
-    local name="$1"
-    local mode="$2"
-    local local_path="$REPO_ROOT/v0/build/$name"
+_resolve_from_roots() {
+    # Generic path resolver. Takes a subtree prefix (e.g. "v0/build" or
+    # "v0/src/m4l-js") and a filename (optionally globbed), checks the current
+    # worktree first, then the parent repo + any sibling worktrees under
+    # .claude/worktrees/. Emits the first hit on stdout.
+    #
+    # $1 = subtree prefix (no trailing slash)
+    # $2 = filename (may contain glob)
+    local subtree="$1"
+    local name="$2"
 
-    # Direct match (no glob).
+    local local_path="$REPO_ROOT/$subtree/$name"
     if [ -e "$local_path" ]; then
         echo "$local_path"
         return 0
     fi
-    # Glob in local tree.
     local hit
-    hit=$(ls -1 "$REPO_ROOT"/v0/build/$name 2>/dev/null | head -1 || true)
+    hit=$(ls -1 "$REPO_ROOT"/$subtree/$name 2>/dev/null | head -1 || true)
     if [ -n "$hit" ]; then
         echo "$hit"
         return 0
     fi
-    # Search sibling worktrees (harness layout: .claude/worktrees/agent-*).
-    local parent
+
+    # Walk upward looking for the main repo first, then any sibling
+    # worktrees. REPO_ROOT from a harness worktree is e.g.
+    # <main>/.claude/worktrees/agent-*; from the main repo it's <main>.
+    # Priority:
+    #   1. this worktree               (already checked above)
+    #   2. main repo (parent of .claude/worktrees, if we're in one)
+    #   3. sibling worktrees under .claude/worktrees
+    # Checking the main repo before siblings avoids picking up stale / broken
+    # artifacts (e.g. a pre-fusion sibling's htdemucs_ft_fused.onnx + .data).
+    local parent grandparent greatgrand
     parent=$(dirname "$REPO_ROOT")
-    # Walk up to find the shared repo + its siblings.
-    for candidate_root in "$parent" "$parent/.." "$parent/../.."; do
-        local found
+    grandparent=$(dirname "$parent")
+    greatgrand=$(dirname "$grandparent")
+
+    # Priority 2: direct parent-repo hits (the main repo when we're in a
+    # worktree). $greatgrand is /Users/.../stemforge when REPO_ROOT is
+    # /Users/.../stemforge/.claude/worktrees/agent-*. $grandparent is
+    # /Users/.../stemforge/.claude. $parent is /Users/.../stemforge/.claude/worktrees.
+    local candidate
+    for candidate in "$greatgrand" "$grandparent" "$parent"; do
+        local direct
         # shellcheck disable=SC2086
-        found=$(ls -1 $candidate_root/*/v0/build/$name 2>/dev/null | head -1 || true)
-        if [ -n "$found" ]; then
-            echo "$found"
+        direct=$(ls -1 $candidate/$subtree/$name 2>/dev/null | head -1 || true)
+        if [ -n "$direct" ]; then
+            echo "$direct"
             return 0
         fi
     done
 
+    # Priority 3: sibling worktrees (one-level-down wildcard).
+    for candidate in "$parent" "$grandparent" "$greatgrand"; do
+        local sibling
+        # shellcheck disable=SC2086
+        sibling=$(ls -1 $candidate/*/$subtree/$name 2>/dev/null | head -1 || true)
+        if [ -n "$sibling" ]; then
+            echo "$sibling"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+resolve_artifact() {
+    # $1 = filename (optionally with glob characters), relative to v0/build/
+    # $2 = "required" | "optional"
+    local name="$1"
+    local mode="$2"
+    local hit
+    if hit=$(_resolve_from_roots "v0/build" "$name"); then
+        echo "$hit"
+        return 0
+    fi
     if [ "$mode" = "required" ]; then
         echo "ERROR: required artifact not found: $name" >&2
-        echo "Checked: $REPO_ROOT/v0/build/ and sibling worktrees." >&2
+        echo "Checked: $REPO_ROOT/v0/build/, parent repo, and sibling worktrees." >&2
+        return 1
+    fi
+    return 1
+}
+
+resolve_m4l_js() {
+    # $1 = filename (no glob), under v0/src/m4l-js/
+    # $2 = "required" | "optional"
+    local name="$1"
+    local mode="$2"
+    local hit
+    if hit=$(_resolve_from_roots "v0/src/m4l-js" "$name"); then
+        echo "$hit"
+        return 0
+    fi
+    if [ "$mode" = "required" ]; then
+        echo "ERROR: required M4L JS not found: $name" >&2
+        echo "Checked: $REPO_ROOT/v0/src/m4l-js/, parent repo, and sibling worktrees." >&2
         return 1
     fi
     return 1
@@ -66,15 +127,54 @@ NATIVE=$(resolve_artifact "stemforge-native" required)
 ORT_DYLIB=$(resolve_artifact "libonnxruntime*.dylib" required)
 AMXD=$(resolve_artifact "StemForge.amxd" required)
 ALS=$(resolve_artifact "StemForge.als" optional || true)
-echo "    stemforge-native : $NATIVE"
-echo "    onnxruntime dylib: $ORT_DYLIB"
-echo "    StemForge.amxd   : $AMXD"
+
+# Model payload: the default htdemucs_ft_fused variant + manifest.
+# Per v0-ship-spec §5 and v0/state/A/fusion_succeeded.md, we ship ONLY the
+# fused .onnx (inline, no .data sidecar). Analyzer models (ast, clap) and
+# fallbacks (htdemucs, htdemucs_6s, 4-head .head{0..3}_static.onnx) are
+# explicitly out of scope for v0.
+MANIFEST=$(resolve_artifact "models/manifest.json" required)
+FUSED_ONNX=$(resolve_artifact "models/htdemucs_ft/htdemucs_ft_fused.onnx" required)
+
+# Node-for-Max bridge/loader JS — must land alongside StemForge.amxd so that
+# the device's embedded node.script can locate them at spawn time.
+BRIDGE_JS=$(resolve_m4l_js "stemforge_bridge.v0.js" required)
+LOADER_JS=$(resolve_m4l_js "stemforge_loader.v0.js" required)
+
+echo "    stemforge-native       : $NATIVE"
+echo "    onnxruntime dylib      : $ORT_DYLIB"
+echo "    StemForge.amxd         : $AMXD"
+echo "    models/manifest.json   : $MANIFEST"
+echo "    htdemucs_ft_fused.onnx : $FUSED_ONNX"
+echo "    stemforge_bridge.v0.js : $BRIDGE_JS"
+echo "    stemforge_loader.v0.js : $LOADER_JS"
 if [ -n "$ALS" ]; then
-    echo "    StemForge.als    : $ALS"
+    echo "    StemForge.als          : $ALS"
     ALS_INCLUDED=true
 else
-    echo "    StemForge.als    : (missing — skeleton.als pending, template will not be bundled)"
+    echo "    StemForge.als          : (missing — skeleton.als pending, template will not be bundled)"
     ALS_INCLUDED=false
+fi
+
+# ---------------------------------------------------------------------------
+# Fusion-contract check: the fused .onnx MUST be a single inline file with no
+# `.data` sidecar in the same directory. CoreML EP MLProgram compile silently
+# falls back to CPU with SystemError 20 when weights are external. Bail loudly
+# here rather than ship a broken pkg. See v0/state/A/fusion_succeeded.md.
+# ---------------------------------------------------------------------------
+FUSED_DIR=$(dirname "$FUSED_ONNX")
+FUSED_BASE=$(basename "$FUSED_ONNX")
+SIDECAR_COUNT=$(ls -1 "$FUSED_DIR" 2>/dev/null | awk -v base="$FUSED_BASE" '
+    $0 == base ".data" || $0 == base ".data0" { c++ }
+    END { print c+0 }')
+if [ "$SIDECAR_COUNT" -gt 0 ]; then
+    echo "ERROR: fused ONNX has an external .data sidecar alongside it." >&2
+    echo "       $FUSED_DIR contains a .data file next to $FUSED_BASE." >&2
+    echo "       CoreML EP cannot consume external-weight ONNX (see" >&2
+    echo "       v0/state/A/fusion_succeeded.md). Rebuild the fused model" >&2
+    echo "       with onnx.save(..., save_as_external_data=False) before" >&2
+    echo "       attempting to ship a pkg." >&2
+    exit 1
 fi
 
 # ---------------------------------------------------------------------------
@@ -94,6 +194,22 @@ cp "$REPO_ROOT/v0/build/uninstall.sh" "$SYS_ROOT/usr/local/bin/stemforge-uninsta
 chmod 0755 "$SYS_ROOT/usr/local/bin/stemforge-uninstall"
 
 cp "$AMXD" "$USR_ROOT/tmp/stemforge-staging/StemForge.amxd"
+
+# Node-for-Max bridge + loader — must be copied alongside the .amxd so the
+# device's embedded node.script finds them. postinstall relocates them into
+# the Ableton User Library next to StemForge.amxd.
+cp "$BRIDGE_JS" "$USR_ROOT/tmp/stemforge-staging/stemforge_bridge.v0.js"
+cp "$LOADER_JS" "$USR_ROOT/tmp/stemforge-staging/stemforge_loader.v0.js"
+
+# Models — approach 1 (see v0-ship-spec §3 W2): stage under user-component
+# staging, then postinstall mv's the tree into the target user's
+# ~/Library/Application Support/StemForge/models/. Same pattern as the .amxd.
+# v0 ships ONLY the htdemucs_ft_fused variant + manifest (≈0.9 GB total).
+MODELS_STAGE="$USR_ROOT/tmp/stemforge-staging/models"
+mkdir -p "$MODELS_STAGE/htdemucs_ft"
+cp "$MANIFEST" "$MODELS_STAGE/manifest.json"
+cp "$FUSED_ONNX" "$MODELS_STAGE/htdemucs_ft/htdemucs_ft_fused.onnx"
+
 if [ -n "$ALS" ]; then
     cp "$ALS" "$USR_ROOT/tmp/stemforge-staging/StemForge.als"
 fi
@@ -135,8 +251,11 @@ productbuild \
     "$OUT"
 
 SIZE=$(stat -f%z "$OUT")
-echo "==> Built $OUT ($SIZE bytes)"
-echo "    als_included: $ALS_INCLUDED"
+SIZE_GB=$(awk -v b="$SIZE" 'BEGIN{printf "%.2f", b/1024/1024/1024}')
+PKG_SHA=$(shasum -a 256 "$OUT" | awk '{print $1}')
+echo "==> Built $OUT ($SIZE bytes, ${SIZE_GB} GB)"
+echo "    sha256       : $PKG_SHA"
+echo "    als_included : $ALS_INCLUDED"
 if [ "$ALS_INCLUDED" = "false" ]; then
     echo ""
     echo "    NOTE: Rerun this script after Track D lands StemForge.als to produce"

--- a/v0/src/installer/scripts/postinstall
+++ b/v0/src/installer/scripts/postinstall
@@ -42,10 +42,40 @@ mkdir -p "$HOME/stemforge/processed"
 mkdir -p "$HOME/stemforge/logs"
 
 STAGING=/tmp/stemforge-staging
+AMXD_DEST="$LIB/Presets/Audio Effects/Max Audio Effect"
 if [ -f "$STAGING/StemForge.amxd" ]; then
-    cp "$STAGING/StemForge.amxd" "$LIB/Presets/Audio Effects/Max Audio Effect/"
+    cp "$STAGING/StemForge.amxd" "$AMXD_DEST/"
 else
     echo "WARNING: StemForge.amxd missing from staging; device will not appear in Ableton" >&2
+fi
+
+# Node-for-Max bridge + loader JS — must sit in the same directory as
+# StemForge.amxd so the device's embedded node.script can resolve them.
+for js in stemforge_bridge.v0.js stemforge_loader.v0.js; do
+    if [ -f "$STAGING/$js" ]; then
+        cp "$STAGING/$js" "$AMXD_DEST/"
+    else
+        echo "WARNING: $js missing from staging; M4L device child process will fail to start" >&2
+    fi
+done
+
+# Models — staged into /tmp under the user component, relocated here into the
+# target user's Application Support tree. v0 ships only the default-path model
+# (htdemucs_ft_fused) + manifest.json; fused .onnx is an inline ~697 MB file
+# (CoreML EP cannot consume an external-weight .data sidecar).
+MODELS_DEST="$HOME/Library/Application Support/StemForge/models"
+if [ -d "$STAGING/models" ]; then
+    # Clear any stale contents (e.g. prior install or symlink) to avoid
+    # shadowing new files with an old version. Preserve the dir itself.
+    if [ -L "$MODELS_DEST" ]; then
+        rm -f "$MODELS_DEST"
+        mkdir -p "$MODELS_DEST"
+    fi
+    # Copy rather than mv so we tolerate cross-device staging roots and so
+    # failures leave staging intact for retry. Use -R to preserve layout.
+    cp -R "$STAGING/models/." "$MODELS_DEST/"
+else
+    echo "WARNING: models/ missing from staging; first split will fail to load htdemucs_ft_fused" >&2
 fi
 
 if [ -f "$STAGING/StemForge.als" ]; then
@@ -58,7 +88,9 @@ fi
 if [ "$(id -u)" = "0" ] && [ -n "${USER:-}" ] && [ "$USER" != "root" ]; then
     chown -R "$USER" "$HOME/Library/Application Support/StemForge" \
                     "$HOME/stemforge" \
-                    "$LIB/Presets/Audio Effects/Max Audio Effect/StemForge.amxd" \
+                    "$AMXD_DEST/StemForge.amxd" \
+                    "$AMXD_DEST/stemforge_bridge.v0.js" \
+                    "$AMXD_DEST/stemforge_loader.v0.js" \
                     "$LIB/Templates/StemForge.als" 2>/dev/null || true
 fi
 

--- a/v0/state/E/artifacts.json
+++ b/v0/state/E/artifacts.json
@@ -1,36 +1,65 @@
 {
   "track": "E",
   "status": "done",
-  "branch": "feat/v0-E-installer",
+  "workstream": "W2",
+  "branch": "feat/v0-ship-w2-installer-rebuild",
   "artifacts": [
     {
       "path": "v0/build/StemForge-0.0.0.pkg",
-      "sha256": "3ccf95c2c7f6e25b6a78ebeadf098ac0a607d13165a8886dd62a6babff8ad6db",
-      "size_bytes": 9667693,
+      "sha256": "c94c838704409d1df2e98cbecacb0d2742274f7ca63f8016ce9a22ae984d2edf",
+      "size_bytes": 409131828,
+      "size_gb": 0.38,
       "signed": false,
       "notarized": false,
-      "als_included": false
+      "als_included": false,
+      "models_included": true,
+      "m4l_js_included": true
     },
-    {"path": "v0/build/build-pkg.sh", "role": "reproducible build entrypoint"},
+    {"path": "v0/build/build-pkg.sh", "role": "reproducible build entrypoint (W2: models + M4L JS staging + fusion-contract check)"},
     {"path": "v0/build/sign-notarize-pkg.sh", "role": "invoked by Track F CI"},
     {"path": "v0/build/install.sh", "role": "curl-pipeable wrapper"},
     {"path": "v0/build/uninstall.sh", "role": "installed at /usr/local/bin/stemforge-uninstall"},
     {"path": "v0/src/installer/distribution.xml", "role": "productbuild distribution"},
-    {"path": "v0/src/installer/scripts/postinstall", "role": ".pkg postinstall (user-local relocation)"},
+    {"path": "v0/src/installer/scripts/postinstall", "role": ".pkg postinstall (W2: models + JS relocation + existing .amxd/warmup)"},
     {"path": "v0/src/installer/component-system.plist", "role": "reserved (empty; non-bundle payload)"},
     {"path": "v0/src/installer/component-user.plist", "role": "reserved (empty; non-bundle payload)"}
   ],
   "upstream_sources": {
-    "stemforge-native": "/Users/zak/zacharysbrown/stemforge/.claude/worktrees/agent-a133b5f9/v0/build/stemforge-native",
-    "libonnxruntime.1.24.4.dylib": "/Users/zak/zacharysbrown/stemforge/.claude/worktrees/agent-a133b5f9/v0/build/libonnxruntime.1.24.4.dylib",
-    "StemForge.amxd": "/Users/zak/zacharysbrown/stemforge/.claude/worktrees/agent-a02a5a81/v0/build/StemForge.amxd",
-    "StemForge.als": "NOT FOUND — Track D blocked on skeleton.als"
+    "stemforge-native": "/Users/zak/zacharysbrown/stemforge/v0/build/stemforge-native",
+    "libonnxruntime.1.24.4.dylib": "/Users/zak/zacharysbrown/stemforge/v0/build/libonnxruntime.1.24.4.dylib",
+    "StemForge.amxd": "v0/build/StemForge.amxd (canonicalized by W1)",
+    "stemforge_bridge.v0.js": "v0/src/m4l-js/stemforge_bridge.v0.js (canonicalized by W1)",
+    "stemforge_loader.v0.js": "v0/src/m4l-js/stemforge_loader.v0.js (canonicalized by W1)",
+    "models/manifest.json": "v0/build/models/manifest.json",
+    "models/htdemucs_ft/htdemucs_ft_fused.onnx": "/Users/zak/zacharysbrown/stemforge/v0/build/models/htdemucs_ft/htdemucs_ft_fused.onnx",
+    "StemForge.als": "NOT FOUND — Track D/W3 pending on skeleton.als human handoff"
   },
-  "tests": {
-    "total": 19,
-    "passed": 19,
-    "failed": 0,
-    "file_layout": "v0/src/installer/tests/"
+  "payload_contents": {
+    "system_component": [
+      "usr/local/bin/stemforge-native",
+      "usr/local/bin/stemforge-uninstall",
+      "usr/local/lib/libonnxruntime.1.24.4.dylib"
+    ],
+    "user_component_staging": [
+      "tmp/stemforge-staging/StemForge.amxd",
+      "tmp/stemforge-staging/stemforge_bridge.v0.js",
+      "tmp/stemforge-staging/stemforge_loader.v0.js",
+      "tmp/stemforge-staging/models/manifest.json",
+      "tmp/stemforge-staging/models/htdemucs_ft/htdemucs_ft_fused.onnx"
+    ],
+    "user_component_scripts": ["postinstall"]
   },
-  "notes": "Unsigned dev build. build-pkg.sh resolves artifacts from this worktree or any sibling worktree (harness multi-agent layout), so `bash v0/build/build-pkg.sh` works from any branch once A/C are done. Rerun the same command after Track D lands StemForge.als to produce a bundle that also installs the template. Signing + notarization is gated on CI secrets (see sign-notarize-pkg.sh); Track F wires it."
+  "embedded_fused_onnx": {
+    "path_in_pkg": "user.pkg/Payload/tmp/stemforge-staging/models/htdemucs_ft/htdemucs_ft_fused.onnx",
+    "sha256": "71828190efe191a622f9c9273471de1458fe0e108f277872d43c5c81cbe29ce9",
+    "size_bytes": 697251672,
+    "has_data_sidecar": false
+  },
+  "verification": {
+    "pkgutil_expand_full": "PASS",
+    "all_expected_files_present": true,
+    "fused_onnx_sha256_matches": true,
+    "fusion_contract_inline_only": true
+  },
+  "notes": "W2 rebuild: pkg now bundles htdemucs_ft_fused.onnx + manifest.json under user-component staging, and ships the two Node-for-Max JS files alongside StemForge.amxd so the device can spawn its child process on a fresh Mac account. postinstall extended to mv models into ~/Library/Application Support/StemForge/models/ and copy JS next to the .amxd (approach 1 from v0-ship-spec §3 W2). Fusion-contract check added to build-pkg.sh fails loudly if a .data sidecar is ever reintroduced next to the fused ONNX. Resolver rewritten to prefer main-repo artifacts over sibling-worktree copies, since some siblings carry a pre-fusion .onnx+.data pair. Final pkg is 0.38 GB — compressed better than the 0.9 GB estimate in the spec (zstd on ONNX fp16 weights), well under the 1.5 GB red-line."
 }

--- a/v0/state/E/done.flag
+++ b/v0/state/E/done.flag
@@ -1,11 +1,18 @@
 {
-  "completed_at": "2026-04-14T08:00:00Z",
-  "branch": "feat/v0-E-installer",
+  "completed_at": "2026-04-16T16:00:00Z",
+  "workstream": "W2",
+  "branch": "feat/v0-ship-w2-installer-rebuild",
   "pkg_path": "v0/build/StemForge-0.0.0.pkg",
-  "pkg_size_bytes": 9667693,
-  "pkg_sha256": "3ccf95c2c7f6e25b6a78ebeadf098ac0a607d13165a8886dd62a6babff8ad6db",
+  "pkg_size_bytes": 409131828,
+  "pkg_size_gb": 0.38,
+  "pkg_sha256": "c94c838704409d1df2e98cbecacb0d2742274f7ca63f8016ce9a22ae984d2edf",
+  "fused_onnx_sha256": "71828190efe191a622f9c9273471de1458fe0e108f277872d43c5c81cbe29ce9",
+  "fused_onnx_size_bytes": 697251672,
+  "has_data_sidecar": false,
+  "models_included": true,
+  "m4l_js_included": true,
   "als_included": false,
   "signed": false,
   "notarized": false,
-  "tests_pass": true
+  "verification_pkgutil_expand_full": "PASS"
 }


### PR DESCRIPTION
## Summary

Rebuilds the .pkg so a fresh Mac account actually has everything the M4L device needs to boot.

- **Bundle the models**: `v0/build/build-pkg.sh` now stages `models/manifest.json` and `models/htdemucs_ft/htdemucs_ft_fused.onnx` (697 MB inline, no `.data` sidecar) into the user component. `v0/src/installer/scripts/postinstall` relocates them into `~/Library/Application Support/StemForge/models/` on install (approach 1 per `docs/v0-ship-spec.md` §3 W2).
- **Bundle the M4L bridge JS**: `stemforge_bridge.v0.js` + `stemforge_loader.v0.js` are copied alongside `StemForge.amxd` in the detected Ableton User Library, so Node for Max can resolve them at device-spawn time.
- **Fusion-contract guard**: `build-pkg.sh` bails loudly if a `.data` sidecar ever reappears next to the fused ONNX — CoreML EP silently falls back to CPU with external weights (see `v0/state/A/fusion_succeeded.md`).
- **Resolver priority**: main-repo `v0/build/` beats sibling worktrees, since some siblings still carry the pre-fusion `.onnx + .data` pair and must not be picked up.
- **Excluded from v0**: `ast/`, `clap/`, `clap_genre_embeddings.json`, `htdemucs/`, `htdemucs_6s/`, 4-head fallback `htdemucs_ft.head{0,1,2,3}_static.onnx`, `ort_cache/`. v0 M4L only calls `htdemucs_ft_fused`.

## Final .pkg artifact

| field | value |
| --- | --- |
| path | `v0/build/StemForge-0.0.0.pkg` |
| size | **409,131,828 bytes (~0.38 GB)** |
| sha256 | `c94c838704409d1df2e98cbecacb0d2742274f7ca63f8016ce9a22ae984d2edf` |
| als_included | `false` (W3 skeleton.als pending) |
| signed / notarized | `false` (post-v0) |

The spec estimated ~0.9 GB but pkgbuild's default zstd compressed the ONNX fp16 weights far better than expected. Well under the 1.5 GB red-line.

## pkgutil expand-verify

`pkgutil --expand-full` output (all expected files present):

```
/tmp/sf-w2-verify/pkg/Distribution
/tmp/sf-w2-verify/pkg/system.pkg/Bom
/tmp/sf-w2-verify/pkg/system.pkg/PackageInfo
/tmp/sf-w2-verify/pkg/system.pkg/Payload/usr/local/bin/stemforge-native
/tmp/sf-w2-verify/pkg/system.pkg/Payload/usr/local/bin/stemforge-uninstall
/tmp/sf-w2-verify/pkg/system.pkg/Payload/usr/local/lib/libonnxruntime.1.24.4.dylib
/tmp/sf-w2-verify/pkg/user.pkg/Bom
/tmp/sf-w2-verify/pkg/user.pkg/PackageInfo
/tmp/sf-w2-verify/pkg/user.pkg/Payload/tmp/stemforge-staging/StemForge.amxd
/tmp/sf-w2-verify/pkg/user.pkg/Payload/tmp/stemforge-staging/models/htdemucs_ft/htdemucs_ft_fused.onnx
/tmp/sf-w2-verify/pkg/user.pkg/Payload/tmp/stemforge-staging/models/manifest.json
/tmp/sf-w2-verify/pkg/user.pkg/Payload/tmp/stemforge-staging/stemforge_bridge.v0.js
/tmp/sf-w2-verify/pkg/user.pkg/Payload/tmp/stemforge-staging/stemforge_loader.v0.js
/tmp/sf-w2-verify/pkg/user.pkg/Scripts/postinstall
```

Embedded fused ONNX:

- `user.pkg/Payload/tmp/stemforge-staging/models/htdemucs_ft/htdemucs_ft_fused.onnx`
- size: **697,251,672 bytes**
- sha256: **`71828190efe191a622f9c9273471de1458fe0e108f277872d43c5c81cbe29ce9`** (matches canonical)
- no `.data` sidecar in the same directory — fusion contract intact

## Test plan

- [ ] Install on a fresh Mac account: `sudo installer -pkg v0/build/StemForge-0.0.0.pkg -target /`
- [ ] Verify `~/Library/Application Support/StemForge/models/htdemucs_ft/htdemucs_ft_fused.onnx` sha256 matches canonical
- [ ] Verify `~/Music/Ableton/User Library/Presets/Audio Effects/Max Audio Effect/` contains `StemForge.amxd`, `stemforge_bridge.v0.js`, `stemforge_loader.v0.js`
- [ ] Open Ableton 12.1.x, drop StemForge onto an audio track, drop a .wav onto it, confirm stems populate (W5 runbook)
- [ ] W4 will add an automated `pkgutil --expand-full` test

Closes #11.

Automated build/verify log stored in `v0/state/E/artifacts.json`.

Generated with [Claude Code](https://claude.com/claude-code).
