### PR TITLE
feat(prechop): add audio_hash to ChunkMeta (Hardening Stream A.1)

### DIFF
--- a/stemforge/prechop.py
+++ b/stemforge/prechop.py
@@ -41,7 +41,7 @@ from typing import Iterable
 import numpy as np
 import soundfile as sf
 
-from .manifest_schema import SampleMeta, Stem, write_sidecar
+from .manifest_schema import SampleMeta, Stem, compute_audio_hash, write_sidecar
 
 
 # ── Phase-3 leading-partial-chunk gates ──────────────────────────────────────
@@ -112,6 +112,7 @@ class ChunkMeta:
     chunk_duration_samples: int = 0  # integer frame count — catches silent resamples
     sample_rate: int = 0  # WAV sample rate
     source_offset_sec: float = 0.0  # where in the source stem this chunk's bar 1 sits
+    audio_hash: str | None = None  # 16-hex sha256 prefix of the chunk WAV
 
     def asdict(self) -> dict:
         return asdict(self)
@@ -313,6 +314,7 @@ def prechop_stem(
             chunk_duration_samples=int(chunk.shape[0]),
             sample_rate=int(sr),
             source_offset_sec=float(target_start) / float(sr),
+            audio_hash=compute_audio_hash(fname),
         )
         metas.append(cm)
 
@@ -385,6 +387,7 @@ def prechop_stem(
             chunk_duration_samples=int(partial_wav.shape[0]),
             sample_rate=int(sr),
             source_offset_sec=partial_source_offset_sec,
+            audio_hash=compute_audio_hash(partial_fname),
         )
         metas.insert(0, partial_meta)
 

--- a/tests/test_prechop.py
+++ b/tests/test_prechop.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 import soundfile as sf
 
+from stemforge.manifest_schema import HASH_LENGTH, compute_audio_hash
 from stemforge.prechop import (
     MIN_LEFTOVER_FRAC,
     SILENCE_THRESHOLD_DBFS,
@@ -374,6 +375,68 @@ def test_pad_bars_zero_yields_unpadded_chunks(tmp_path):
         assert data.shape[0] == expected
         assert cm.loop_start_sec == 0.0
         assert abs(cm.loop_end_sec - expected / float(SR)) < 1e-6
+
+
+def test_chunk_audio_hash_is_present_and_matches_file(tmp_path):
+    # Hardening Stream A.1: every chunk's manifest entry carries an `audio_hash`
+    # field that matches the on-disk WAV bytes. Configurator clip-refs and any
+    # "did this chunk actually change?" check downstream depend on this.
+    bars = 2
+    pad_bars = 1
+    n_frames = FPB * 6
+    stem = tmp_path / "drums.wav"
+    _write_marker_stem(stem, n_frames)
+
+    metas = prechop_stem(
+        stem,
+        tmp_path,
+        "drums",
+        bpm=BPM,
+        bars=bars,
+        pad_bars=pad_bars,
+        pad_last=True,
+        write_sidecars=False,
+    )
+    assert len(metas) >= 2
+    seen_hashes: set[str] = set()
+    for cm in metas:
+        assert cm.audio_hash is not None, "every chunk must carry audio_hash"
+        assert len(cm.audio_hash) == HASH_LENGTH
+        assert all(c in "0123456789abcdef" for c in cm.audio_hash)
+        wav = tmp_path / cm.file
+        assert cm.audio_hash == compute_audio_hash(wav), (
+            "audio_hash must match a fresh sha256 of the chunk WAV"
+        )
+        seen_hashes.add(cm.audio_hash)
+    # Distinct chunks have distinct content (marker stem makes this true).
+    assert len(seen_hashes) == len(metas)
+
+
+def test_top_level_manifest_serializes_audio_hash(tmp_path):
+    # The dataclass field flows through `asdict()` into prechop_manifest.json.
+    bars = 2
+    n_frames = FPB * 4
+    stem = tmp_path / "drums.wav"
+    _write_marker_stem(stem, n_frames)
+
+    out = tmp_path / "out"
+    out.mkdir()
+    manifest_path = prechop(
+        {"drums": stem},
+        out,
+        bpm=BPM,
+        bars=bars,
+        pad_bars=1,
+        pad_last=True,
+        write_sidecars=False,
+    )
+    data = json.loads(manifest_path.read_text())
+    chunks = data["stems"]["drums"]["chunks"]
+    assert chunks, "manifest must contain at least one chunk"
+    for chunk in chunks:
+        assert "audio_hash" in chunk
+        assert isinstance(chunk["audio_hash"], str)
+        assert len(chunk["audio_hash"]) == HASH_LENGTH
 
 
 # ── Phase-3: leading partial chunk emission ─────────────────────────────────


### PR DESCRIPTION
## Summary

First PR of the StemForge hardening pass. Adds a 16-hex sha256-prefix `audio_hash` field to every entry of `prechop_manifest.json`, mirroring the existing `SampleMeta.audio_hash` pattern in `manifest_schema.py`.

**Why now:** configurator clip-refs and any future "did this chunk actually change?" check need a content-stable identifier. The current identifier (file path) breaks under `re-anchor`, which rewrites WAVs at the same paths. Adding `audio_hash` to the hardening baseline means downstream consumers always see hashes — avoiding a future retrofit + revalidation cycle.

## Changes

- `ChunkMeta.audio_hash: str | None = None` — new dataclass field on [stemforge/prechop.py:115](stemforge/prechop.py#L115).
- Both `ChunkMeta(...)` construction sites in `prechop_stem` populate the field via `compute_audio_hash(path)` ([prechop.py:317](stemforge/prechop.py#L317), [prechop.py:390](stemforge/prechop.py#L390)). Reuses the existing helper at [manifest_schema.py:100](stemforge/manifest_schema.py#L100).
- Two new regression tests in [tests/test_prechop.py](tests/test_prechop.py):
  - `test_chunk_audio_hash_is_present_and_matches_file` — every chunk carries a 16-hex sha256 prefix that re-hashes to the same value and is unique across distinct chunks.
  - `test_top_level_manifest_serializes_audio_hash` — the dataclass field flows through `asdict()` into `prechop_manifest.json`.

## Acceptance gates closed

From `docs/STEMFORGE_HARDENING_SPEC.md`:

- [x] **F-1** — `audio_hash` field present in `ChunkMeta`, serialized in `prechop_manifest.json`.
- [x] **F-2** — All test fixtures regenerated; full test suite green. *(No fixture cascade: no committed `prechop_manifest.json` files exist anywhere in the repo — all tests generate manifests at runtime in `tmp_path`. Risk R2 from the spec turned out to be near-zero.)*

## Test plan

- [x] `uv run --extra dev --extra beat pytest -q` — 507 tests pass (was 505 pre-A.1; +2 new tests added by this PR)
- [x] `uv run ruff check stemforge tests` — All checks passed
- [x] `uv run ruff format --check stemforge tests` — 84 files already formatted
- [x] Pre-commit hooks pass on commit

## Honesty footer

**Verified by reading code:** `ChunkMeta` structure at [stemforge/prechop.py:99](stemforge/prechop.py#L99); both construction sites at lines 304 and 376 (now 317 and 390 in this PR); `compute_audio_hash()` helper at [manifest_schema.py:100](stemforge/manifest_schema.py#L100); the existing `SampleMeta.audio_hash` precedent at [manifest_schema.py:66](stemforge/manifest_schema.py#L66); zero committed `prechop_manifest.json` fixtures across the repo (verified by `find`).

**Inferred from docs:** the spec's R2 risk ("fixture regeneration cascade") was based on the assumption that some test fixture might be committed. Reality is cleaner — all manifests are tmp-path generated at test runtime. Field addition is back-compat (optional with default `None`); no consumer-side changes needed.

**Surprised by:** how clean the change ended up being. Spec budgeted "half a day for fixture cascade" — that didn't materialize. The retroactive footnote on the spec is "regen cascade is zero when no fixtures are committed; consider this a near-cost-free gate."

🤖 Generated with [Claude Code](https://claude.com/claude-code)