### PR TITLE
feat: curation library router + stems_only preset + song-form templates

### DIFF
--- a/docs/exec-plans/curation-library-device-changes.md
+++ b/docs/exec-plans/curation-library-device-changes.md
@@ -1,0 +1,128 @@
+# Device-side changes for curation library — exec plan
+
+Three device-touching changes follow the curation-router work landing on
+`feat/curation-library-v2`. None are written yet. **This doc is review-
+gate** — once you sign off on a change set, we cut a focused branch and
+follow the standard pipeline (debug patch in standalone Max → build_amxd.py →
+build-pkg.sh → install). Per the Test & Deploy Discipline memory, no manual
+.amxd copies, no skipped steps.
+
+## Change 1 — Export-vs-distribute toggle (smallest, do first)
+
+**What it does:** UI control on the device that picks one of three modes:
+
+| Mode | Behavior |
+|---|---|
+| `export only` (default) | Bounce writes to `~/stemforge/exports/<song>/`. Library untouched. |
+| `distribute only` | Bounce writes to a tmp dir, then router relocates everything into `~/mus/Samples/`, then tmp dir is cleaned up. |
+| `export and distribute` | Bounce writes to `~/stemforge/exports/<song>/` AND router copies into `~/mus/Samples/`. (Default after first use, probably.) |
+
+**Where it lives:**
+- `sf_clip_export.js` (in BOTH `v0/src/m4l-js/` and `v0/src/m4l-package/StemForge/javascript/` — JS dual-location sync)
+- The bounce spec (`spec.json` written by sf_clip_export.js → consumed by `tools/m4l_export_clips.py`) gains a new field:
+  ```
+  "post_action": "export_only" | "distribute_only" | "export_and_distribute",
+  "library_root": "/Users/zak/mus"     # only present when post_action != export_only
+  ```
+- After the bouncer finishes, sf_clip_export.js issues a second `[shell]` call:
+  ```
+  uv run stemforge route <export_dir> --library <library_root>
+  ```
+  (Or, in `distribute_only` mode, runs route then deletes the temp dir.)
+
+**Risk assessment:**
+- **Low** for the JS UI control — adding one umenu/dropdown to the bounce panel.
+- **Low** for the spec.json schema additions — bouncer ignores unknown fields.
+- **Low** for the second shell call — independent of bounce, errors don't cascade.
+- **Medium** for the dual-location sync discipline — easy to forget to copy JS into both `v0/src/m4l-js/` and `v0/src/m4l-package/`. Will run the existing build-pkg.sh which copies for us.
+
+**Configurability question** (your earlier ask): the export dir path
+(`~/stemforge/exports/`) becomes a device-level setting too, in case you
+later want it inside `~/mus/Exports/` to consolidate everything in `~/mus/`.
+Default stays at `~/stemforge/exports/`.
+
+## Change 2 — Raw-stem loader target type (medium)
+
+**What it does:** Adds a new `target.type === "stem"` (or `"raw_stem"`)
+handler in `stemforge_loader.v0.js`. When the preset says
+`{ "type": "stem" }`, the loader skips curation entirely and loads the
+full stem WAV onto a single track, in clip slot 1.
+
+**Why this matters:** unblocks the *real* `stems_only.json` preset (drop
+each main stem on its own track, no slicing) AND the
+`drums_only_split.json` preset (one track per LarsNet sub-stem). Today's
+`stems_only.json` is a workaround that drops one curated 8-bar phrase per
+stem because there's no raw-stem path.
+
+**What changes:**
+- `v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js` —
+  add a third branch alongside `target.type === "clips"` and `"rack"`:
+  ```javascript
+  } else if (target.type === "stem") {
+      var stemWavPath = manifest.stems[stemName].wav_path;
+      if (!stemWavPath) { status("    skipped (no stem wav)"); continue; }
+      var trackIdx = trackCount();
+      createAudioTrack(trackIdx);
+      renameTrack(trackIdx, targetName + " | " + songName, targetColor);
+      if (chain.length > 0) applyInsertChain(trackIdx, chain);
+      loadClipToTrack(trackIdx, stemWavPath, /*slotIdx*/ 0);
+      loaded += 1;
+  }
+  ```
+- `stems_only.json` — change all 4 targets from `"type": "clips"` to
+  `"type": "stem"`, drop the curation params.
+- `drums_only_split.json` — new preset with 6 stem-type tracks (drums +
+  kick/snare/hat/toms/cymbals via sub-stem refs, see Change 3) on top of
+  the existing 6 curated drum tracks.
+
+**Risk assessment:**
+- **Medium**. Touches the core loader's main switch. New code path = new
+  failure mode. Mitigation: small, isolated branch, debug in standalone
+  Max with the existing harness, add a debug-bang test before deploying
+  via build-pkg.sh.
+- The loader memory ("M4L Device Development Guide" — 20 pitfalls) is
+  the required reading before this branch. Especially the [shell]+[js]
+  architecture and the build_amxd.py → build-pkg.sh discipline.
+
+## Change 3 — Sub-stem paths in manifest (small, blocks Change 2 for sub-stems)
+
+**What it does:** When LarsNet runs (today, only as part of one-shot
+extraction in `stemforge/oneshot.py`), persist the sub-stem WAV paths
+into `stems.json` so the loader can find them.
+
+**What changes:**
+- `stemforge/manifest.py` — extend `StemInfo` with optional
+  `sub_stems: dict[str, str]` field (e.g. `{"kick": "/path/to/kick.wav", ...}`)
+- `stemforge/oneshot.py` — after `separate_drums()` returns the sub-stem
+  paths, surface them up to the manifest writer.
+- `stemforge_loader.v0.js` — when `target.params.source_substem === "kick"`
+  is set on a `"stem"`-type target, look up `stem.sub_stems[<key>]` instead
+  of `stem.wav_path`.
+
+**Risk assessment:**
+- **Low** for the manifest schema (additive field, ignored by old readers).
+- **Low** for oneshot.py (we already have the paths, just plumbing).
+- **Low** for the loader change once Change 2 is in (it's an extension of
+  the new `"stem"` branch).
+
+## Recommended order
+
+1. **Change 1** first — small, reversible, immediately useful. Land it,
+   use it for a couple of bounces, build confidence in the JS shell-call
+   pattern before touching the loader.
+2. **Change 3** second — pure pipeline change, no device behavior change
+   yet. Sub-stem paths show up in manifests.
+3. **Change 2** last — the loader extension. By this point we have JS
+   call patterns proven (Change 1) and sub-stem paths available (Change 3),
+   so the loader change can do everything in one branch.
+
+## Things I'm explicitly NOT doing without your sign-off
+
+- Touching `stemforge_loader.v0.js`
+- Touching `sf_clip_export.js`
+- Modifying the .amxd
+- Running build-pkg.sh or installing a new package
+- Changing the manifest writer in `stemforge/manifest.py`
+
+Sign off per change number (e.g. "Change 1 yes, Change 2 hold") and I'll
+cut a focused branch off this one for whichever you want to start.

--- a/docs/song-forms/README.md
+++ b/docs/song-forms/README.md
@@ -1,0 +1,51 @@
+# Song-Form Templates
+
+Five Ableton Live `.als` templates for guided song-idea sketching. Each
+defines: target tempo, total length, locator placements (Ableton arrangement
+markers), recommended sample-set inputs, and a starter processing chain.
+
+The templates themselves are `.als` files the user builds in Ableton; this
+directory holds the **specs** — bar-counts, locator labels, instrument and
+chain recommendations — so the templates can be rebuilt or migrated
+deterministically.
+
+| Form | Genre | BPM | Bars |
+|---|---|---|---|
+| [`ambient_long_form`](ambient_long_form.md) | Ambient | 60–80 | 128 |
+| [`lofi_aaba`](lofi_aaba.md) | Lo-fi hip hop | 80–95 | 84 |
+| [`idm_squarepusher`](idm_squarepusher.md) | Glitch IDM | 140–170 | 80 |
+| [`idm_fourtet_evolve`](idm_fourtet_evolve.md) | Slow-burn IDM | 110–130 | 96 |
+| [`big_beat_drop`](big_beat_drop.md) | Big Beat | 120–140 | 128 |
+
+## Workflow these templates support
+
+1. **Pick the form** that matches the mood/energy you want.
+2. **Open the template** — `.als` already has tempo, locators, track lanes,
+   and processing chains laid out.
+3. **Drop in 4–5 sample sets** — typically curated runs from the StemForge
+   library at `~/mus/Samples/`, dragged into the designated palette tracks.
+4. **Sketch by section** — the locators force you to make A different from B
+   different from BREAK before you've over-committed to a single loop.
+5. **Bounce / commit** when a section feels right.
+
+The intent: escape "one-loop mentality" by surfacing structural variety up
+front. Empty named sections in the timeline are a stronger arrangement
+prompt than a blank canvas.
+
+## Conventions used in the per-form specs
+
+- **Locator names** become arrangement-view markers in Live (set via the
+  Insert Locator menu, or the `+` icon in the arrangement toolbar)
+- **Tempo range** is the genre's typical span; pick one and commit
+- **Track recommendations** name the *role* (e.g. "drum loops", "bass mono")
+  not specific Live devices — see `chains.md` per form for actual devices
+- **Sample-set slots** name how many palette tracks to dedicate to dragged-in
+  curation outputs
+
+## Related
+
+- `~/mus/Samples/` — StemForge library where curated palettes live
+- `~/mus/Templates/` — where the actual `.als` files should live, named to
+  match the slugs above (e.g. `ambient_long_form Project/`)
+- `stemforge/router.py` — the curation router that distributes outputs
+  into the library these templates pull from

--- a/docs/song-forms/ambient_long_form.md
+++ b/docs/song-forms/ambient_long_form.md
@@ -1,0 +1,57 @@
+# `ambient_long_form` — Ambient (Eno / Hecker / Basinski)
+
+Long-form, no hard transitions. The "form" is *which layers are present
+when* — locators mark layer entries, not section changes.
+
+## Tempo & length
+
+- **BPM:** 60–80 (recommended start: 70 — slow enough for evolution, fast
+  enough that 128 bars is ~7.3 min)
+- **Total bars:** 128 (≈ 7 min at 70 BPM)
+- **Time signature:** 4/4 (or 6/8 if you want lilt)
+
+## Locators (layer-entry markers, not section breaks)
+
+| Bar | Name | What enters |
+|---:|---|---|
+|   1 | `BED`     | drone bed only — long pad or field recording |
+|  33 | `LAYER1`  | second textural element (granular, choir, broken radio) |
+|  65 | `LAYER2`  | melodic motif (sparse, repeating) — first hint of pulse |
+|  97 | `DECAY`   | strip back to BED + tail; let reverbs ring out |
+
+## Tracks
+
+1. **Drone Bed** — Wavetable pad on a long sustained note, *or* a sampled
+   pad/choir loop with cross-fades to mask repetition
+2. **Granular Texture 1** — Granulator II on a found-sound source
+3. **Granular Texture 2** — second Granulator II, different source, panned opposite
+4. **Field Recording** — looped environmental audio (rain, street, room)
+5. **Melodic Motif** — sparse single-note sample on Simpler, triggered slowly
+6. **Bass Drone Sub** — optional 60–80 Hz sine, very low level
+7. **Convolution Reverb Send** — long IR (10–15 s tail)
+8. **Delay/Spectral Send** — Spectral Resonator or long Echo
+
+## Starter chains
+
+- **Pad / Drone:** Hybrid Reverb (large hall, 100% wet on send) → Auto Filter
+  with very slow LFO (0.05 Hz, full sweep) → Saturator (subtle warmth)
+- **Granular textures:** Spectral Resonator → Erosion (high-pass noise mode)
+  → wide stereo Echo (1/8d both sides)
+- **Field recording:** EQ Eight (high-pass at 200 Hz, low-pass at 8 kHz to
+  fit) → Compressor (gentle) → reverb send
+- **Master:** broad EQ smile → very gentle bus compression (1.5:1, slow
+  attack) → tape saturator
+- **No drums.** If you must have a pulse: a single shaker, mute it 80% of
+  the time.
+
+## Sample-set inputs
+
+- `Samples/Ambient/<source>_*.wav` — pads, drones, atmospheres
+- `Samples/Loops/Melodic/<song>_melodyloop_*.wav` — sparse motifs
+- `Samples/Vocals/<song>_vocalshot_*.wav` — choir-like or breath fragments
+
+## Sketching cue
+
+Resist drums. Resist tempo-locked elements. The form lives in *very long*
+crossfades and the way Reverb tails carry energy across locators. If you
+catch yourself adding a fourth element before bar 65, mute one.

--- a/docs/song-forms/ambient_long_form.md
+++ b/docs/song-forms/ambient_long_form.md
@@ -55,3 +55,29 @@ when* — locators mark layer entries, not section changes.
 Resist drums. Resist tempo-locked elements. The form lives in *very long*
 crossfades and the way Reverb tails carry energy across locators. If you
 catch yourself adding a fourth element before bar 65, mute one.
+
+## Building this template in Live (~25 min)
+
+1. **New Set** → tempo **70 BPM**, time signature **4/4**.
+2. **Arrangement view** (Tab).
+3. **Locators** (jump to bar, `Cmd+L`, rename):
+   - bar 1 → `BED`
+   - bar 33 → `LAYER1`
+   - bar 65 → `LAYER2`
+   - bar 97 → `DECAY`
+4. **Arrangement loop end** at bar 128.
+5. **Tracks** (audio unless noted):
+   - `Drone Bed` (purple) — destination for Wavetable or sampled pad
+   - `Granular 1` (light purple) — Granulator II target
+   - `Granular 2` (light purple)
+   - `Field Rec` (gray)
+   - `Melodic Motif` (mint) — Simpler with sparse single-note source
+   - `Bass Drone Sub` (dark blue, optional)
+6. **Three return tracks**: Convolution Reverb (long IR, 10-15s tail);
+   Spectral / Delay (Spectral Resonator OR very long Echo with feedback);
+   Texture (subtle saturator + filter sweep send).
+7. **Master**: gentle bus comp 1.5:1 slow → broad EQ smile → tape saturator.
+   Set Master output ceiling at -6 dBFS — ambient lives in low-RMS territory.
+8. **Insert chains per track** (see chains section above). Especially
+   important: Auto Filter with very slow LFO (~0.05 Hz) on the Drone Bed.
+9. **Save** to `~/mus/Templates/ambient_long_form Project/ambient_long_form.als`.

--- a/docs/song-forms/big_beat_drop.md
+++ b/docs/song-forms/big_beat_drop.md
@@ -1,0 +1,67 @@
+# `big_beat_drop` — Big Beat (Chemical Brothers / Prodigy / Fatboy Slim)
+
+Drum-led, breakbeat-heavy, EXTREME dynamic contrast. The breakdown→drop
+move is the genre's defining engine. Drop must land on a 16-bar boundary
+or the whole structure deflates.
+
+## Tempo & length
+
+- **BPM:** 120–140 (recommended start: 132)
+- **Total bars:** 128 (≈ 3:53 at 132 BPM)
+
+## Locators
+
+| Bar | Name | What's happening |
+|---:|---|---|
+|   1 | `INTRO`        | filter intro, drums build, no full break yet |
+|  17 | `A`            | first full break drops, main groove |
+|  33 | `BREAKDOWN`    | drums STRIP — bass+pad only, build with riser/sweep |
+|  49 | `DROP`         | full energy: break + bass + stab + vocal sample |
+|  81 | `BREAK`        | short stripped passage, 8 bars, drum fill at end |
+|  89 | `DROP'`        | second drop, more elements, climax |
+| 121 | `OUT`          | filter sweep, drum fill, hard cut at 128 |
+
+## Tracks
+
+1. **Break Loop** — sliced Amen / Apache / Funky Drummer on Simpler (slice mode)
+2. **Break Crushed** — parallel of #1 with heavy bus comp + saturator
+3. **Bass 303** — TB-303 emulation (Operator or external) with squelchy filter automation
+4. **Bass Sub** — sustained sub-bass for the DROP sections
+5. **Stab Sample** — short orchestra hit / horn stab on Simpler (one-shot)
+6. **Vocal Sample** — chopped vocal phrase, classic big beat ad-lib
+7. **Riser / FX** — automation lane lives here, builds at end of each section
+8. **Reverb Send** — large bright plate
+9. **Compressor Bus (drums+bass)** — heavy bus compression, fast attack
+
+## Starter chains
+
+- **Break Loop:** Glue Comp (4:1 fast attack, ratio 4) → Saturator (drive 0.5) → EQ Eight (low-shelf +2 dB at 80 Hz, slight 2 kHz cut)
+- **Break Crushed:** Compressor (8:1, hard) → Redux 4-bit → Filter (low-pass at 6 kHz, automated)
+- **Bass 303:** Filter automation lane is everything — start closed at INTRO, full open at DROP
+- **Bass Sub:** EQ low-pass 200 Hz → Compressor heavy → Saturator (sub fatness)
+- **Stabs:** EQ Eight (slight high-shelf bump) → short Reverb send → Auto Pan (subtle)
+- **Master:** Glue Comp 3:1 fast → tape saturator → limiter (push it)
+
+## Automation lanes (CRITICAL)
+
+Big Beat lives in automation. Set up lanes in advance:
+
+- Master low-pass filter — closes during BREAKDOWN, opens at DROP
+- Drum bus volume — drops to silence for last beat of every 16-bar block
+- Riser FX — increases over each pre-DROP build
+- 303 filter cutoff — sweeps continuously
+
+## Sample-set inputs
+
+- `Samples/Breaks/{Classic,Modern}/*.wav` — Amen/Apache/Funky Drummer family
+- `Samples/Oneshots/Kicks/<song>_kick_*.wav` — for parallel layered kick
+- `Samples/Loops/Bass/*.wav` — sub-bass for DROP sections
+- `Samples/Vocals/<song>_vocalshot_*.wav` — chopped ad-libs
+- Ableton's stock Operator preset library has TB-303 starters
+
+## Sketching cue
+
+Build BACKWARDS from the DROP. Lock bar 49 first — full energy, every track
+on, the moment everything "lands." THEN work backward to the BREAKDOWN
+strip-down. Most failed Big Beat sketches put energy too early — the drop
+is only powerful BECAUSE the breakdown was empty.

--- a/docs/song-forms/big_beat_drop.md
+++ b/docs/song-forms/big_beat_drop.md
@@ -65,3 +65,34 @@ Build BACKWARDS from the DROP. Lock bar 49 first — full energy, every track
 on, the moment everything "lands." THEN work backward to the BREAKDOWN
 strip-down. Most failed Big Beat sketches put energy too early — the drop
 is only powerful BECAUSE the breakdown was empty.
+
+## Building this template in Live (~35 min)
+
+1. **New Set** → tempo **132 BPM**, time signature **4/4**.
+2. **Arrangement view**.
+3. **Locators**:
+   - bar 1 → `INTRO`
+   - bar 17 → `A`
+   - bar 33 → `BREAKDOWN`
+   - bar 49 → `DROP`
+   - bar 81 → `BREAK`
+   - bar 89 → `DROP'`
+   - bar 121 → `OUT`
+4. **Arrangement loop end** at bar 128.
+5. **Tracks**:
+   - `Break Loop` (red) — Simpler slice mode (Amen/Apache/Funky Drummer)
+   - `Break Crushed` (dark red)
+   - `Bass 303` (blue) — Operator with squelchy filter automation
+   - `Bass Sub` (dark blue) — for DROP sections only
+   - `Stab Sample` (orange) — Simpler one-shot
+   - `Vocal Sample` (yellow) — chopped phrase
+   - `Riser / FX` (gray) — automation lives here
+6. **Returns**: Reverb (large bright plate), Drum+Bass Bus (heavy parallel
+   compression).
+7. **Master**: Glue Comp 3:1 fast → tape saturator → limiter (push it).
+8. **Set up automation lanes — CRITICAL for this form**:
+   - Master low-pass filter (closes at BREAKDOWN, opens at DROP)
+   - Drum bus volume (drops to silence end of every 16-bar block)
+   - Riser FX (increases over each pre-DROP build)
+   - 303 filter cutoff (continuous sweep)
+9. **Save** to `~/mus/Templates/big_beat_drop Project/big_beat_drop.als`.

--- a/docs/song-forms/idm_fourtet_evolve.md
+++ b/docs/song-forms/idm_fourtet_evolve.md
@@ -1,0 +1,58 @@
+# `idm_fourtet_evolve` — Horizontal IDM (Four Tet / Caribou)
+
+Horizontal evolution: organic accumulation of layers over time. Unlike the
+Squarepusher form (which keeps the bed constant and varies drums), this
+form lets every element grow and decay across the track.
+
+## Tempo & length
+
+- **BPM:** 110–130 (recommended start: 120)
+- **Total bars:** 96 (≈ 3:12 at 120 BPM)
+
+## Locators
+
+| Bar | Name | Layer state |
+|---:|---|---|
+|   1 | `SEED`       | one looping element only — typically a melodic chop |
+|  17 | `BUILD`      | + perc / shaker / texture |
+|  33 | `ESTABLISH`  | + drums (kick/snare appear), motif locks |
+|  49 | `VARIATION`  | melody mutates: pitch shift, new chop, harmony layer |
+|  65 | `BLOOM`      | full arrangement, all elements present, biggest density |
+|  81 | `DECAY`      | strip back: melody alone returns, ringing tails |
+
+## Tracks
+
+1. **Drums Loop** — sliced organic break (acoustic, soft transients)
+2. **Drums Crushed** — parallel saturator/bitcrush of #1 (low send pre-BLOOM)
+3. **Percussion** — shaker / tambourine / found-sound rhythm
+4. **Bass** — sub OR upright sample on Simpler
+5. **Melodic Chop A** — main motif on Simpler, slice mode
+6. **Melodic Chop B** — pitched/chopped variant of A (5th up, octave down, etc.)
+7. **Pad / Texture** — long evolving pad, gradual filter sweep
+8. **Vocal Chop** — wordless vocal sample, used sparingly
+9. **Reverb Send** — medium plate (3–5 s)
+10. **Delay Send** — synced 1/8d with feedback ~0.5
+
+## Starter chains
+
+- **Drums Loop:** Compressor (gentle 2:1) → EQ Eight (gentle low-shelf) → Reverb send pre-fader
+- **Drums Crushed:** Redux + Saturator + Auto Filter (gradually open over the track)
+- **Bass:** EQ low-pass at 200 Hz → Compressor → subtle Saturator (warmth not grit)
+- **Melodic Chops:** Simpler (slice) → Auto Pan (slow LFO) → Spectral Resonator (subtle shimmer) → Reverb send
+- **Pad:** Wavetable → Hybrid Reverb (massive) → Frequency Shifter (cents range, slow)
+- **Master:** Glue Comp gentle → broad warm EQ → soft limiter
+
+## Sample-set inputs
+
+- `Loops/Drums/<song>_drumloop_*.wav` — soft, organic, acoustic-leaning
+- `Loops/Bass/<song>_bassloop_*.wav` — preferably acoustic/sub
+- `Loops/Melodic/<song>_melodyloop_*.wav` — the SEED chop is critical here
+- `Loops/Vocal/<song>_vocalloop_*.wav` — sparse use
+- `Samples/Ambient/*.wav` — for the pad layer
+
+## Sketching cue
+
+The SEED chop carries the entire track. Spend 80% of your sketch time picking
+it (Loops/Melodic/ is your friend). Once it's chosen, every other element
+exists to support, vary, or decay around it. Resist adding drums before
+bar 33 — the long lead-in is the genre's signature.

--- a/docs/song-forms/idm_fourtet_evolve.md
+++ b/docs/song-forms/idm_fourtet_evolve.md
@@ -56,3 +56,29 @@ The SEED chop carries the entire track. Spend 80% of your sketch time picking
 it (Loops/Melodic/ is your friend). Once it's chosen, every other element
 exists to support, vary, or decay around it. Resist adding drums before
 bar 33 — the long lead-in is the genre's signature.
+
+## Building this template in Live (~30 min)
+
+1. **New Set** → tempo **120 BPM**, time signature **4/4**.
+2. **Arrangement view**.
+3. **Locators**:
+   - bar 1 → `SEED`
+   - bar 17 → `BUILD`
+   - bar 33 → `ESTABLISH`
+   - bar 49 → `VARIATION`
+   - bar 65 → `BLOOM`
+   - bar 81 → `DECAY`
+4. **Arrangement loop end** at bar 96.
+5. **Tracks**:
+   - `Drums Loop` (red) — Simpler slice mode
+   - `Drums Crushed` (dark red) — parallel saturator/bitcrush
+   - `Percussion` (orange) — shaker / tambourine / found-sound
+   - `Bass` (blue) — Simpler upright OR Operator sub
+   - `Melodic Chop A` (yellow) — main motif Simpler
+   - `Melodic Chop B` (yellow) — pitched variant
+   - `Pad / Texture` (purple) — Wavetable, slow attack
+   - `Vocal Chop` (orange, optional)
+6. **Returns**: Reverb (medium plate, 3-5s), Delay (1/8d feedback ~0.5),
+   Spectral Send (Spectral Resonator).
+7. **Master**: Glue Comp gentle → broad warm EQ → soft limiter.
+8. **Save** to `~/mus/Templates/idm_fourtet_evolve Project/idm_fourtet_evolve.als`.

--- a/docs/song-forms/idm_squarepusher.md
+++ b/docs/song-forms/idm_squarepusher.md
@@ -53,3 +53,29 @@ Lock the bass and pad EARLY (bars 1–8) — they will not change for the whole
 track. Spend the rest of the session ONLY on drum variation. The drum
 complexity arc (A → A' → CLIMAX) is the song's only real engine. If you
 find yourself reaching for a chord change, you're writing a different form.
+
+## Building this template in Live (~30 min)
+
+1. **New Set** → tempo **160 BPM**, time signature **4/4**.
+2. **Arrangement view**.
+3. **Locators**:
+   - bar 1 → `INTRO`
+   - bar 9 → `A`
+   - bar 25 → `A'`
+   - bar 41 → `BREAK`
+   - bar 49 → `CLIMAX`
+   - bar 73 → `OUT`
+4. **Arrangement loop end** at bar 80.
+5. **Tracks**:
+   - `Drums Loop` (red) — Simpler slot, slice mode
+   - `Drums Granular` (red) — Granulator II
+   - `Drums Repeat` (crimson) — Beat Repeat host
+   - `Drums Stretch` (crimson) — Simpler, texture mode
+   - `Sub Bass` (blue) — Operator FM
+   - `Pad / Chord Bed` (mint) — Wavetable
+6. **Returns**: Glitch FX (Spectral Time + Frequency Shifter), Drum Bus
+   parallel comp (Compressor 8:1 fast attack), Reverb.
+7. **Master**: Glue Comp 3:1 fast → tape saturator → limiter pushed.
+8. **Set up an automation lane** on the drum bus volume — you'll want it
+   later for the BREAK silence and CLIMAX ducks.
+9. **Save** to `~/mus/Templates/idm_squarepusher Project/idm_squarepusher.als`.

--- a/docs/song-forms/idm_squarepusher.md
+++ b/docs/song-forms/idm_squarepusher.md
@@ -1,0 +1,55 @@
+# `idm_squarepusher` — Vertical IDM (Squarepusher / early Aphex)
+
+Vertical evolution: same harmonic bed, drum chaos escalates. The bass and
+chords stay relatively constant; what changes is rhythmic complexity.
+
+## Tempo & length
+
+- **BPM:** 140–170 (recommended start: 160)
+- **Total bars:** 80 (≈ 2 min at 160 BPM — tight, dense)
+
+## Locators
+
+| Bar | Name | Drum complexity |
+|---:|---|---|
+|   1 | `INTRO`     | bass + pad only, no drums |
+|   9 | `A`         | basic drum pattern, 1/16 hats |
+|  25 | `A'`        | drum pattern doubles in density: ratchets, fills, time-stretched hits |
+|  41 | `BREAK`     | drums fully out — bass/pad solo, cliff-edge tension |
+|  49 | `CLIMAX`    | drum pattern at MAXIMUM — granular drums, glitch repeats, parallel stacks |
+|  73 | `OUT`       | drums cut, bass+pad ring, hard cut at 80 |
+
+## Tracks
+
+1. **Drums Loop** — sliced break on Simpler (slice mode, transient)
+2. **Drums Granular** — Granulator II on the same break, modulated grain size
+3. **Drums Repeat** — clone with Beat Repeat (chance 0.6, grid 1/32)
+4. **Drums Time-Stretch** — Simpler (texture mode), pitched chops
+5. **Sub Bass** — Operator FM (Algo 4, mod=carrier ratio 1:1, fast envelopes)
+6. **Pad / Chord Bed** — Wavetable, slow attack, 4–8 bar hold notes
+7. **Glitch FX Send** — Spectral Time + Frequency Shifter
+8. **Compressor Bus (drums)** — parallel compression, fast attack
+
+## Starter chains
+
+- **Drums Loop:** Compressor (4:1, fast) → Saturator → EQ Eight (slight bump 2 kHz)
+- **Drums Granular:** Granulator II → Auto Filter with envelope follower → Reverb (small bright)
+- **Drums Repeat:** Beat Repeat (Chance 0.6, Grid 7=1/32, Variation 5) → Compressor
+- **Drums Time-Stretch:** Simpler texture mode → Erosion → Stereo Imager
+- **Sub Bass:** Operator → EQ Eight (low-pass 200 Hz, sub focus) → Compressor (heavy 8:1)
+- **Pad:** Wavetable → Hybrid Reverb (large) → Auto Filter slow LFO
+- **Master:** Glue Comp (3:1, fast) → tape saturator → limiter
+
+## Sample-set inputs
+
+- `Samples/Breaks/Sliced/<song>_break*.wav` or `Loops/Drums/` — main break
+- `Samples/Oneshots/{Kicks,Snares,Hats,Percussion}/<song>_*.wav` — for granular/repeat tracks
+- `Samples/Loops/Bass/<song>_bassloop_*.wav` — sub-bass alternative
+- `Samples/Loops/Melodic/<song>_melodyloop_*.wav` — pad bed
+
+## Sketching cue
+
+Lock the bass and pad EARLY (bars 1–8) — they will not change for the whole
+track. Spend the rest of the session ONLY on drum variation. The drum
+complexity arc (A → A' → CLIMAX) is the song's only real engine. If you
+find yourself reaching for a chord change, you're writing a different form.

--- a/docs/song-forms/lofi_aaba.md
+++ b/docs/song-forms/lofi_aaba.md
@@ -53,3 +53,36 @@ Lock A into 16 bars, COPY to A' and A'' positions immediately, THEN start
 varying. The temptation is to build A and stop — the locators exist to
 force you into B and BREAK. Spend 80% of the time on those, not on
 perfecting A.
+
+## Building this template in Live (~25 min)
+
+1. **New Set** → set tempo to **86 BPM**, time signature **4/4**.
+2. **Switch to Arrangement view** (Tab).
+3. **Insert locators** at the bars below. Easiest: type the bar number into
+   the position display (top of arrangement), hit Enter to jump there, then
+   `Cmd+L` to insert a locator. Right-click the locator to rename it:
+   - bar 1 → `INTRO`
+   - bar 5 → `A`
+   - bar 21 → `B`
+   - bar 37 → `A'`
+   - bar 53 → `BREAK`
+   - bar 61 → `A''`
+   - bar 77 → `OUT`
+4. **Set arrangement loop end** at bar 84 (so playback stops there).
+5. **Create tracks** (Cmd+T audio, Cmd+Shift+T MIDI). Name + color each:
+   - `Drums Loop` (red)
+   - `Drums Crushed` (dark red)
+   - `Bass Mono` (blue)
+   - `Keys` (yellow)
+   - `Sample Loop A` (orange) — palette slot for dragged-in curation
+   - `Sample Loop B` (orange)
+   - `Texture` (gray) — vinyl/room tone send target
+6. **Add three return tracks** (Cmd+Alt+T): Reverb (short plate), Delay
+   (1/8d slap), Texture (vinyl crackle bus).
+7. **Insert chains per track** (see [Starter chains](#starter-chains-per-track-type)
+   above). For lo-fi, Tape Saturator + Glue Comp + low-pass at 8 kHz on
+   the master is the lo-fi-defining move.
+8. **File → Save Live Set As…** → save to
+   `~/mus/Templates/lofi_aaba Project/lofi_aaba.als`.
+9. To use as a template start point, **File → Save Current Set as Default**
+   *or* just `Cmd+O` and open this `.als` directly when sketching.

--- a/docs/song-forms/lofi_aaba.md
+++ b/docs/song-forms/lofi_aaba.md
@@ -1,0 +1,55 @@
+# `lofi_aaba` — Lo-fi Hip Hop AABA
+
+Loop-faithful lo-fi sketch. The artistry is in *almost-identical* repetition
+with subtle drops at the BREAK. J Dilla / Nujabes territory.
+
+## Tempo & length
+
+- **BPM:** 80–95 (recommended start: 86)
+- **Total bars:** 84 (≈ 4 min at 86 BPM, 4/4)
+
+## Locators
+
+| Bar | Name | Notes |
+|---:|---|---|
+|   1 | `INTRO`  | drums in slowly, no bass, vinyl crackle present |
+|   5 | `A`      | full beat, all elements |
+|  21 | `B`      | reharmonization or new sample focus, drums same |
+|  37 | `A'`     | back to A material with one subtle variation (filter, swap) |
+|  53 | `BREAK`  | drums drop out OR bass drops, vocal/melodic exposed |
+|  61 | `A''`    | full return, biggest moment of the track |
+|  77 | `OUT`    | filter sweep / tape stop / fade to vinyl crackle |
+
+## Tracks (order top → bottom in arrangement)
+
+1. **Drums Loop** — sliced break or programmed kit; chops on a Simpler
+2. **Drums Crushed** — parallel of #1 with heavy saturation/bitcrush
+3. **Bass Mono** — sampled upright bass or Operator sub
+4. **Keys** — Rhodes/Wurli sampled, slightly detuned
+5. **Sample Loop A** — palette slot for dragged-in curation output (vocal chops / instrumental hook)
+6. **Sample Loop B** — second palette slot
+7. **Texture Send** — vinyl crackle, room tone, tape hiss
+8. **Reverb Send** — short plate
+9. **Delay Send** — analog-modeled slap
+
+## Starter chains (per track type)
+
+- **Drums:** Tape saturator (Drive ≈ 0.4) → Glue Comp (4:1, fast attack) → low-pass at 8 kHz
+- **Drums Crushed:** Redux (8-bit) → Saturator (drive 0.7) → low-pass at 4 kHz
+- **Bass Mono:** EQ Eight (high-cut at 2 kHz) → Glue Comp (2:1) → subtle saturator
+- **Keys:** Multiband compressor → tape saturator → slap-delay send (1/8d)
+- **Master:** Glue Comp (gentle, 1.2:1) → vinyl crackle on a parallel send → low-shelf -1 dB at 60 Hz
+
+## Sample-set inputs (drag from `~/mus/Samples/`)
+
+- `Loops/Drums/<song>_drumloop_4bar_*.wav` — main loop variants
+- `Loops/Bass/<song>_bassloop_4bar_*.wav` — bass options for B section
+- `Loops/Melodic/<song>_melodyloop_*.wav` — keys/sample chops
+- `Loops/Vocal/<song>_vocalloop_*.wav` — optional vocal chops for hooks
+
+## Sketching cue
+
+Lock A into 16 bars, COPY to A' and A'' positions immediately, THEN start
+varying. The temptation is to build A and stop — the locators exist to
+force you into B and BREAK. Spend 80% of the time on those, not on
+perfecting A.

--- a/presets/stems_only.json
+++ b/presets/stems_only.json
@@ -1,0 +1,86 @@
+{
+  "preset": {
+    "name": "Stems Only",
+    "version": "1.0.0",
+    "description": "One long loop per stem on its own track, no effects. Quickest A/B for hearing the raw separation. Note: until raw-stem loader lands, this drops one ~8-bar curated phrase per stem (not the full stem WAV).",
+    "displayName": "Stems Only"
+  },
+  "stems": {
+    "drums": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "red",
+            "index": 14,
+            "hex": "#FF3A34"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    },
+    "bass": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "blue",
+            "index": 9,
+            "hex": "#5480E4"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    },
+    "vocals": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "orange",
+            "index": 1,
+            "hex": "#FFA529"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    },
+    "other": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "mint",
+            "index": 6,
+            "hex": "#25FFA8"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    }
+  }
+}

--- a/stemforge/cli.py
+++ b/stemforge/cli.py
@@ -716,6 +716,66 @@ def re_anchor(track_dir, bpm, first_downbeat, pre_bars, pad_pre_bars, pad_post_b
         console.print("  [dim]Old chunks preserved at <stem>_prechop.bak/.[/dim]")
 
 
+@cli.command()
+@click.argument("export_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--library", "-l", default=None, type=click.Path(path_type=Path),
+              help="Library root (default: ~/mus)")
+@click.option("--song-slug", "-s", default=None,
+              help="Override song slug. Defaults to BatchManifest.track or export-dir name.")
+@click.option("--symlink", is_flag=True, default=False,
+              help="Symlink instead of copy (default: copy).")
+@click.option("--dry-run", is_flag=True, default=False,
+              help="Show what would be routed without writing.")
+def route(export_dir, library, song_slug, symlink, dry_run):
+    """
+    Distribute a bounce dir's outputs into ~/mus/Samples/<bucket>/.
+
+    \b
+    Examples:
+      stemforge route ~/stemforge/exports/oohlala_2026-04-26
+      stemforge route ./bounce_dir --song-slug "ooh la la"
+      stemforge route ./bounce_dir --library ~/other-library
+      stemforge route ./bounce_dir --symlink           # link instead of copy
+    """
+    from .router import route_export_dir, DEFAULT_LIBRARY_ROOT, classify, derive_song_slug
+    from .manifest_schema import BATCH_FILENAME, load_batch
+
+    library_root = (library or DEFAULT_LIBRARY_ROOT).expanduser()
+
+    if dry_run:
+        batch_path = export_dir / BATCH_FILENAME
+        if not batch_path.exists():
+            raise click.ClickException(f"No {BATCH_FILENAME} in {export_dir}")
+        batch = load_batch(batch_path)
+        slug = derive_song_slug(explicit=song_slug, batch=batch, export_dir=export_dir)
+        console.print(f"[bold]Song slug:[/bold] {slug}")
+        console.print(f"[bold]Library:  [/bold] {library_root}")
+        console.print(f"[bold]Mode:     [/bold] {'symlink' if symlink else 'copy'} (DRY-RUN)")
+        for entry in batch.samples:
+            bucket = classify(entry)
+            console.print(f"  [cyan]{entry.file or '?'}[/cyan]  →  Samples/{bucket.subpath}/  "
+                          f"[dim]({bucket.kind})[/dim]")
+        return
+
+    result = route_export_dir(
+        export_dir,
+        library_root=library_root,
+        song_slug=song_slug,
+        copy=not symlink,
+    )
+
+    console.print(f"\n[bold]Routed[/bold] {len(result.records)} samples to "
+                  f"[cyan]{library_root}/Samples/[/cyan] under slug [bold]{result.song_slug}[/bold]")
+    for rec in result.records:
+        console.print(f"  ✓ {rec.dest_wav.name} → Samples/{rec.bucket}/")
+    if result.skipped:
+        console.print(f"\n[yellow]Skipped {len(result.skipped)}:[/yellow]")
+        for path, reason in result.skipped:
+            console.print(f"  – {path.name}  [dim]({reason})[/dim]")
+    console.print(f"\n[dim]Run manifest: "
+                  f"{library_root}/Projects/Stems/{result.song_slug}/stemforge_curation.json[/dim]")
+
+
 @cli.command("list")
 def list_options():
     """Show available Demucs models."""

--- a/stemforge/router.py
+++ b/stemforge/router.py
@@ -1,0 +1,338 @@
+"""Curation router — distribute bounced StemForge outputs into the user's library.
+
+Reads a bounce directory's `.manifest.json` (BatchManifest), classifies each
+sample by its metadata (playmode/role/stem/name), and copies it into the
+matching `~/mus/Samples/<bucket>/` location with a song-prefixed filename.
+The original per-WAV `.manifest_<hash>.json` sidecar travels alongside (the
+hash is content-based, so the filename stays valid after rename).
+
+A per-run curation manifest is written to:
+    <library_root>/Projects/Stems/<song_slug>/stemforge_curation.json
+
+This is the only place that records *where every output went* — the routed
+files themselves carry only their hash sidecar, which points back via the
+audio_hash + the run manifest.
+
+The router does NOT touch the source bounce dir. Routing is additive and
+idempotent (re-routing the same bounce updates the run manifest and skips
+files already in place by hash).
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from .manifest_schema import (
+    BATCH_FILENAME,
+    BatchManifest,
+    SampleMeta,
+    compute_audio_hash,
+    load_batch,
+    sidecar_path_for,
+)
+
+DEFAULT_LIBRARY_ROOT = Path("~/mus").expanduser()
+RUN_MANIFEST_FILENAME = "stemforge_curation.json"
+
+
+# ── Bucket taxonomy ────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class Bucket:
+    """A target destination in the library, with a filename "kind" tag."""
+    subpath: str   # relative to <library_root>/Samples/, e.g. "Oneshots/Kicks"
+    kind: str      # filename tag, e.g. "kick"
+
+
+# Order matters — first matching rule wins.
+ONESHOT_BUCKETS: tuple[tuple[re.Pattern, Bucket], ...] = (
+    (re.compile(r"\bkick", re.I),                 Bucket("Oneshots/Kicks",       "kick")),
+    (re.compile(r"\bsnare|\bsnr|\brim", re.I),    Bucket("Oneshots/Snares",      "snare")),
+    (re.compile(r"\bhat|\bhh\b|\bhi[- ]?hat", re.I), Bucket("Oneshots/Hats",     "hat")),
+    (re.compile(r"\bclap|\btom|\bcymbal|\bcrash|\bride|\bperc|\bshaker", re.I),
+                                                  Bucket("Oneshots/Percussion",  "perc")),
+    (re.compile(r"\bvox|\bvocal", re.I),          Bucket("Vocals",               "vocalshot")),
+)
+
+LOOP_BY_STEM: dict[str, Bucket] = {
+    "drums":  Bucket("Loops/Drums",   "drumloop"),
+    "bass":   Bucket("Loops/Bass",    "bassloop"),
+    "vocals": Bucket("Loops/Vocal",   "vocalloop"),
+    "other":  Bucket("Loops/Melodic", "melodyloop"),
+}
+
+LOOP_NAME_HEURISTICS: tuple[tuple[re.Pattern, Bucket], ...] = (
+    # More specific stems first so "Bass Loop" doesn't drift to Drums on "loop".
+    (re.compile(r"\bbass|\bsub\b|\b808", re.I),     Bucket("Loops/Bass",    "bassloop")),
+    (re.compile(r"\bvox|\bvocal", re.I),            Bucket("Loops/Vocal",   "vocalloop")),
+    (re.compile(r"\bdrum|\bbreak", re.I),           Bucket("Loops/Drums",   "drumloop")),
+    (re.compile(r"\bsynth|\bpad|\bkey|\blead|\bchord|\bmelod|\botherk?\b", re.I),
+                                                    Bucket("Loops/Melodic", "melodyloop")),
+)
+
+INCOMING = Bucket("_Incoming", "unsorted")
+
+
+def classify(meta: SampleMeta) -> Bucket:
+    """Pick a destination bucket for a single SampleMeta. First match wins."""
+    name = (meta.name or "").strip()
+
+    # One-shots: classify by role first (most reliable), then name keywords.
+    if meta.playmode == "oneshot":
+        role = (meta.role or "").lower()
+        if role in {"kick", "snare", "hat", "perc", "clap", "tom", "cymbal"}:
+            for pattern, bucket in ONESHOT_BUCKETS:
+                if pattern.search(role):
+                    return bucket
+        for pattern, bucket in ONESHOT_BUCKETS:
+            if pattern.search(name):
+                return bucket
+        # Fallback: unknown one-shot → percussion bucket (catch-all)
+        return Bucket("Oneshots/Percussion", "perc")
+
+    # Loops (playmode key/legato/None — treat None as loop if bars >= 1).
+    if meta.stem in LOOP_BY_STEM:
+        return LOOP_BY_STEM[meta.stem]
+    for pattern, bucket in LOOP_NAME_HEURISTICS:
+        if pattern.search(name):
+            return bucket
+
+    return INCOMING
+
+
+# ── Slug + filename rules ──────────────────────────────────────────────────
+
+_SLUG_STRIP = re.compile(r"^\d+[\s_\-\.]*")
+_SLUG_NONALPHANUM = re.compile(r"[^a-zA-Z0-9]+")
+_SLUG_REPEAT = re.compile(r"_+")
+
+
+def to_slug(raw: str) -> str:
+    """Normalize an arbitrary string to snake_case ASCII slug."""
+    s = _SLUG_STRIP.sub("", raw or "")
+    s = _SLUG_NONALPHANUM.sub("_", s)
+    s = _SLUG_REPEAT.sub("_", s).strip("_")
+    return s.lower() or "untitled"
+
+
+def build_filename(slug: str, bucket: Bucket, n: int, *, bars: float | None = None) -> str:
+    """Construct the routed filename. e.g. `oohlala_drumloop_4bar_001.wav`."""
+    parts = [slug, bucket.kind]
+    if bars and bucket.kind in {"drumloop", "bassloop", "vocalloop", "melodyloop"}:
+        # Round to nearest int when nearly-whole; preserve fractions otherwise.
+        b_int = int(round(bars))
+        if abs(bars - b_int) < 0.01 and b_int > 0:
+            parts.append(f"{b_int}bar")
+    parts.append(f"{n:03d}")
+    return "_".join(parts) + ".wav"
+
+
+def next_index(dest_dir: Path, slug: str, bucket: Bucket) -> int:
+    """Find the next free 3-digit index for `<slug>_<kind>_NNN.wav` in dest_dir."""
+    if not dest_dir.exists():
+        return 1
+    prefix = f"{slug}_{bucket.kind}_"
+    pat = re.compile(rf"{re.escape(prefix)}(?:\d+bar_)?(\d{{3}})\.wav$")
+    used = set()
+    for p in dest_dir.glob(f"{prefix}*.wav"):
+        m = pat.search(p.name)
+        if m:
+            used.add(int(m.group(1)))
+    n = 1
+    while n in used:
+        n += 1
+    return n
+
+
+# ── Routing records & result ───────────────────────────────────────────────
+
+@dataclass
+class RouteRecord:
+    source_wav: Path
+    dest_wav: Path
+    bucket: str          # e.g. "Loops/Drums"
+    audio_hash: str
+    meta: SampleMeta
+
+
+@dataclass
+class RouteResult:
+    song_slug: str
+    library_root: Path
+    records: list[RouteRecord] = field(default_factory=list)
+    skipped: list[tuple[Path, str]] = field(default_factory=list)
+
+
+# ── Core routing ───────────────────────────────────────────────────────────
+
+def derive_song_slug(
+    *,
+    explicit: str | None,
+    batch: BatchManifest | None,
+    export_dir: Path,
+) -> str:
+    """Pick a song slug. Explicit > batch.track > export_dir basename."""
+    if explicit:
+        return to_slug(explicit)
+    if batch and batch.track:
+        return to_slug(batch.track)
+    return to_slug(export_dir.name)
+
+
+def _samples_with_paths(
+    batch: BatchManifest, export_dir: Path,
+) -> Iterable[tuple[Path, SampleMeta]]:
+    """Yield (wav_path, meta) for each batch entry that resolves to a real file."""
+    for entry in batch.samples:
+        if not entry.file:
+            continue
+        wav = export_dir / entry.file
+        if wav.exists():
+            yield wav, entry
+
+
+def _copy_with_sidecar(
+    src_wav: Path,
+    dest_wav: Path,
+    *,
+    audio_hash: str,
+    copy_mode: bool = True,
+) -> None:
+    """Copy WAV + its hash-named sidecar (if present) to the destination dir.
+
+    The sidecar's name is based on the audio hash, which is content-derived,
+    so it stays valid after a content-preserving copy.
+    """
+    dest_wav.parent.mkdir(parents=True, exist_ok=True)
+    if copy_mode:
+        shutil.copy2(src_wav, dest_wav)
+    else:
+        if dest_wav.exists() or dest_wav.is_symlink():
+            dest_wav.unlink()
+        dest_wav.symlink_to(src_wav.resolve())
+
+    src_sidecar = sidecar_path_for(src_wav, audio_hash=audio_hash)
+    if src_sidecar.exists():
+        dest_sidecar = dest_wav.parent / src_sidecar.name
+        if copy_mode:
+            shutil.copy2(src_sidecar, dest_sidecar)
+        else:
+            if dest_sidecar.exists() or dest_sidecar.is_symlink():
+                dest_sidecar.unlink()
+            dest_sidecar.symlink_to(src_sidecar.resolve())
+
+
+def _write_run_manifest(
+    library_root: Path,
+    result: RouteResult,
+    *,
+    source_export_dir: Path,
+    project_bpm: float | None,
+) -> Path:
+    """Write per-run curation manifest at Projects/Stems/<slug>/."""
+    import json
+
+    run_dir = library_root / "Projects" / "Stems" / result.song_slug
+    run_dir.mkdir(parents=True, exist_ok=True)
+    out = run_dir / RUN_MANIFEST_FILENAME
+
+    payload = {
+        "version": 1,
+        "song_slug": result.song_slug,
+        "source_export_dir": str(source_export_dir.resolve()),
+        "library_root": str(library_root.resolve()),
+        "project_bpm": project_bpm,
+        "routed_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "records": [
+            {
+                "source_wav": str(r.source_wav.resolve()),
+                "dest_wav": str(r.dest_wav.resolve()),
+                "bucket": r.bucket,
+                "audio_hash": r.audio_hash,
+                "meta": r.meta.model_dump(exclude_none=True),
+            }
+            for r in result.records
+        ],
+        "skipped": [{"path": str(p), "reason": reason} for p, reason in result.skipped],
+    }
+    out.write_text(json.dumps(payload, indent=2))
+    return out
+
+
+def route_export_dir(
+    export_dir: Path,
+    *,
+    library_root: Path = DEFAULT_LIBRARY_ROOT,
+    song_slug: str | None = None,
+    copy: bool = True,
+    write_run_manifest: bool = True,
+) -> RouteResult:
+    """Route every sample in `export_dir` into `<library_root>/Samples/<bucket>/`.
+
+    Returns a RouteResult. Idempotent: re-routing skips by hash collision in
+    the destination (a file with the same audio_hash already routed).
+    """
+    export_dir = Path(export_dir).expanduser()
+    library_root = Path(library_root).expanduser()
+
+    batch_path = export_dir / BATCH_FILENAME
+    if not batch_path.exists():
+        raise FileNotFoundError(f"No {BATCH_FILENAME} in {export_dir}")
+    batch = load_batch(batch_path)
+
+    slug = derive_song_slug(explicit=song_slug, batch=batch, export_dir=export_dir)
+    result = RouteResult(song_slug=slug, library_root=library_root)
+
+    samples_root = library_root / "Samples"
+
+    for src_wav, meta in _samples_with_paths(batch, export_dir):
+        try:
+            audio_hash = meta.audio_hash or compute_audio_hash(src_wav)
+        except OSError as e:
+            result.skipped.append((src_wav, f"hash_failed: {e}"))
+            continue
+
+        bucket = classify(meta)
+        dest_dir = samples_root / bucket.subpath
+
+        if _hash_already_in_dir(dest_dir, audio_hash):
+            result.skipped.append((src_wav, "already_routed"))
+            continue
+
+        n = next_index(dest_dir, slug, bucket)
+        filename = build_filename(slug, bucket, n, bars=meta.bars)
+        dest_wav = dest_dir / filename
+
+        try:
+            _copy_with_sidecar(src_wav, dest_wav, audio_hash=audio_hash, copy_mode=copy)
+        except OSError as e:
+            result.skipped.append((src_wav, f"copy_failed: {e}"))
+            continue
+
+        # Stamp the meta we record with the audio_hash (in case it was missing)
+        recorded_meta = meta.model_copy(update={"audio_hash": audio_hash, "file": filename})
+        result.records.append(RouteRecord(
+            source_wav=src_wav,
+            dest_wav=dest_wav,
+            bucket=bucket.subpath,
+            audio_hash=audio_hash,
+            meta=recorded_meta,
+        ))
+
+    if write_run_manifest:
+        _write_run_manifest(library_root, result,
+                            source_export_dir=export_dir,
+                            project_bpm=batch.bpm)
+    return result
+
+
+def _hash_already_in_dir(dest_dir: Path, audio_hash: str) -> bool:
+    """Return True if any sidecar in `dest_dir` already references this hash."""
+    if not dest_dir.exists():
+        return False
+    target = f".manifest_{audio_hash}.json"
+    return (dest_dir / target).exists()

--- a/tests/test_init_library.py
+++ b/tests/test_init_library.py
@@ -1,0 +1,48 @@
+"""Tests for tools/init_library.py — library subdivision bootstrap."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HELPER = Path(__file__).resolve().parents[1] / "tools" / "init_library.py"
+_spec = importlib.util.spec_from_file_location("init_library", _HELPER)
+init_library_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(init_library_mod)
+
+
+def test_creates_all_subdirs_in_empty_root(tmp_path):
+    created, existed = init_library_mod.init_library(tmp_path, dry_run=False)
+    assert len(created) == len(init_library_mod.SUBDIRS)
+    assert not existed
+    for sub in init_library_mod.SUBDIRS:
+        assert (tmp_path / sub).is_dir()
+
+
+def test_idempotent_second_run(tmp_path):
+    init_library_mod.init_library(tmp_path, dry_run=False)
+    created, existed = init_library_mod.init_library(tmp_path, dry_run=False)
+    assert not created
+    assert len(existed) == len(init_library_mod.SUBDIRS)
+
+
+def test_dry_run_creates_nothing(tmp_path):
+    created, _ = init_library_mod.init_library(tmp_path, dry_run=True)
+    assert created  # would have created
+    for p in created:
+        assert not p.exists()
+
+
+def test_preserves_existing_user_dirs(tmp_path):
+    # Simulate user already has some dirs from their reorg
+    (tmp_path / "Samples" / "Breaks" / "Sliced").mkdir(parents=True)
+    (tmp_path / "Samples" / "Loops" / "pauls_loops").mkdir(parents=True)
+    (tmp_path / "Samples" / "Loops" / "pauls_loops" / "kick.wav").touch()
+
+    init_library_mod.init_library(tmp_path, dry_run=False)
+
+    # User's stuff still there
+    assert (tmp_path / "Samples" / "Breaks" / "Sliced").is_dir()
+    assert (tmp_path / "Samples" / "Loops" / "pauls_loops" / "kick.wav").exists()
+    # New subdivisions added
+    assert (tmp_path / "Samples" / "Loops" / "Drums").is_dir()
+    assert (tmp_path / "Samples" / "Loops" / "Vocal").is_dir()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -17,7 +17,6 @@ from stemforge.manifest_schema import (
 from stemforge.router import (
     INCOMING,
     LOOP_BY_STEM,
-    RouteResult,
     build_filename,
     classify,
     derive_song_slug,

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,243 @@
+"""Tests for stemforge.router — distributing bounce outputs into the library."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from stemforge.manifest_schema import (
+    BatchManifest,
+    SampleMeta,
+    write_batch,
+    write_sidecar,
+)
+from stemforge.router import (
+    INCOMING,
+    LOOP_BY_STEM,
+    RouteResult,
+    build_filename,
+    classify,
+    derive_song_slug,
+    next_index,
+    route_export_dir,
+    to_slug,
+)
+
+
+def _write_wav(path: Path, *, seconds: float = 0.1, sr: int = 44100, freq: float = 440.0):
+    t = np.linspace(0.0, seconds, int(sr * seconds), endpoint=False, dtype=np.float32)
+    audio = 0.1 * np.sin(2 * np.pi * freq * t)
+    sf.write(str(path), audio, sr, subtype="FLOAT")
+
+
+def _make_export_dir(tmp_path: Path, samples: list[tuple[str, SampleMeta, float]]) -> Path:
+    """Create a fake bounce dir with WAVs + sidecars + batch manifest.
+
+    Each `samples` entry: (filename, meta, freq_hz_for_distinct_audio).
+    """
+    export_dir = tmp_path / "bounce_xyz"
+    export_dir.mkdir()
+    batch_entries: list[SampleMeta] = []
+    for fname, meta, freq in samples:
+        wav = export_dir / fname
+        _write_wav(wav, freq=freq)
+        write_sidecar(wav, meta)
+        batch_entries.append(meta.model_copy(update={"file": fname}))
+    write_batch(export_dir, BatchManifest(version=1, track="Test Song 01", bpm=120.0,
+                                          samples=batch_entries))
+    return export_dir
+
+
+# ── classify ───────────────────────────────────────────────────────────────
+
+def test_classify_oneshot_kick_by_role():
+    meta = SampleMeta(name="Some Hit", playmode="oneshot", role="kick")
+    assert classify(meta).subpath == "Oneshots/Kicks"
+
+
+def test_classify_oneshot_snare_by_name():
+    meta = SampleMeta(name="Tight Snare", playmode="oneshot", role="one_shot")
+    assert classify(meta).subpath == "Oneshots/Snares"
+
+
+def test_classify_oneshot_unknown_falls_to_perc():
+    meta = SampleMeta(name="weird hit", playmode="oneshot")
+    assert classify(meta).subpath == "Oneshots/Percussion"
+
+
+def test_classify_loop_by_stem():
+    meta = SampleMeta(name="anything", playmode="key", stem="bass")
+    assert classify(meta) is LOOP_BY_STEM["bass"]
+
+
+def test_classify_loop_by_name_when_stem_missing():
+    meta = SampleMeta(name="Big Bass Loop", playmode="key")
+    assert classify(meta).subpath == "Loops/Bass"
+
+
+def test_classify_unknown_loop_to_incoming():
+    meta = SampleMeta(name="zzz_unmatchable_blob", playmode="key")
+    assert classify(meta) is INCOMING
+
+
+def test_classify_vocal_oneshot_routes_to_vocals():
+    meta = SampleMeta(name="vox stab", playmode="oneshot")
+    assert classify(meta).subpath == "Vocals"
+
+
+# ── slug + filename ────────────────────────────────────────────────────────
+
+def test_to_slug_strips_track_numbers():
+    assert to_slug("01 Hey Mami") == "hey_mami"
+    assert to_slug("04 - Can I Kick It_") == "can_i_kick_it"
+
+
+def test_to_slug_handles_empty():
+    assert to_slug("") == "untitled"
+    assert to_slug("!!!") == "untitled"
+
+
+def test_build_filename_appends_bars_for_loops():
+    bucket = LOOP_BY_STEM["drums"]
+    assert build_filename("oohlala", bucket, 1, bars=4) == "oohlala_drumloop_4bar_001.wav"
+
+
+def test_build_filename_oneshots_skip_bars():
+    from stemforge.router import Bucket
+    bucket = Bucket("Oneshots/Kicks", "kick")
+    assert build_filename("oohlala", bucket, 1, bars=0.25) == "oohlala_kick_001.wav"
+
+
+def test_build_filename_skips_fractional_bars():
+    bucket = LOOP_BY_STEM["bass"]
+    # 1.7 bars isn't a clean musical length — skip the bar tag
+    name = build_filename("oohlala", bucket, 1, bars=1.7)
+    assert "bar" not in name
+    assert name == "oohlala_bassloop_001.wav"
+
+
+def test_next_index_starts_at_one_in_empty_dir(tmp_path):
+    bucket = LOOP_BY_STEM["drums"]
+    assert next_index(tmp_path / "missing", "x", bucket) == 1
+
+
+def test_next_index_skips_used(tmp_path):
+    bucket = LOOP_BY_STEM["drums"]
+    (tmp_path / "x_drumloop_4bar_001.wav").touch()
+    (tmp_path / "x_drumloop_4bar_002.wav").touch()
+    (tmp_path / "x_drumloop_8bar_005.wav").touch()
+    assert next_index(tmp_path, "x", bucket) == 3
+
+
+# ── derive_song_slug ───────────────────────────────────────────────────────
+
+def test_derive_song_slug_explicit_wins(tmp_path):
+    batch = BatchManifest(track="Track Name")
+    assert derive_song_slug(explicit="Override Me",
+                            batch=batch, export_dir=tmp_path / "any") == "override_me"
+
+
+def test_derive_song_slug_falls_back_to_track(tmp_path):
+    batch = BatchManifest(track="01 Hey Mami")
+    assert derive_song_slug(explicit=None, batch=batch,
+                            export_dir=tmp_path / "any") == "hey_mami"
+
+
+def test_derive_song_slug_falls_back_to_dir(tmp_path):
+    assert derive_song_slug(explicit=None, batch=None,
+                            export_dir=tmp_path / "Some_Bounce_dir") == "some_bounce_dir"
+
+
+# ── end-to-end route ───────────────────────────────────────────────────────
+
+def test_route_full_flow(tmp_path):
+    library = tmp_path / "mus"
+    export = _make_export_dir(tmp_path, [
+        ("A00.wav", SampleMeta(name="Punchy Kick", playmode="oneshot", role="kick", bars=0.25), 100.0),
+        ("A01.wav", SampleMeta(name="Snare Crack", playmode="oneshot", role="snare", bars=0.25), 200.0),
+        ("B00.wav", SampleMeta(name="Drums Loop", playmode="key", stem="drums", bars=4.0, bpm=120.0), 300.0),
+        ("C00.wav", SampleMeta(name="Bass Line", playmode="key", stem="bass", bars=4.0, bpm=120.0), 400.0),
+    ])
+
+    result = route_export_dir(export, library_root=library, song_slug="ooh la la")
+
+    assert result.song_slug == "ooh_la_la"
+    assert len(result.records) == 4
+    assert not result.skipped
+
+    # Files at their destinations with expected names
+    by_bucket = {r.bucket: r.dest_wav.name for r in result.records}
+    assert by_bucket["Oneshots/Kicks"] == "ooh_la_la_kick_001.wav"
+    assert by_bucket["Oneshots/Snares"] == "ooh_la_la_snare_001.wav"
+    assert by_bucket["Loops/Drums"] == "ooh_la_la_drumloop_4bar_001.wav"
+    assert by_bucket["Loops/Bass"] == "ooh_la_la_bassloop_4bar_001.wav"
+
+    # Sidecars travelled along (hash-named — same hash as source)
+    for rec in result.records:
+        sidecar = rec.dest_wav.parent / f".manifest_{rec.audio_hash}.json"
+        assert sidecar.exists(), f"missing sidecar at {sidecar}"
+
+    # Run manifest exists and lists all 4
+    run_manifest = library / "Projects" / "Stems" / "ooh_la_la" / "stemforge_curation.json"
+    assert run_manifest.exists()
+    payload = json.loads(run_manifest.read_text())
+    assert payload["song_slug"] == "ooh_la_la"
+    assert len(payload["records"]) == 4
+    assert payload["project_bpm"] == 120.0
+
+
+def test_route_idempotent_skips_already_routed(tmp_path):
+    library = tmp_path / "mus"
+    export = _make_export_dir(tmp_path, [
+        ("A00.wav", SampleMeta(name="Punchy Kick", playmode="oneshot", role="kick"), 100.0),
+    ])
+
+    first = route_export_dir(export, library_root=library, song_slug="x")
+    second = route_export_dir(export, library_root=library, song_slug="x")
+
+    assert len(first.records) == 1
+    assert not second.records
+    assert second.skipped and second.skipped[0][1] == "already_routed"
+
+
+def test_route_increments_index_when_different_hash(tmp_path):
+    library = tmp_path / "mus"
+    # Two kicks with different audio (different freq → different hash)
+    export = _make_export_dir(tmp_path, [
+        ("A00.wav", SampleMeta(name="Kick A", playmode="oneshot", role="kick"), 100.0),
+        ("A01.wav", SampleMeta(name="Kick B", playmode="oneshot", role="kick"), 110.0),
+    ])
+
+    result = route_export_dir(export, library_root=library, song_slug="x")
+    names = sorted(r.dest_wav.name for r in result.records)
+    assert names == ["x_kick_001.wav", "x_kick_002.wav"]
+
+
+def test_route_unknown_lands_in_incoming(tmp_path):
+    library = tmp_path / "mus"
+    export = _make_export_dir(tmp_path, [
+        ("A00.wav", SampleMeta(name="zzz_mystery", playmode="key"), 100.0),
+    ])
+    result = route_export_dir(export, library_root=library, song_slug="x")
+    assert len(result.records) == 1
+    assert result.records[0].bucket == "_Incoming"
+
+
+def test_route_missing_batch_manifest_raises(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError):
+        route_export_dir(empty, library_root=tmp_path / "mus")
+
+
+def test_route_symlink_mode(tmp_path):
+    library = tmp_path / "mus"
+    export = _make_export_dir(tmp_path, [
+        ("A00.wav", SampleMeta(name="Kick", playmode="oneshot", role="kick"), 100.0),
+    ])
+    result = route_export_dir(export, library_root=library, song_slug="x", copy=False)
+    dest = result.records[0].dest_wav
+    assert dest.is_symlink()

--- a/tools/init_library.py
+++ b/tools/init_library.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""init_library — create the StemForge subdivisions inside the user's library.
+
+Idempotent. Creates only the directories that are missing; never moves or
+deletes existing files.
+
+Adds the Loops/ subdivision (Drums/, Bass/, Melodic/, Vocal/) on top of the
+user's existing taxonomy at ~/mus/Samples/. See specs/library-routing.md.
+
+Usage:
+    uv run python tools/init_library.py             # default: ~/mus
+    uv run python tools/init_library.py --root /other/library
+    uv run python tools/init_library.py --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Subdivisions the curation router writes into. Match stemforge/router.py
+# bucket subpaths.
+SUBDIRS = (
+    "Samples/Loops/Drums",
+    "Samples/Loops/Bass",
+    "Samples/Loops/Melodic",
+    "Samples/Loops/Vocal",
+    "Samples/Oneshots/Kicks",
+    "Samples/Oneshots/Snares",
+    "Samples/Oneshots/Hats",
+    "Samples/Oneshots/Percussion",
+    "Samples/Vocals",
+    "Samples/_Incoming",
+    "Projects/Stems",
+)
+
+
+def init_library(root: Path, *, dry_run: bool = False) -> tuple[list[Path], list[Path]]:
+    created: list[Path] = []
+    existed: list[Path] = []
+    for sub in SUBDIRS:
+        path = root / sub
+        if path.exists():
+            existed.append(path)
+            continue
+        if dry_run:
+            created.append(path)
+            continue
+        path.mkdir(parents=True, exist_ok=True)
+        created.append(path)
+    return created, existed
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", "-r", type=Path, default=Path("~/mus").expanduser(),
+                    help="Library root (default: ~/mus)")
+    ap.add_argument("--dry-run", "-n", action="store_true",
+                    help="Print what would be created without writing")
+    args = ap.parse_args(argv)
+
+    root = args.root.expanduser()
+    if not root.exists():
+        print(f"[!] Library root does not exist: {root}", file=sys.stderr)
+        print(f"    Create it first or pass --root <path>.", file=sys.stderr)
+        return 2
+
+    created, existed = init_library(root, dry_run=args.dry_run)
+
+    label = "WOULD CREATE" if args.dry_run else "CREATED"
+    if created:
+        print(f"\n{label} ({len(created)}):")
+        for p in created:
+            print(f"  + {p}")
+    if existed:
+        print(f"\nALREADY EXIST ({len(existed)}):")
+        for p in existed:
+            print(f"  · {p}")
+    if not created and not existed:
+        print("Nothing to do — library_root has no expected subpaths and dry-run was off?")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/init_library.py
+++ b/tools/init_library.py
@@ -63,7 +63,7 @@ def main(argv: list[str] | None = None) -> int:
     root = args.root.expanduser()
     if not root.exists():
         print(f"[!] Library root does not exist: {root}", file=sys.stderr)
-        print(f"    Create it first or pass --root <path>.", file=sys.stderr)
+        print("    Create it first or pass --root <path>.", file=sys.stderr)
         return 2
 
     created, existed = init_library(root, dry_run=args.dry_run)

--- a/v0/src/m4l-package/StemForge/presets/stems_only.json
+++ b/v0/src/m4l-package/StemForge/presets/stems_only.json
@@ -1,0 +1,86 @@
+{
+  "preset": {
+    "name": "Stems Only",
+    "version": "1.0.0",
+    "description": "One long loop per stem on its own track, no effects. Quickest A/B for hearing the raw separation. Note: until raw-stem loader lands, this drops one ~8-bar curated phrase per stem (not the full stem WAV).",
+    "displayName": "Stems Only"
+  },
+  "stems": {
+    "drums": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "red",
+            "index": 14,
+            "hex": "#FF3A34"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    },
+    "bass": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "blue",
+            "index": 9,
+            "hex": "#5480E4"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    },
+    "vocals": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "orange",
+            "index": 1,
+            "hex": "#FFA529"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    },
+    "other": {
+      "targets": [
+        {
+          "name": "stem",
+          "type": "clips",
+          "color": {
+            "name": "mint",
+            "index": 6,
+            "hex": "#25FFA8"
+          },
+          "params": {
+            "phrase_bars": 8,
+            "loop_count": 1,
+            "strategy": "max-diversity"
+          },
+          "chain": []
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Promotes the genuinely net-new functional work from the long-running `feat/curation-library-v2` branch to a fresh PR off current main. The original branch had aged badly (42 ahead, 7 behind, with `prechop.py` diverging in conflict with main's superseded version). This is a clean cherry-pick of the pieces that don't conflict.

- **`stemforge route` CLI + `stemforge/router.py`** — distributes a forge bounce dir's outputs into `~/mus/Samples/<bucket>/` (Loops/Drums, Loops/Bass, Loops/Vocal, Loops/Melodic, Oneshots/Kicks, Oneshots/Snares, Oneshots/Hats, Oneshots/Percussion, Vocals). Idempotent, additive — does not touch the source bounce dir. Per-run manifest written to `<library>/Projects/Stems/<song_slug>/stemforge_curation.json`.
- **`tools/init_library.py`** — idempotent bootstrap that creates the library subdir tree.
- **`presets/stems_only.json`** (mirrored to `v0/src/m4l-package/.../presets/`) — workaround preset until raw-stem loader lands.
- **`docs/song-forms/`** — five "Build in Live" template recipes (lofi_aaba, ambient_long_form, idm_squarepusher, idm_fourtet_evolve, big_beat_drop) + README.
- **`docs/exec-plans/curation-library-device-changes.md`** — three pending device changes captured behind a review gate (NOT implemented in this PR).

## What was deliberately NOT cherry-picked

- `dc24872` (prechop chunker) — main's `prechop.py` is the strictly-better newer version with bar-padding, loop offsets, and SampleMeta sidecars (PR #35).
- `d566fb5` (session handoff doc) — point-in-time artifact, not useful on main.

After this lands: `feat/curation-library-v2` and its parent `feat/curation-engine-v2` can be retired.

## Test plan

- [x] `tests/test_router.py` — 23 tests pass
- [x] `tests/test_init_library.py` — 4 tests pass
- [x] `stemforge route --help` shows subcommand correctly
- [x] `ruff check` clean on cherry-picked files
- [ ] Manual: run `stemforge forge <song>` then `stemforge route <bounce_dir>` end-to-end and verify files land in `~/mus/Samples/<bucket>/` with expected names
- [ ] Manual: `python tools/init_library.py` on a fresh path, verify subdirs created idempotently

Generated with [Claude Code](https://claude.com/claude-code)
