### PR TITLE
feat(tests): hardened LiveAPI mock with backing liveTree (Hardening B.2)

### DIFF
--- a/tests/js_mocks/max_api.js
+++ b/tests/js_mocks/max_api.js
@@ -4,19 +4,54 @@
 // used by StemForge JS modules. Lives entirely in Node; no Max install needed.
 //
 // Scope: just enough surface to execute sf_preset_loader.js, sf_state.js,
-// sf_forge.js, and the priority-chain section of stemforge_loader.v0.js for
-// offline regression tests.
+// sf_forge.js, sf_arrangement_reader.js, sf_arrangement_loader.js,
+// stemforge_loader.v0.js's `_commitSessionTracks`, and the priority-chain
+// section of stemforge_loader.v0.js for offline regression tests.
 //
 // Module state is intentionally global-on-this-module so multiple modules
 // loaded in the same sandbox share Dict state (mirroring the real Max runtime
 // where `new Dict("sf_preset")` returns a handle to a single process-wide
 // dict).
+//
+// LiveAPI hardening (Hardening Stream B.2):
+//   The LiveAPI constructor traverses a backing `state.liveTree` — a nested
+//   dict where each node has `_properties` (scalar properties accessible via
+//   `.get(prop)`) and named children (collections as arrays, singletons as
+//   objects). Path syntax mirrors Live's: space-separated tokens like
+//   "live_set tracks 0 clip_slots 0 clip". Unseeded paths fall back to the
+//   no-op behavior (returning 0 / [] / 'no-op set') so existing tests that
+//   don't set up a tree continue to work.
+//
+//   LOM quirks honored (per `feedback_arrangement_clip_lom`):
+//     * `warp_bpm` writes are silently dropped (read-only LOM property)
+//     * `end_time` writes are silently dropped (read-only on Clip)
+//     * Marker-unit flip with warping is exposed via `liveMarkerUnit(path)`
+//       (returns "beats" if warping=1, "seconds" if warping=0). Mock does
+//       NOT auto-convert; tests can assert the unit flag and verify caller
+//       logic uses the right interpretation.
 // ─────────────────────────────────────────────────────────────────────────────
 
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
+
+// LOM properties that the real Live runtime accepts writes for but silently
+// ignores. Documented in `memory/feedback_arrangement_clip_lom.md`.
+const LOM_READONLY_PROPS = Object.freeze({
+    warp_bpm: true,
+    end_time: true,
+});
+
+// Properties whose unit (seconds vs beats) flips with the clip's `warping`
+// flag. Used by `liveMarkerUnit()` so tests can assert against the right
+// numeric basis.
+const LOM_MARKER_PROPS = Object.freeze({
+    start_marker: true,
+    end_marker: true,
+    loop_start: true,
+    loop_end: true,
+});
 
 // Shared global state per harness session.
 const state = {
@@ -25,6 +60,9 @@ const state = {
     logs: [],                          // post() captures
     outlets: Object.create(null),      // outletNum (number) -> list of arg-arrays
     liveApiCalls: [],                  // for optional inspection
+    liveTree: null,                    // root LOM mock; null = unseeded → no-op
+    liveCallHandlers: Object.create(null), // verb -> (lomPath, args) => result
+    liveReadonlyDrops: [],             // log of writes silently dropped
 };
 
 function resetState() {
@@ -33,6 +71,9 @@ function resetState() {
     state.logs.length = 0;
     state.outlets = Object.create(null);
     state.liveApiCalls.length = 0;
+    state.liveTree = null;
+    state.liveCallHandlers = Object.create(null);
+    state.liveReadonlyDrops.length = 0;
 }
 
 // ── Path helpers ─────────────────────────────────────────────────────────────
@@ -258,17 +299,177 @@ function arrayfromargs(/* ...args */) {
     return out;
 }
 
+// ── liveTree path resolution ─────────────────────────────────────────────────
+// Path syntax (LOM):  "live_set" | "live_set tracks 0" |
+//   "live_set tracks 0 clip_slots 0 clip" |
+//   "live_set cue_points 0".
+//
+// Tree shape:
+//   {
+//     _properties: { tempo: 120, signature_numerator: 4, ... },
+//     tracks: [                          // collection (array)
+//       {
+//         _properties: { name: "A", color: 1 },
+//         clip_slots: [
+//           { _properties: { has_clip: 1 },
+//             clip: {                     // scalar child (object, not array)
+//               _properties: {
+//                 file_path: "...", start_marker: 0, ..., warping: 1,
+//               },
+//               warp_markers: [ { _properties: {...} }, ... ],
+//             },
+//           },
+//         ],
+//         arrangement_clips: [...],
+//       },
+//     ],
+//     cue_points: [
+//       { _properties: { time: 0, name: "Verse" } },
+//     ],
+//   }
+
+function _splitPath(pathStr) {
+    return String(pathStr || '')
+        .trim()
+        .split(/\s+/)
+        .filter(function (s) { return s.length; });
+}
+
+function _resolveNode(rootKey, segs) {
+    if (!state.liveTree) return null;
+    if (segs[0] !== rootKey) return null;
+    let node = state.liveTree;
+    let i = 1;
+    while (i < segs.length) {
+        const childKey = segs[i];
+        const child = node[childKey];
+        if (Array.isArray(child)) {
+            // Collection — next seg is the index.
+            const idxStr = segs[i + 1];
+            if (idxStr === undefined) return null;
+            const idx = Number(idxStr);
+            if (!Number.isFinite(idx) || idx < 0 || idx >= child.length) return null;
+            node = child[idx];
+            if (!node) return null;
+            i += 2;
+        } else if (child && typeof child === 'object') {
+            // Singleton child (e.g., clip_slot.clip) — no index follows.
+            node = child;
+            i += 1;
+        } else {
+            return null;
+        }
+    }
+    return node;
+}
+
+// Public seeders for tests. Pass a plain JS object using the tree shape above.
+function seedLiveTree(tree) {
+    state.liveTree = tree || null;
+}
+
+function getLiveTree() {
+    return state.liveTree;
+}
+
+// Set/get a property at any LOM path. For tests + diagnostics.
+function setLiveProperty(lomPath, prop, value) {
+    const segs = _splitPath(lomPath);
+    if (!segs.length) return false;
+    const node = _resolveNode(segs[0], segs);
+    if (!node) return false;
+    if (!node._properties) node._properties = {};
+    node._properties[prop] = value;
+    return true;
+}
+
+function getLiveProperty(lomPath, prop) {
+    const segs = _splitPath(lomPath);
+    if (!segs.length) return undefined;
+    const node = _resolveNode(segs[0], segs);
+    if (!node || !node._properties) return undefined;
+    return node._properties[prop];
+}
+
+// Marker-unit oracle. Call after seeding a clip's warping flag to know which
+// numeric basis loop_start/end + start/end_marker live in.
+function liveMarkerUnit(lomPath) {
+    const segs = _splitPath(lomPath);
+    if (!segs.length) return 'beats';
+    const node = _resolveNode(segs[0], segs);
+    if (!node || !node._properties) return 'beats';
+    const w = node._properties.warping;
+    return (w === 0 || w === false) ? 'seconds' : 'beats';
+}
+
+// Register a handler for a specific LiveAPI.call() verb. Handler signature:
+//   (lomPath, argsArray) -> any
+function setLiveCallHandler(verb, handler) {
+    state.liveCallHandlers[String(verb)] = handler;
+}
+
 // ── Mock LiveAPI ─────────────────────────────────────────────────────────────
 function LiveAPI(pathOrCb, maybePath) {
-    // Minimal — don't throw on construction. Track calls for optional assertions.
-    this._path = typeof pathOrCb === 'string' ? pathOrCb : maybePath || '';
+    // Mirror Max LiveAPI: first arg can be a callback fn or a path string.
+    this._path = typeof pathOrCb === 'string' ? pathOrCb : (maybePath || '');
     state.liveApiCalls.push({ ctor: this._path });
 }
-LiveAPI.prototype.getcount = function () { return 0; };
-LiveAPI.prototype.get = function () { return []; };
-LiveAPI.prototype.set = function () { /* no-op */ };
-LiveAPI.prototype.call = function () { return 0; };
-LiveAPI.prototype.goto = function () { /* no-op */ };
+
+LiveAPI.prototype._node = function () {
+    if (!state.liveTree) return null;
+    const segs = _splitPath(this._path);
+    if (!segs.length) return null;
+    return _resolveNode(segs[0], segs);
+};
+
+LiveAPI.prototype.getcount = function (childName) {
+    if (!state.liveTree) return 0;
+    const node = this._node();
+    if (!node) return 0;
+    const child = node[childName];
+    return Array.isArray(child) ? child.length : 0;
+};
+
+LiveAPI.prototype.get = function (prop) {
+    if (!state.liveTree) return [];
+    const node = this._node();
+    if (!node || !node._properties) return [];
+    const val = node._properties[prop];
+    if (val === undefined) return [];
+    // LOM scalar reads return a 1-element array. Lists stay lists.
+    return Array.isArray(val) ? val.slice() : [val];
+};
+
+LiveAPI.prototype.set = function (prop, value) {
+    if (LOM_READONLY_PROPS[prop]) {
+        // Mirror Live: silent drop.
+        state.liveReadonlyDrops.push({ path: this._path, prop, value });
+        return;
+    }
+    if (!state.liveTree) return;
+    const node = this._node();
+    if (!node) return;
+    if (!node._properties) node._properties = {};
+    node._properties[prop] = value;
+};
+
+LiveAPI.prototype.call = function (verb /* , ...args */) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    const handlers = state.liveCallHandlers || {};
+    const handler = handlers[verb];
+    if (typeof handler === 'function') {
+        return handler(this._path, args);
+    }
+    state.liveApiCalls.push({ unhandledCall: { path: this._path, verb, args } });
+    return 0;
+};
+
+LiveAPI.prototype.goto = function (p) {
+    this._path = String(p || '');
+};
+
+// `property` is sometimes assigned on real LiveAPI for observer callbacks.
+// Keep as a simple writable string; not load-bearing for our test paths.
 LiveAPI.prototype.property = '';
 
 // ── Exports ──────────────────────────────────────────────────────────────────
@@ -277,6 +478,8 @@ module.exports = {
     File,
     Folder,
     LiveAPI,
+    LOM_READONLY_PROPS,
+    LOM_MARKER_PROPS,
     post,
     outlet,
     arrayfromargs,
@@ -285,4 +488,10 @@ module.exports = {
     seedFilesystem,
     seedDir,
     seedFile,
+    seedLiveTree,
+    getLiveTree,
+    setLiveProperty,
+    getLiveProperty,
+    liveMarkerUnit,
+    setLiveCallHandler,
 };

--- a/tests/js_mocks/test_liveapi_mock.test.js
+++ b/tests/js_mocks/test_liveapi_mock.test.js
@@ -1,0 +1,312 @@
+// test_liveapi_mock.test.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Tier-3 tests for the hardened LiveAPI mock (Hardening Stream B.2).
+//
+// What this proves:
+//   1. Default LiveAPI (no liveTree seeded) is back-compat: all reads return
+//      empty / no-op, matching the prior mock's behavior. Existing JS tests
+//      that build their own LiveAPI continue to override seamlessly.
+//   2. With a seeded liveTree, get/set/getcount work on real path traversal.
+//   3. LOM read-only properties (warp_bpm, end_time) silently drop writes.
+//   4. Marker-unit oracle (liveMarkerUnit) reflects warping flag.
+//   5. Path traversal handles collections (arrays) AND singleton children.
+//   6. The call() handler table dispatches by verb.
+// ─────────────────────────────────────────────────────────────────────────────
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const maxApi = require('./max_api');
+
+function freshState() {
+    maxApi.resetState();
+}
+
+// ── Default behavior (unseeded tree = back-compat with prior no-op mock) ─────
+
+test('LiveAPI with no liveTree returns empty/no-op for all calls', () => {
+    freshState();
+    const api = new maxApi.LiveAPI('live_set');
+    assert.equal(api.getcount('tracks'), 0);
+    assert.deepEqual(api.get('tempo'), []);
+    api.set('tempo', 200);  // no-op, doesn't throw
+    assert.equal(api.call('some_verb', 1, 2), 0);
+});
+
+// ── Property reads / writes ──────────────────────────────────────────────────
+
+test('LiveAPI.get returns scalar wrapped in 1-element array (LOM convention)', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        _properties: { tempo: 120, signature_numerator: 4 },
+    });
+    const api = new maxApi.LiveAPI('live_set');
+    assert.deepEqual(api.get('tempo'), [120]);
+    assert.deepEqual(api.get('signature_numerator'), [4]);
+});
+
+test('LiveAPI.get on missing property returns empty array', () => {
+    freshState();
+    maxApi.seedLiveTree({ _properties: { tempo: 120 } });
+    const api = new maxApi.LiveAPI('live_set');
+    assert.deepEqual(api.get('does_not_exist'), []);
+});
+
+test('LiveAPI.set persists on the seeded node', () => {
+    freshState();
+    maxApi.seedLiveTree({ _properties: { tempo: 120 } });
+    const api = new maxApi.LiveAPI('live_set');
+    api.set('tempo', 145);
+    assert.deepEqual(api.get('tempo'), [145]);
+});
+
+test('LiveAPI.set creates _properties bag if missing', () => {
+    freshState();
+    maxApi.seedLiveTree({ tracks: [{}] });
+    const api = new maxApi.LiveAPI('live_set tracks 0');
+    api.set('name', 'Drums');
+    assert.equal(maxApi.getLiveProperty('live_set tracks 0', 'name'), 'Drums');
+});
+
+// ── getcount on collections ──────────────────────────────────────────────────
+
+test('LiveAPI.getcount on a collection returns array length', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            { _properties: { name: 'A' } },
+            { _properties: { name: 'B' } },
+            { _properties: { name: 'C' } },
+        ],
+        cue_points: [{ _properties: { time: 0, name: 'Verse' } }],
+    });
+    const api = new maxApi.LiveAPI('live_set');
+    assert.equal(api.getcount('tracks'), 3);
+    assert.equal(api.getcount('cue_points'), 1);
+    assert.equal(api.getcount('does_not_exist'), 0);
+});
+
+// ── Path traversal (collections + singletons) ────────────────────────────────
+
+test('LiveAPI traverses collection-by-index paths', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            { _properties: { name: 'A' } },
+            { _properties: { name: 'B' } },
+        ],
+    });
+    const trackA = new maxApi.LiveAPI('live_set tracks 0');
+    const trackB = new maxApi.LiveAPI('live_set tracks 1');
+    assert.deepEqual(trackA.get('name'), ['A']);
+    assert.deepEqual(trackB.get('name'), ['B']);
+});
+
+test('LiveAPI traverses singleton-child paths (clip_slot.clip)', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            {
+                clip_slots: [
+                    {
+                        _properties: { has_clip: 1 },
+                        clip: {
+                            _properties: { file_path: '/abs/foo.wav', warping: 1 },
+                        },
+                    },
+                ],
+            },
+        ],
+    });
+    const clipApi = new maxApi.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    assert.deepEqual(clipApi.get('file_path'), ['/abs/foo.wav']);
+    assert.deepEqual(clipApi.get('warping'), [1]);
+});
+
+test('LiveAPI returns empty for out-of-range collection index', () => {
+    freshState();
+    maxApi.seedLiveTree({ tracks: [{ _properties: { name: 'A' } }] });
+    const api = new maxApi.LiveAPI('live_set tracks 5');
+    assert.deepEqual(api.get('name'), []);
+    assert.equal(api.getcount('clip_slots'), 0);
+});
+
+test('LiveAPI.goto repoints to a new path', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            { _properties: { name: 'A' } },
+            { _properties: { name: 'B' } },
+        ],
+    });
+    const api = new maxApi.LiveAPI('live_set tracks 0');
+    assert.deepEqual(api.get('name'), ['A']);
+    api.goto('live_set tracks 1');
+    assert.deepEqual(api.get('name'), ['B']);
+});
+
+// ── LOM read-only quirks ─────────────────────────────────────────────────────
+
+test('LiveAPI.set on warp_bpm is silently dropped (LOM read-only)', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            {
+                clip_slots: [
+                    {
+                        clip: {
+                            _properties: { warp_bpm: 120 },
+                        },
+                    },
+                ],
+            },
+        ],
+    });
+    const clip = new maxApi.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    clip.set('warp_bpm', 160);
+    // Original value preserved.
+    assert.deepEqual(clip.get('warp_bpm'), [120]);
+    // Drop is logged for assertions.
+    assert.equal(maxApi.state.liveReadonlyDrops.length, 1);
+    assert.equal(maxApi.state.liveReadonlyDrops[0].prop, 'warp_bpm');
+    assert.equal(maxApi.state.liveReadonlyDrops[0].value, 160);
+});
+
+test('LiveAPI.set on end_time is silently dropped (LOM read-only)', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [{ arrangement_clips: [{ _properties: { end_time: 4.0 } }] }],
+    });
+    const clip = new maxApi.LiveAPI('live_set tracks 0 arrangement_clips 0');
+    clip.set('end_time', 8.0);
+    assert.deepEqual(clip.get('end_time'), [4.0]);
+    assert.equal(maxApi.state.liveReadonlyDrops.length, 1);
+    assert.equal(maxApi.state.liveReadonlyDrops[0].prop, 'end_time');
+});
+
+// ── Marker unit oracle ───────────────────────────────────────────────────────
+
+test('liveMarkerUnit returns "beats" when warping=1 (default)', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            {
+                clip_slots: [
+                    { clip: { _properties: { warping: 1, start_marker: 4 } } },
+                ],
+            },
+        ],
+    });
+    const unit = maxApi.liveMarkerUnit('live_set tracks 0 clip_slots 0 clip');
+    assert.equal(unit, 'beats');
+});
+
+test('liveMarkerUnit returns "seconds" when warping=0', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [
+            {
+                clip_slots: [
+                    { clip: { _properties: { warping: 0, start_marker: 1.5 } } },
+                ],
+            },
+        ],
+    });
+    const unit = maxApi.liveMarkerUnit('live_set tracks 0 clip_slots 0 clip');
+    assert.equal(unit, 'seconds');
+});
+
+test('liveMarkerUnit defaults to beats when warping unset', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [{ clip_slots: [{ clip: { _properties: {} } }] }],
+    });
+    const unit = maxApi.liveMarkerUnit('live_set tracks 0 clip_slots 0 clip');
+    assert.equal(unit, 'beats');
+});
+
+// ── call() handler table ─────────────────────────────────────────────────────
+
+test('LiveAPI.call dispatches to registered handler', () => {
+    freshState();
+    maxApi.seedLiveTree({});
+    const seen = [];
+    maxApi.setLiveCallHandler('create_clip', (lomPath, args) => {
+        seen.push({ lomPath, args });
+        return 42;
+    });
+    const api = new maxApi.LiveAPI('live_set tracks 0 clip_slots 0');
+    const result = api.call('create_clip', '/abs/foo.wav', 4.0);
+    assert.equal(result, 42);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].lomPath, 'live_set tracks 0 clip_slots 0');
+    assert.deepEqual(seen[0].args, ['/abs/foo.wav', 4.0]);
+});
+
+test('LiveAPI.call without handler returns 0 and logs the unhandled verb', () => {
+    freshState();
+    maxApi.seedLiveTree({});
+    const api = new maxApi.LiveAPI('live_set');
+    assert.equal(api.call('mystery_verb', 'a', 'b'), 0);
+    const unhandled = maxApi.state.liveApiCalls.filter((c) => c.unhandledCall);
+    assert.equal(unhandled.length, 1);
+    assert.equal(unhandled[0].unhandledCall.verb, 'mystery_verb');
+});
+
+// ── Public seeders / getters surface ─────────────────────────────────────────
+
+test('setLiveProperty + getLiveProperty round-trip', () => {
+    freshState();
+    maxApi.seedLiveTree({
+        tracks: [{ _properties: { name: 'A' } }],
+    });
+    assert.equal(maxApi.getLiveProperty('live_set tracks 0', 'name'), 'A');
+    const ok = maxApi.setLiveProperty('live_set tracks 0', 'name', 'Drums');
+    assert.equal(ok, true);
+    assert.equal(maxApi.getLiveProperty('live_set tracks 0', 'name'), 'Drums');
+});
+
+test('setLiveProperty on missing path returns false', () => {
+    freshState();
+    maxApi.seedLiveTree({ tracks: [] });
+    const ok = maxApi.setLiveProperty('live_set tracks 5', 'name', 'X');
+    assert.equal(ok, false);
+});
+
+test('resetState clears liveTree + handlers + drops', () => {
+    freshState();
+    maxApi.seedLiveTree({ _properties: { tempo: 120 } });
+    maxApi.setLiveCallHandler('foo', () => 1);
+    new maxApi.LiveAPI('live_set').set('warp_bpm', 200);
+    assert.equal(maxApi.state.liveReadonlyDrops.length, 1);
+    maxApi.resetState();
+    assert.equal(maxApi.getLiveTree(), null);
+    assert.equal(maxApi.state.liveReadonlyDrops.length, 0);
+    assert.equal(Object.keys(maxApi.state.liveCallHandlers).length, 0);
+});
+
+// ── Hardening Spec acceptance gate TI-2 anchor ───────────────────────────────
+
+test('acceptance gate TI-2: hardened LiveAPI mock with backing liveTree', () => {
+    // Hardening Spec acceptance gate TI-2:
+    //   "LiveAPI mock has backing liveTree; existing JS tests pass through
+    //   the new mock."
+    // The static proof:
+    //   - liveTree exists in module state
+    //   - get/set/getcount route through it
+    //   - LOM quirks are encoded
+    //   - existing tests in this directory continue to pass (verified at
+    //     suite level — see the parallel test files that DON'T import this
+    //     gate but still pass).
+    freshState();
+    assert.equal(typeof maxApi.seedLiveTree, 'function');
+    assert.equal(typeof maxApi.getLiveTree, 'function');
+    assert.equal(typeof maxApi.liveMarkerUnit, 'function');
+    assert.equal(typeof maxApi.setLiveCallHandler, 'function');
+    // Quirk constants exposed.
+    assert.equal(maxApi.LOM_READONLY_PROPS.warp_bpm, true);
+    assert.equal(maxApi.LOM_READONLY_PROPS.end_time, true);
+    assert.equal(maxApi.LOM_MARKER_PROPS.start_marker, true);
+});


### PR DESCRIPTION
## Summary

Fifth PR of the StemForge hardening pass. Replaces the no-op `LiveAPI` stubs in [tests/js_mocks/max_api.js](tests/js_mocks/max_api.js) with a tree-aware mock that traverses LOM-style paths against a backing `state.liveTree` dict. Encodes the known LOM quirks (`warp_bpm` and `end_time` silent-drop on write; marker-unit flip with warping flag).

**Why now:** the testability bundle (§A.5) flagged the no-op LiveAPI as the single biggest leverage point in offline JS testing — hardening it unlocks ~40% more JS-module testability. **This is the prereq for D.1** (`m4l.button.commit` Tier-3 tests), which the spec calls out as the highest-impact uncovered path in the entire codebase.

## Changes

### Hardened mock ([tests/js_mocks/max_api.js](tests/js_mocks/max_api.js))

- `state.liveTree` (default `null` = unseeded → no-op, back-compat).
- `_splitPath` / `_resolveNode` internal traversal of `"live_set tracks 0 clip_slots 0 clip"`-style LOM paths.
- `LiveAPI.getcount` / `get` / `set` / `call` rerouted through the tree:
  - `get` returns scalar wrapped in 1-element array (LOM convention).
  - `set` persists; creates `_properties` bag if missing.
  - `getcount` inspects collection arrays.
  - `call` dispatches to a verb → handler table.
- `LiveAPI.goto(path)` repoints `_path` mid-test.
- **LOM read-only quirks encoded** per `memory/feedback_arrangement_clip_lom`:
  - `warp_bpm` → `set` silently dropped, logged to `state.liveReadonlyDrops`.
  - `end_time` → same.
- `liveMarkerUnit(path)` oracle returns `"beats"` (warping=1) or `"seconds"` (warping=0).
- Public seeders: `seedLiveTree`, `setLiveProperty`, `getLiveProperty`, `setLiveCallHandler`.
- Quirk constants exported: `LOM_READONLY_PROPS`, `LOM_MARKER_PROPS`.

### Tree shape used by tests
```
{
  _properties: { tempo: 120, signature_numerator: 4 },
  tracks: [
    {
      _properties: { name: "A" },
      clip_slots: [
        { clip: { _properties: { file_path, start_marker, warping, ... } } }
      ]
    }
  ],
  cue_points: [{ _properties: { time, name } }]
}
```

### Tests ([tests/js_mocks/test_liveapi_mock.test.js](tests/js_mocks/test_liveapi_mock.test.js))

21 cases covering:
- Default unseeded behavior (back-compat with the prior no-op mock).
- `get` / `set` / `getcount` on properties + collections.
- Path traversal through collections AND singleton children.
- Out-of-range index handling.
- `goto` re-pointing.
- `warp_bpm` + `end_time` silent-drop quirks (with assertions on the drop log).
- `liveMarkerUnit` oracle (warping=1 → beats, warping=0 → seconds, default → beats).
- `call()` handler dispatch + unhandled-verb logging.
- Public seeder/getter API surface.
- `resetState` clears all liveTree state.
- Static acceptance-gate sentinel for TI-2.

## Back-compat verified

The 4 existing JS test files (54 tests) all build their **own** LiveAPI factories per-test and inject them into the sandbox via `ctx.LiveAPI = MyMock`. The default mock from `max_api.js` is what they fall back on but don't actually use — those tests never invoke the seeded liveTree. So the upgraded mock is purely additive: existing tests pass without any changes, new tests opt in.

End-to-end check: `node --test tests/js_mocks/*.test.js` passes all 75 tests (54 existing + 21 new).

## Acceptance gate closed

From `docs/STEMFORGE_HARDENING_SPEC.md`:

- [x] **TI-2** — LiveAPI mock has backing `liveTree`; existing JS tests pass through the new mock.

## Test plan

- [x] `node --test tests/js_mocks/*.test.js` — 75 passing
- [x] `uv run --extra dev --extra beat pytest -q` — 540 passing (no change to Python paths)
- [x] `uv run ruff check stemforge tests` — All checks passed
- [x] Pre-commit hooks pass on commit

## Honesty footer

**Verified by reading code:** the existing four JS test files in `tests/js_mocks/` and confirmed each builds its own `LiveAPI` factory (so they don't depend on the default no-op mock). The relevant memory entry [feedback_arrangement_clip_lom.md](memory/feedback_arrangement_clip_lom.md) for the read-only properties + marker-unit flip behavior. The actual LOM path syntax `"live_set tracks N clip_slots N clip"` from real M4L code in `v0/src/m4l-js/`.

**Inferred from docs:** the precise tree shape (especially the singleton-child convention for `clip_slot.clip` vs collection-array for `clip_slots`). I derived this from the way real LOM paths are structured in the JS code; verified by running my mock against the path syntax used in `sf_arrangement_reader.js` and confirming reads succeed.

**Surprised by:** how little surface area the existing tests share with the default mock — every LiveAPI-using test builds its own factory. This made back-compat much easier than the spec implied (R3 risk on B.2 was that "existing tests use the default mock and break"). They don't, so they didn't.

**Future hooks:** the `setLiveCallHandler` API is intentionally simple (verb → fn). D.1 will register handlers for the verbs `_commitSessionTracks` invokes (`get_clip_slot`, `find_track_by_name`, etc.). Those don't exist yet — out of scope for B.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
