### PR TITLE
feat(schemas): Pydantic models for the 3 undocumented JSON contracts (Hardening A.2 — re-land)

### DIFF
--- a/stemforge/manifest.py
+++ b/stemforge/manifest.py
@@ -123,7 +123,13 @@ def write_manifest(
     )
 
     path = output_dir / "stems.json"
-    path.write_text(json.dumps(asdict(manifest), indent=2))
+    payload = asdict(manifest)
+    # Hardening Stream A.2 — validate at the write boundary so producer-side
+    # shape drift fails loud at the CLI rather than at downstream M4L read.
+    from .schemas import validate_stems_manifest
+
+    validate_stems_manifest(payload)
+    path.write_text(json.dumps(payload, indent=2))
 
     # Update index.json in the parent (processed/) dir for M4L device discovery
     update_index(output_dir.parent, track_name)

--- a/stemforge/prechop.py
+++ b/stemforge/prechop.py
@@ -576,6 +576,11 @@ def prechop(
         }
 
     out_path = output_dir / "prechop_manifest.json"
+    # Hardening Stream A.2 — validate at the write boundary so producer-side
+    # shape drift fails loud at the CLI rather than at downstream M4L read.
+    from .schemas import validate_prechop_manifest
+
+    validate_prechop_manifest(summary)
     out_path.write_text(json.dumps(summary, indent=2))
     return out_path
 

--- a/stemforge/schemas.py
+++ b/stemforge/schemas.py
@@ -1,0 +1,216 @@
+"""Pydantic schemas for StemForge's three undocumented JSON contracts.
+
+Hardening Stream A.2. Until now `stems.json`, `prechop_manifest.json`, and
+`snapshot.json` had only a Python dataclass (or JS comment) as their
+source-of-truth shape. This module gives each one a runtime-validatable
+Pydantic model so producers and consumers can fail loud when shape drifts.
+
+The models intentionally use `extra="ignore"` — they are forward-compatible:
+adding a field to a writer doesn't break a reader on an older schema. New
+required fields are a breaking change and need a deliberate version bump.
+
+The existing dataclasses in `stemforge.manifest` and `stemforge.prechop`
+keep working unchanged. These models are an opt-in validation layer; reach
+for them at boundaries (CLI write, M4L read) rather than internal call paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+# ── stems.json (Track A — Demucs split + slice manifest) ─────────────────────
+
+
+class StemInfoModel(BaseModel):
+    name: str
+    wav_path: str
+    beats_dir: str
+    beat_count: int
+
+    model_config = {"extra": "ignore"}
+
+
+class TempoProvenanceModel(BaseModel):
+    source: str
+    confidence: str
+    first_downbeat_sec: float | None = None
+    n_downbeats: int = 0
+    warning: str | None = None
+    all_estimates: list[dict[str, Any]] = Field(default_factory=list)
+
+    model_config = {"extra": "ignore"}
+
+
+class InputAudioModel(BaseModel):
+    sample_rate: int
+    duration_samples: int
+    sha256: str
+
+    model_config = {"extra": "ignore"}
+
+
+class StemsManifestModel(BaseModel):
+    """`stems.json` — Track A's per-track split-and-slice output."""
+
+    track_name: str
+    source_file: str
+    backend: str
+    bpm: float
+    beat_count: int
+    stems: list[StemInfoModel]
+    output_dir: str
+    pipeline: str
+    processed_at: str
+    tempo: TempoProvenanceModel | None = None
+    input_audio: InputAudioModel | None = None
+
+    model_config = {"extra": "ignore"}
+
+
+# ── prechop_manifest.json (padded N-bar chunk descriptors) ───────────────────
+
+
+class ChunkMetaModel(BaseModel):
+    """One row in `prechop_manifest.json` per chunk file. Mirrors the
+    `ChunkMeta` dataclass in `stemforge.prechop`; `audio_hash` (Stream A.1)
+    is the content-stable identifier downstream consumers (configurator
+    clip-refs, future projectors) use to detect chunk content changes."""
+
+    file: str
+    stem: str
+    chunk_index: int
+    bars: int
+    pad_bars: int
+    pad_pre_bars: float
+    pad_post_bars: float
+    loop_start_sec: float
+    loop_end_sec: float
+    total_sec: float
+    chunk_duration_samples: int = 0
+    sample_rate: int = 0
+    source_offset_sec: float = 0.0
+    audio_hash: str | None = None
+
+    model_config = {"extra": "ignore"}
+
+
+class StemPrechopModel(BaseModel):
+    dir: str
+    chunks: list[ChunkMetaModel]
+    chunk_count: int
+
+    model_config = {"extra": "ignore"}
+
+
+class PrechopManifestModel(BaseModel):
+    """`prechop_manifest.json` — top-level summary of a prechop run."""
+
+    bpm: float
+    bars: int
+    pad_bars: int
+    pad_pre_bars: int
+    pad_post_bars: int
+    pad_last: bool
+    beats_per_bar: int
+    first_downbeat_sec: float
+    pre_bars: int
+    musical_bar_1_chunk_index: int
+    leading_partial_emitted: bool
+    stems: dict[str, StemPrechopModel]
+
+    model_config = {"extra": "ignore"}
+
+
+# ── snapshot.json (Track B — arrangement-view export) ────────────────────────
+
+
+class LocatorModel(BaseModel):
+    time_sec: float
+    name: str = ""
+
+    model_config = {"extra": "ignore"}
+
+
+class ArrangementClipModel(BaseModel):
+    file_path: str
+    start_time_sec: float
+    length_sec: float
+    warping: int = 1
+
+    model_config = {"extra": "ignore"}
+
+
+class SnapshotModel(BaseModel):
+    """`snapshot.json` — Track B's arrangement-view dump.
+
+    Source-of-truth shape is documented inline at the top of
+    `v0/src/m4l-js/sf_arrangement_reader.js`. Per-track clip lists are
+    keyed by group label A/B/C/D today; future configurator work will
+    generalize to N-group dicts but this model only constrains today's
+    contract.
+    """
+
+    tempo: float
+    time_sig: tuple[int, int]
+    arrangement_length_sec: float
+    locators: list[LocatorModel]
+    tracks: dict[str, list[ArrangementClipModel]]
+
+    model_config = {"extra": "ignore"}
+
+    @field_validator("time_sig", mode="before")
+    @classmethod
+    def _coerce_time_sig(cls, v: Any) -> Any:
+        # JSON arrays come in as `list`; the model wants a 2-tuple.
+        if isinstance(v, list) and len(v) == 2:
+            return tuple(v)
+        return v
+
+
+# ── Validation helpers (use these at write/read boundaries) ──────────────────
+
+
+def validate_stems_manifest(data: dict | str | Path) -> StemsManifestModel:
+    """Validate a `stems.json` payload (dict, JSON string, or path)."""
+    return _validate(StemsManifestModel, data)
+
+
+def validate_prechop_manifest(data: dict | str | Path) -> PrechopManifestModel:
+    """Validate a `prechop_manifest.json` payload."""
+    return _validate(PrechopManifestModel, data)
+
+
+def validate_snapshot(data: dict | str | Path) -> SnapshotModel:
+    """Validate a `snapshot.json` payload."""
+    return _validate(SnapshotModel, data)
+
+
+def _validate(model: type[BaseModel], data: dict | str | Path) -> Any:
+    if isinstance(data, Path):
+        return model.model_validate_json(data.read_text())
+    if isinstance(data, str):
+        return model.model_validate_json(data)
+    if isinstance(data, dict):
+        return model.model_validate(data)
+    raise TypeError(f"unsupported payload type: {type(data).__name__}")
+
+
+__all__ = [
+    "ArrangementClipModel",
+    "ChunkMetaModel",
+    "InputAudioModel",
+    "LocatorModel",
+    "PrechopManifestModel",
+    "SnapshotModel",
+    "StemInfoModel",
+    "StemPrechopModel",
+    "StemsManifestModel",
+    "TempoProvenanceModel",
+    "validate_prechop_manifest",
+    "validate_snapshot",
+    "validate_stems_manifest",
+]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,273 @@
+"""Tests for `stemforge.schemas` — Pydantic models for the three undocumented
+JSON contracts (stems.json, prechop_manifest.json, snapshot.json).
+
+Hardening Stream A.2. Each schema is round-tripped through a real producer
+and validated; deliberate shape-drift cases are also tested to confirm the
+models flag missing required fields.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+from pydantic import ValidationError
+
+from stemforge.manifest import (
+    InputAudio,
+    StemInfo,
+    StemManifest,
+    TempoProvenance,
+    write_manifest,
+)
+from stemforge.prechop import frames_per_bar, prechop
+from stemforge.schemas import (
+    PrechopManifestModel,
+    SnapshotModel,
+    StemsManifestModel,
+    validate_prechop_manifest,
+    validate_snapshot,
+    validate_stems_manifest,
+)
+
+
+SR = 22050
+BPM = 120.0
+FPB = frames_per_bar(BPM, SR, beats_per_bar=4)
+
+
+def _write_silent_stem(path: Path, n_frames: int = FPB * 4) -> None:
+    y = np.zeros((n_frames, 2), dtype=np.float32)
+    sf.write(str(path), y, SR, subtype="PCM_24")
+
+
+# ── stems.json ───────────────────────────────────────────────────────────────
+
+
+def test_stems_manifest_validates_real_writer_output(tmp_path):
+    # Write a real `stems.json` via the CLI's writer, validate it back through
+    # the Pydantic schema. Round-trip proves producer ↔ schema agreement.
+    source = tmp_path / "song.wav"
+    _write_silent_stem(source)
+    drums = tmp_path / "drums.wav"
+    bass = tmp_path / "bass.wav"
+    _write_silent_stem(drums)
+    _write_silent_stem(bass)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    write_manifest(
+        output_dir=out_dir,
+        track_name="test_track",
+        source_file=source,
+        backend="demucs",
+        bpm=BPM,
+        beat_count=16,
+        stem_paths={"drums": drums, "bass": bass},
+        slice_counts={"drums": 16, "bass": 16},
+        pipeline="default",
+        tempo=TempoProvenance(source="beat-this:mix", confidence="high", n_downbeats=4),
+        input_audio=InputAudio(sample_rate=SR, duration_samples=FPB * 4, sha256="0" * 64),
+    )
+
+    stems_path = out_dir / "stems.json"
+    assert stems_path.exists()
+    model = validate_stems_manifest(stems_path)
+    assert model.track_name == "test_track"
+    assert model.bpm == BPM
+    assert len(model.stems) == 2
+    assert model.tempo is not None
+    assert model.tempo.source == "beat-this:mix"
+    assert model.input_audio is not None
+
+
+def test_stems_manifest_rejects_missing_required_field():
+    # A required field absent → ValidationError with a clear locator.
+    bad = asdict(
+        StemManifest(
+            track_name="x",
+            source_file="x",
+            backend="demucs",
+            bpm=120.0,
+            beat_count=0,
+            stems=[],
+            output_dir="x",
+            pipeline="default",
+            processed_at="2026-05-05T12:00:00",
+        )
+    )
+    bad.pop("track_name")
+    with pytest.raises(ValidationError) as exc:
+        validate_stems_manifest(bad)
+    assert "track_name" in str(exc.value)
+
+
+def test_stems_manifest_extra_fields_are_ignored():
+    # Forward-compat: a producer that adds a new field must not break a
+    # consumer running against the old schema.
+    payload = asdict(
+        StemManifest(
+            track_name="x",
+            source_file="x",
+            backend="demucs",
+            bpm=120.0,
+            beat_count=0,
+            stems=[StemInfo(name="drums", wav_path="x.wav", beats_dir="d", beat_count=0)],
+            output_dir="x",
+            pipeline="default",
+            processed_at="2026-05-05T12:00:00",
+        )
+    )
+    payload["future_field"] = "ignored"
+    model = validate_stems_manifest(payload)
+    assert model.track_name == "x"
+
+
+# ── prechop_manifest.json ────────────────────────────────────────────────────
+
+
+def test_prechop_manifest_validates_real_writer_output(tmp_path):
+    drums = tmp_path / "drums.wav"
+    _write_silent_stem(drums, FPB * 8)
+    out = tmp_path / "out"
+    out.mkdir()
+    manifest_path = prechop(
+        {"drums": drums},
+        out,
+        bpm=BPM,
+        bars=2,
+        pad_bars=1,
+        pad_last=True,
+        write_sidecars=False,
+    )
+    model = validate_prechop_manifest(manifest_path)
+    assert model.bpm == BPM
+    assert model.bars == 2
+    assert "drums" in model.stems
+    assert model.stems["drums"].chunk_count >= 1
+    # Stream A.1 field flows through the schema:
+    for chunk in model.stems["drums"].chunks:
+        assert chunk.audio_hash is not None
+        assert len(chunk.audio_hash) == 16
+
+
+def test_prechop_manifest_rejects_missing_required_field():
+    payload = {
+        # missing "bpm"
+        "bars": 2,
+        "pad_bars": 1,
+        "pad_pre_bars": 1,
+        "pad_post_bars": 1,
+        "pad_last": True,
+        "beats_per_bar": 4,
+        "first_downbeat_sec": 0.0,
+        "pre_bars": 0,
+        "musical_bar_1_chunk_index": 0,
+        "leading_partial_emitted": False,
+        "stems": {},
+    }
+    with pytest.raises(ValidationError) as exc:
+        validate_prechop_manifest(payload)
+    assert "bpm" in str(exc.value)
+
+
+# ── snapshot.json ────────────────────────────────────────────────────────────
+
+
+def _example_snapshot_payload() -> dict:
+    """Mirror of the JS source-of-truth shape at
+    `v0/src/m4l-js/sf_arrangement_reader.js` header lines 17-34."""
+    return {
+        "tempo": 120.0,
+        "time_sig": [4, 4],
+        "arrangement_length_sec": 64.0,
+        "locators": [
+            {"time_sec": 0.0, "name": "Verse"},
+            {"time_sec": 16.0, "name": "Chorus"},
+        ],
+        "tracks": {
+            "A": [
+                {
+                    "file_path": "/abs/path.wav",
+                    "start_time_sec": 0.0,
+                    "length_sec": 4.0,
+                    "warping": 1,
+                }
+            ],
+            "B": [],
+            "C": [],
+            "D": [],
+        },
+    }
+
+
+def test_snapshot_validates_canonical_shape():
+    model = validate_snapshot(_example_snapshot_payload())
+    assert model.tempo == 120.0
+    assert model.time_sig == (4, 4)
+    assert len(model.locators) == 2
+    assert model.locators[0].name == "Verse"
+    assert len(model.tracks["A"]) == 1
+    assert model.tracks["A"][0].warping == 1
+
+
+def test_snapshot_validates_json_string_input():
+    model = validate_snapshot(json.dumps(_example_snapshot_payload()))
+    assert model.tempo == 120.0
+
+
+def test_snapshot_validates_path_input(tmp_path):
+    p = tmp_path / "snapshot.json"
+    p.write_text(json.dumps(_example_snapshot_payload()))
+    model = validate_snapshot(p)
+    assert model.tempo == 120.0
+
+
+def test_snapshot_rejects_missing_tempo():
+    payload = _example_snapshot_payload()
+    del payload["tempo"]
+    with pytest.raises(ValidationError) as exc:
+        validate_snapshot(payload)
+    assert "tempo" in str(exc.value)
+
+
+def test_snapshot_extra_fields_ignored():
+    payload = _example_snapshot_payload()
+    payload["debug_field"] = {"anything": True}
+    payload["tracks"]["A"][0]["future_property"] = "ignored"
+    model = validate_snapshot(payload)
+    # Inner extra is dropped (no future_property attr).
+    assert not hasattr(model.tracks["A"][0], "future_property")
+
+
+def test_snapshot_locator_default_name_empty():
+    payload = _example_snapshot_payload()
+    payload["locators"][0] = {"time_sec": 0.0}  # no name
+    model = validate_snapshot(payload)
+    assert model.locators[0].name == ""
+
+
+# ── Cross-schema sanity ──────────────────────────────────────────────────────
+
+
+def test_models_export_via_module_all():
+    # Re-affirms the public surface advertised by `__all__`.
+    from pydantic import BaseModel
+
+    from stemforge import schemas
+
+    for name in (
+        "StemsManifestModel",
+        "PrechopManifestModel",
+        "SnapshotModel",
+        "validate_stems_manifest",
+        "validate_prechop_manifest",
+        "validate_snapshot",
+    ):
+        assert hasattr(schemas, name), f"{name} missing from schemas module"
+    for model_cls in (StemsManifestModel, PrechopManifestModel, SnapshotModel):
+        assert issubclass(model_cls, BaseModel)


### PR DESCRIPTION
## Summary

Second PR of the StemForge hardening pass — stacked on top of [feat/hardening-a1-audio-hash](https://github.com/ZacharySBrown/stemforge/pull/39). Adds Pydantic models for the three undocumented JSON contracts (`stems.json`, `prechop_manifest.json`, `snapshot.json`) and wires validation at the producer-side write boundaries.

**Why now:** until this PR, those three contracts only had a Python dataclass (or JS comment) as their source-of-truth shape. There was no runtime validation. A producer-side bug that wrote a malformed manifest would only surface when a downstream consumer (M4L device, CLI exporter) hit the bad data. Now it surfaces at the write site.

## Changes

- **New module** [stemforge/schemas.py](stemforge/schemas.py):
  - `StemsManifestModel` for stems.json (mirrors `StemManifest` dataclass + nested `StemInfoModel`, `TempoProvenanceModel`, `InputAudioModel`).
  - `PrechopManifestModel` for prechop_manifest.json (mirrors top-level summary + nested `StemPrechopModel` + `ChunkMetaModel`). The `audio_hash` field from Stream A.1 flows through cleanly.
  - `SnapshotModel` for snapshot.json (source-of-truth: JS comment header in [v0/src/m4l-js/sf_arrangement_reader.js:17-34](v0/src/m4l-js/sf_arrangement_reader.js#L17-L34)).
  - `validate_stems_manifest`, `validate_prechop_manifest`, `validate_snapshot` helpers — each accepts dict, JSON string, or `Path`.
  - Every model uses `extra="ignore"` for forward-compatibility (a producer adding a new field doesn't break a reader on the old schema).
- **Wire validation at write boundaries:**
  - [manifest.py:127](stemforge/manifest.py#L127) — `write_manifest` validates the stems.json payload before writing.
  - [prechop.py:580](stemforge/prechop.py#L580) — `prechop()` validates the prechop_manifest.json payload before writing.
  - Reader-side validation is opt-in via the `validate_*` helpers; existing `read_manifest` / `resolve_scenes` callers unchanged so blast radius stays bounded.
- **12 new tests** in [tests/test_schemas.py](tests/test_schemas.py) covering: round-trip via the real producer (writer output passes the schema), missing-required-field rejection with `ValidationError`, forward-compat extra-field tolerance, JSON-string + `Path` input variants, optional locator-name fallback, and `__all__` surface.

## Acceptance gate closed

From `docs/STEMFORGE_HARDENING_SPEC.md`:

- [x] **F-3** — Pydantic schemas for `stems.json`, `prechop_manifest.json`, `snapshot.json` exist; reads/writes validate against them.

## Test plan

- [x] `uv run --extra dev --extra beat pytest -q` — 519 tests pass (was 507 pre-A.2; +12 new schema tests)
- [x] `uv run ruff check stemforge tests` — All checks passed
- [x] `uv run ruff format --check stemforge tests` — 86 files already formatted
- [x] Pre-commit hooks pass on commit

## Honesty footer

**Verified by reading code:**
- `StemManifest` dataclass + `write_manifest` at [stemforge/manifest.py:47](stemforge/manifest.py#L47).
- `ChunkMeta` dataclass + the prechop manifest writer at [stemforge/prechop.py](stemforge/prechop.py).
- snapshot.json shape from the JS header comment at [v0/src/m4l-js/sf_arrangement_reader.js:17-34](v0/src/m4l-js/sf_arrangement_reader.js#L17-L34) — cross-checked against `song_resolver.resolve_scenes` ([stemforge/exporters/ep133/song_resolver.py:125](stemforge/exporters/ep133/song_resolver.py#L125)) which consumes it via `ArrangementClip.from_dict` (line 33).

**Inferred from docs:** the spec's "reads/writes validate against them" wording. I interpret "validate" as "fail loud at write boundaries" + "validate helpers available for opt-in read-side use." Bigger refactor (replacing dataclass-based serialization wholesale with Pydantic) is out of scope per the spec's "no other work" discipline.

**Surprised by:** how cleanly the JS-header docstring shape matched the Python-side resolver expectations. The two have been in sync without enforcement; this PR makes that contract enforceable.

**Stacked on:** [feat/hardening-a1-audio-hash](https://github.com/ZacharySBrown/stemforge/pull/39). Will rebase to main once #39 merges. The `audio_hash` field on `ChunkMetaModel` is what couples them — without A.1 the prechop manifests wouldn't carry hashes for the schema to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Re-land context

The original A.2 PR (#40) was based on `feat/hardening-a1-audio-hash` (stacked PR). That branch merged at 20:35:04. A.2 then merged into the now-stale A.1 branch at 20:35:17 — 13 seconds *after* the A.1 branch was already merged into main, so A.2's commit never propagated to main.

This PR cherry-picks the original A.2 commit (`204279d`) onto a fresh branch off the current main. Diff is identical to #40; the only change is the base.