### PR TITLE
chore(lint): clean up format/lint debt from PR #37 merge

### DIFF
--- a/stemforge/cli.py
+++ b/stemforge/cli.py
@@ -251,9 +251,7 @@ def split(
     auto_bpm = reconciled.bpm
     auto_beats = reconciled.beat_times
     auto_downbeats = reconciled.downbeat_times
-    auto_first_downbeat = (
-        float(auto_downbeats[0]) if len(auto_downbeats) > 0 else 0.0
-    )
+    auto_first_downbeat = float(auto_downbeats[0]) if len(auto_downbeats) > 0 else 0.0
 
     # Apply manual overrides. When BPM is overridden we resynthesize the
     # beat grid at the user's tempo, anchored on whichever first_downbeat
@@ -261,9 +259,7 @@ def split(
     overrides_active = (bpm_override is not None) or (first_downbeat_override is not None)
     bpm = bpm_override if bpm_override is not None else auto_bpm
     first_downbeat_sec = (
-        first_downbeat_override
-        if first_downbeat_override is not None
-        else auto_first_downbeat
+        first_downbeat_override if first_downbeat_override is not None else auto_first_downbeat
     )
 
     if bpm_override is not None:
@@ -297,8 +293,10 @@ def split(
     if len(beat_times) == 0:
         bpm, beat_times = detect_bpm_and_beats(bpm_source)
 
-    src_color = "green" if (overrides_active or reconciled.confidence == "high") else (
-        "yellow" if reconciled.confidence == "medium" else "red"
+    src_color = (
+        "green"
+        if (overrides_active or reconciled.confidence == "high")
+        else ("yellow" if reconciled.confidence == "medium" else "red")
     )
     console.print(
         f"  BPM: [bold cyan]{bpm:.2f}[/bold cyan]  "
@@ -395,9 +393,7 @@ def split(
         tempo_provenance = TempoProvenance(
             source=reconciled.source,
             confidence=reconciled.confidence,
-            first_downbeat_sec=(
-                float(downbeat_times[0]) if len(downbeat_times) > 0 else None
-            ),
+            first_downbeat_sec=(float(downbeat_times[0]) if len(downbeat_times) > 0 else None),
             n_downbeats=int(len(downbeat_times)),
             warning=reconciled.warning,
             all_estimates=[e.to_dict() for e in reconciled.all_estimates],
@@ -595,7 +591,8 @@ def re_anchor(track_dir, bpm, first_downbeat, pre_bars, pad_pre_bars, pad_post_b
         old_dn = sj["tempo"].get("first_downbeat_sec")
         console.print(
             f"  Old first_downbeat: [yellow]{old_dn}s[/yellow]"
-            if old_dn is not None else "  Old first_downbeat: [dim]none recorded[/dim]"
+            if old_dn is not None
+            else "  Old first_downbeat: [dim]none recorded[/dim]"
         )
     console.print(f"  New first_downbeat: [green]{first_downbeat}s[/green]")
 

--- a/stemforge/exporters/koala.py
+++ b/stemforge/exporters/koala.py
@@ -38,7 +38,6 @@ import shutil
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
 
 # Koala hard limits (per the manual)
 PADS_PER_BANK = 64
@@ -114,9 +113,7 @@ def export_koala(curated_dir: Path, config: KoalaExportConfig | None = None) -> 
     bank_02_count = _build_bank_02_kit(curated_dir, bank_02, config)
 
     # README for the human at the other end of the AirDrop
-    _write_readme(
-        staging, project_name, manifest, bank_01_count, bank_02_count, config
-    )
+    _write_readme(staging, project_name, manifest, bank_01_count, bank_02_count, config)
 
     # Zip it
     zip_path = config.output_dir / f"{project_name}_koala.zip"
@@ -153,7 +150,6 @@ def _build_bank_01_loops(
     keeps the visual 4×4 grid alignment stable across exports — drums always
     on row 1, bass always on row 2, etc.
     """
-    pad_index = 1
     files_copied = 0
 
     for row, stem in enumerate(STEM_ORDER):
@@ -186,8 +182,6 @@ def _build_bank_01_loops(
             dest_name = f"{pad:02d}_{stem}_{slot + 1:02d}.wav"
             shutil.copy2(src, bank_dir / dest_name)
             files_copied += 1
-
-        pad_index = row_start + config.loops_per_stem
 
     return files_copied
 
@@ -252,8 +246,7 @@ def _load_manifest(curated_dir: Path) -> dict:
     manifest_path = curated_dir / "manifest.json"
     if not manifest_path.exists():
         raise FileNotFoundError(
-            f"No manifest.json in {curated_dir}. "
-            f"Did you run `stemforge curate` on this project?"
+            f"No manifest.json in {curated_dir}. Did you run `stemforge curate` on this project?"
         )
     return json.loads(manifest_path.read_text())
 
@@ -284,10 +277,7 @@ def _ranked_loops_for_stem(manifest: dict, stem: str, limit: int) -> list[str]:
 
     # Shape B: {"loops": [{"stem": "drums", "file": "...", "rank": 1}, ...]}
     if "loops" in manifest and isinstance(manifest["loops"], list):
-        entries = [
-            e for e in manifest["loops"]
-            if isinstance(e, dict) and e.get("stem") == stem
-        ]
+        entries = [e for e in manifest["loops"] if isinstance(e, dict) and e.get("stem") == stem]
         sorted_entries = sorted(
             entries,
             key=lambda e: e.get("rank", e.get("position", e.get("score", 0))),
@@ -309,7 +299,7 @@ def _write_readme(
     bpm = manifest.get("bpm", "unknown")
     readme = f"""\
 {project_name} — Koala Sampler bank set
-{'=' * 60}
+{"=" * 60}
 
 Source BPM: {bpm}
 Bank 1 (loops): {bank_01_count} samples

--- a/stemforge/prechop.py
+++ b/stemforge/prechop.py
@@ -261,9 +261,7 @@ def prechop_stem(
         # start that don't exist on disk.
         silence_before_frames = max(0, pad_pre_frames - target_start)
         if silence_before_frames > 0:
-            silence_before = np.zeros(
-                (silence_before_frames, chunk.shape[1]), dtype=chunk.dtype
-            )
+            silence_before = np.zeros((silence_before_frames, chunk.shape[1]), dtype=chunk.dtype)
             chunk = np.concatenate([silence_before, chunk], axis=0)
             actual_pre = pad_pre_frames
         else:
@@ -468,9 +466,7 @@ def _decide_emit_partial(
         if name in skip_set:
             continue
         try:
-            data, _ = sf.read(
-                str(path), start=0, stop=leftover_frames, always_2d=True
-            )
+            data, _ = sf.read(str(path), start=0, stop=leftover_frames, always_2d=True)
         except Exception:
             continue
         if data.size == 0:

--- a/stemforge/tempo_reconciler.py
+++ b/stemforge/tempo_reconciler.py
@@ -35,6 +35,7 @@ Returns a `ReconciledTempo` with full provenance — every estimate that ran is
 preserved so the manifest can capture what each detector saw, not just the
 winner. That data is what makes future-fix work tractable.
 """
+
 from __future__ import annotations
 
 import logging
@@ -230,9 +231,7 @@ def _detect_beat_this(
         # too noisy to filter (e.g. drum-and-bass with one downbeat per phrase).
         bpm_from_bars = _bpm_from_downbeats(downbeats)
         bpm = (
-            bpm_from_bars
-            if bpm_from_bars is not None
-            else 60.0 / float(np.median(np.diff(beats)))
+            bpm_from_bars if bpm_from_bars is not None else 60.0 / float(np.median(np.diff(beats)))
         )
         # Trim phantom early downbeats: keep only from the first one whose
         # IBI to its successor matches the bar period within 5%. This makes
@@ -247,8 +246,10 @@ def _detect_beat_this(
             if idx > 0:
                 downbeats = downbeats[idx:]
         source: TempoSource = (
-            "beat-this:mix" if audio_label == "mix"
-            else "beat-this:drums" if audio_label == "drums"
+            "beat-this:mix"
+            if audio_label == "mix"
+            else "beat-this:drums"
+            if audio_label == "drums"
             else "beat-this:kick"
         )
         return TempoEstimate(
@@ -273,8 +274,7 @@ def _detect_librosa(
 
     bpm, beats = detect_bpm_and_beats(audio_path)
     source: TempoSource = (
-        "librosa:mix" if audio_label == "mix"
-        else "librosa:drums"
+        "librosa:mix" if audio_label == "mix" else "librosa:drums"
         # librosa never runs on kick stem in the reconciler — kick is
         # only used as a beat-this tiebreaker. But keep the type sound.
     )
@@ -315,14 +315,10 @@ def refine_first_downbeat(
 
     y, sr = librosa.load(str(audio_path), sr=None, mono=True)
     # Kick-band only — channel 0 of multi-band onset detection (~20-200 Hz)
-    onset_multi = librosa.onset.onset_strength_multi(
-        y=y, sr=sr, channels=[0, 32, 64, 96, 128]
-    )
+    onset_multi = librosa.onset.onset_strength_multi(y=y, sr=sr, channels=[0, 32, 64, 96, 128])
     kick_onset = onset_multi[0]
     hop = 512  # librosa default
-    onset_times = librosa.frames_to_time(
-        np.arange(len(kick_onset)), sr=sr, hop_length=hop
-    )
+    onset_times = librosa.frames_to_time(np.arange(len(kick_onset)), sr=sr, hop_length=hop)
 
     beat_period = 60.0 / bpm
     bar_period = beats_per_bar * beat_period

--- a/tests/ep133/test_song_synthesizer.py
+++ b/tests/ep133/test_song_synthesizer.py
@@ -607,7 +607,9 @@ def test_synthesize_loop_region_tiles_across_longer_pattern(manifest):
                 start_time_sec=0.0,
                 length_sec=16.0,
             ),
-            b_clip=None, c_clip=None, d_clip=None,
+            b_clip=None,
+            c_clip=None,
+            d_clip=None,
         ),
     ]
     spec = synthesize(snaps, enriched, 120.0, (4, 4), 1, arrangement_length_sec=16.0)

--- a/tests/test_koala_exporter.py
+++ b/tests/test_koala_exporter.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import pytest
 
 from stemforge.exporters.koala import (
-    LOOPS_BANK_PADS,
     PADS_PER_BANK,
     KoalaExportConfig,
     export_koala,
@@ -70,9 +69,7 @@ def curated_dir(tmp_path: Path) -> Path:
     oneshot_counts = {"kick": 12, "snare": 8, "hihat": 6, "toms": 3, "cymbals": 4}
     for part, count in oneshot_counts.items():
         for i in range(1, count + 1):
-            _write_silent_wav(
-                curated / f"{part}_oneshots" / f"{part}_oneshot_{i:03d}.wav"
-            )
+            _write_silent_wav(curated / f"{part}_oneshots" / f"{part}_oneshot_{i:03d}.wav")
 
     manifest = {"bpm": 126.05, "n_bars": loops_per_stem, "stems": manifest_stems}
     (curated / "manifest.json").write_text(json.dumps(manifest, indent=2))
@@ -124,9 +121,7 @@ def test_bank_01_uses_correct_pad_layout(curated_dir: Path, tmp_path: Path) -> N
     assert bank_01_basenames[15].startswith("16_vocals")
 
 
-def test_bank_02_substems_first_then_oneshots(
-    curated_dir: Path, tmp_path: Path
-) -> None:
+def test_bank_02_substems_first_then_oneshots(curated_dir: Path, tmp_path: Path) -> None:
     config = KoalaExportConfig(output_dir=tmp_path / "out")
     zip_path = export_koala(curated_dir, config)
 

--- a/tests/test_prechop.py
+++ b/tests/test_prechop.py
@@ -152,7 +152,6 @@ def test_pre_chunk_crossing_source_zero_silence_pads_at_start(tmp_path):
     pad_post_bars = 1
     pre_bars = bars  # one pre-chunk's worth, identical to chunk size
     bar_frames = FPB
-    n_intro_frames = 1 * bar_frames  # 1 bar of intro source
     n_total_frames = 9 * bar_frames  # 1 bar intro + 8 bars song
     first_downbeat_sec = bar_frames / float(SR)  # exactly 1 bar in
 
@@ -480,7 +479,7 @@ def test_emit_partial_creates_chunk_001_with_silence_left_pad(tmp_path):
     assert not np.allclose(real_segment, 0.0)
     # The real audio is the source's [0, leftover_frames) — constant 0.5
     # baseline, so RMS should be ~0.5.
-    assert abs(float(np.sqrt(np.mean(real_segment ** 2))) - 0.5) < 0.01
+    assert abs(float(np.sqrt(np.mean(real_segment**2))) - 0.5) < 0.01
     # Post-pad: also real audio (continues from leftover_frames into source).
     post_pad_start = real_end
     post_pad_end = post_pad_start + pad_post_frames
@@ -622,7 +621,7 @@ def test_decide_emit_partial_any_stem_with_content_triggers_emit(tmp_path):
     stem's leading region has content, all stems emit a partial."""
     drums = tmp_path / "drums.wav"
     bass = tmp_path / "bass.wav"
-    _write_silent_stem(drums, FPB * 8)             # silent
+    _write_silent_stem(drums, FPB * 8)  # silent
     _write_marker_stem_offset(bass, FPB * 8, 0.5)  # has content
     bars = 4
     leftover_bars = 2

--- a/tests/test_tempo_reconciler.py
+++ b/tests/test_tempo_reconciler.py
@@ -1,4 +1,5 @@
 """Tests for stemforge.tempo_reconciler — multi-source BPM detection."""
+
 from __future__ import annotations
 
 from unittest import mock
@@ -205,9 +206,7 @@ class TestReconcileTempo:
 
         with (
             mock.patch("stemforge.tempo_reconciler._detect_beat_this", return_value=None),
-            mock.patch(
-                "stemforge.tempo_reconciler._detect_librosa", return_value=librosa_estimate
-            ),
+            mock.patch("stemforge.tempo_reconciler._detect_librosa", return_value=librosa_estimate),
         ):
             result = reconcile_tempo(mix, drums, kick_tiebreaker=False)
 


### PR DESCRIPTION
## Summary

PR #37 (`feat/m4l-locator-anchor`) merged with pre-existing lint/format issues that block clean commits on top. This is pure hygiene — no behavior change. Surfaced while starting the StemForge hardening pass (Stream A.1, audio_hash on ChunkMeta), where pre-commit blocks the A.1 commit due to these inherited issues.

**Lint fixes (4 errors → 0):**
- Remove 3 dead-code unused vars: \`n_intro_frames\` in [test_prechop.py:155](tests/test_prechop.py#L155), \`pad_index\` (×2) in [koala.py](stemforge/exporters/koala.py).
- Remove 2 unused imports: \`typing.Literal\` from [koala.py](stemforge/exporters/koala.py), \`LOOPS_BANK_PADS\` from [test_koala_exporter.py](tests/test_koala_exporter.py).

**Format fixes (8 files):**
- Line-wrap consolidations ruff format prefers (single-line where the line fits, removed redundant multiline wrap, single blank line after module docstring).
- Files: [cli.py](stemforge/cli.py), [koala.py](stemforge/exporters/koala.py), [prechop.py](stemforge/prechop.py), [tempo_reconciler.py](stemforge/tempo_reconciler.py), [tests/ep133/test_song_synthesizer.py](tests/ep133/test_song_synthesizer.py), [tests/test_koala_exporter.py](tests/test_koala_exporter.py), [tests/test_prechop.py](tests/test_prechop.py), [tests/test_tempo_reconciler.py](tests/test_tempo_reconciler.py).

## Test plan
- [x] \`uv run --extra dev --extra beat pytest -q\` — 505 tests pass
- [x] \`uv run ruff check stemforge tests\` — All checks passed
- [x] \`uv run ruff format --check stemforge tests\` — 84 files already formatted
- [x] Pre-commit hooks pass on commit

## Why this is its own PR

Per StemForge hardening spec discipline: per-stream PRs, no bundling. The audio_hash work (Stream A.1, coming next) needs a clean main to land cleanly. Bundling lint hygiene with feature work would conflate concerns and complicate review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)