### PR TITLE
fix(prechop): always emit leading partial chunk; add --emit-partial CLI flag

### DIFF
--- a/stemforge/cli.py
+++ b/stemforge/cli.py
@@ -168,6 +168,12 @@ def cli():
     help="Bars of post-pad inside each chunk WAV (audio AFTER the loop region). "
     "Default 1 — useful for drag-extending forward + crossfade headroom at the seam.",
 )
+@click.option(
+    "--emit-partial/--no-emit-partial",
+    default=True,
+    help="Emit a leading partial chunk_001 when the user-supplied / detected "
+    "downbeat leaves a sub-chunk-period intro before bar 1. Default: True.",
+)
 def split(
     audio_file,
     model,
@@ -182,6 +188,7 @@ def split(
     pre_bars,
     pad_pre_bars,
     pad_post_bars,
+    emit_partial,
 ):
     """
     Split an audio file into stems and slice at beat boundaries.
@@ -454,6 +461,7 @@ def split(
                 pre_bars=resolved_pre_bars,
                 pad_pre_bars=pad_pre_bars,
                 pad_post_bars=pad_post_bars,
+                emit_partial=emit_partial,
             )
             pc = status_post.get("prechop", {})
             if pc:
@@ -522,13 +530,31 @@ def split(
     help="Bars of post-pad inside each chunk WAV (default 1 = drag-extend headroom forward).",
 )
 @click.option(
+    "--emit-partial/--no-emit-partial",
+    default=True,
+    help="Emit a leading partial chunk_001 capturing the sub-chunk-period "
+    "intro material between source frame 0 and bar 1. Default: True. "
+    "Pass --no-emit-partial to drop the intro entirely (the prior auto-gate "
+    "behavior, removed because RMS-based gating flipped binary on sub-dB "
+    "noise-floor drift between Demucs runs).",
+)
+@click.option(
     "--keep-old",
     is_flag=True,
     default=False,
     help="Keep the previous prechop output as `<stem>_prechop.bak/` instead of overwriting.",
 )
 @with_audit("re-anchor")
-def re_anchor(track_dir, bpm, first_downbeat, pre_bars, pad_pre_bars, pad_post_bars, keep_old):
+def re_anchor(
+    track_dir,
+    bpm,
+    first_downbeat,
+    pre_bars,
+    pad_pre_bars,
+    pad_post_bars,
+    emit_partial,
+    keep_old,
+):
     """
     Re-cut the prechop chunks of an already-forged track at user-supplied
     BPM + first_downbeat. Skips Demucs re-run (~30 s saved) — only re-runs
@@ -656,6 +682,7 @@ def re_anchor(track_dir, bpm, first_downbeat, pre_bars, pad_pre_bars, pad_post_b
         pre_bars=resolved_pre_bars,
         pad_pre_bars=pad_pre_bars,
         pad_post_bars=pad_post_bars,
+        emit_partial=emit_partial,
     )
     pc = status.get("prechop", {})
     if pc:

--- a/stemforge/pipelines.py
+++ b/stemforge/pipelines.py
@@ -97,6 +97,7 @@ def run_post_split_steps(
     pre_bars: int = 0,
     pad_pre_bars: int | None = None,
     pad_post_bars: int | None = None,
+    emit_partial: bool | None = None,
 ) -> dict[str, Any]:
     """Apply any Python-side post-split steps from the pipeline.
 
@@ -105,6 +106,10 @@ def run_post_split_steps(
     `pre_bars` includes that many bars of intro material before bar 1.
     `pad_pre_bars` / `pad_post_bars` override the symmetric `pad_bars`
     config when set (None = use the pipeline's `pad_bars`).
+    `emit_partial` controls the leading-partial chunk gate: True (CLI
+    default) always emits when boundary conditions allow; False skips;
+    None defers to prechop's auto-decide. The CLI flips this to True
+    explicitly so callers see deterministic behavior.
 
     Returns a small status dict keyed by step name. Today: just `prechop`.
     """
@@ -125,6 +130,7 @@ def run_post_split_steps(
             pre_bars=pre_bars,
             pad_pre_bars=pad_pre_bars,
             pad_post_bars=pad_post_bars,
+            emit_partial=emit_partial,
         )
         status["prechop"] = {
             "manifest": str(manifest_path),
@@ -134,6 +140,7 @@ def run_post_split_steps(
             "pad_post_bars": pad_post_bars,
             "first_downbeat_sec": float(first_downbeat_sec),
             "pre_bars": int(pre_bars),
+            "emit_partial": emit_partial,
         }
 
     return status

--- a/stemforge/prechop.py
+++ b/stemforge/prechop.py
@@ -52,15 +52,10 @@ from .manifest_schema import SampleMeta, Stem, compute_audio_hash, write_sidecar
 # clip in arrangement view to be reachable.
 
 # Minimum fraction of one chunk-period for the leftover region to be
-# considered visually meaningful. Set to 0 so any non-silent leading audio
-# becomes a visible chunk_001 (instead of being hidden in chunk_002's
-# pre-pad, where users couldn't reach pre-bar-1 transients without manual
-# clip-edge dragging). The RMS gate still skips truly silent leading
-# regions.
+# considered worth emitting. Default 0 = any non-empty leftover triggers
+# a visible chunk_001 so users can reach pre-bar-1 transients without
+# manual clip-edge dragging. Tweak only if you have a specific reason.
 MIN_LEFTOVER_FRAC = 0.0
-
-# RMS floor: leading region below this is treated as dead air; no emit.
-SILENCE_THRESHOLD_DBFS = -60.0
 
 
 # ── Math helpers ─────────────────────────────────────────────────────────────
@@ -426,59 +421,49 @@ def _decide_emit_partial(
 ) -> bool:
     """Phase-3 gating: should we emit a leading partial chunk?
 
-    Three gates, AND-combined:
+    Two boundary gates, AND-combined:
 
     1. `first_downbeat_sec > 0` — there's pre-downbeat material to consider.
-    2. Leftover region size: `leftover_sec / chunk_period_sec >= MIN_LEFTOVER_FRAC`.
-       Below this threshold the pad-stash mechanism handles it cleanly and
-       there's no need for a visible chunk_001.
-    3. RMS gate: max RMS across stems' leading regions >= -60 dBFS. Skips
-       emit when the leading region is dead air (e.g., a clean opening
-       silence that the BPM detector saw past).
+    2. `0 < leftover_frames < chunk_frames` — the leftover region (the
+       sub-chunk-period intro that sits between source frame 0 and the
+       first whole pre-chunk, or between source 0 and the first
+       post-downbeat chunk when no pre-bars) has audio worth a chunk
+       AND isn't already covered by a whole pre-bars chunk.
+
+    No content gate: when the user supplies an explicit downbeat (split
+    --first-downbeat or re-anchor), they intend to keep the intro
+    regardless of audio level. The previous RMS gate (≥ -60 dBFS across
+    any stem) was a binary cliff that flipped the decision based on
+    sub-dB noise-floor drift between Demucs runs. Per
+    ``feedback_downbeat_alignment``, we trust user-driven downbeats
+    explicitly; auto-detection paths funnel through the same gate but
+    typically land on first_downbeat=0 or a whole-bar-aligned position
+    where the leftover region is already empty.
 
     Decision is shared across all stems for arrangement-loader consistency
-    (parallel chunks must align across tracks).
+    (parallel chunks must align across tracks). The ``stem_paths`` /
+    ``skip_set`` parameters are retained for ABI back-compat with callers
+    who pass them; they're no longer read.
     """
+    del stem_paths, skip_set  # retained for ABI; no longer consulted
     if first_downbeat_sec <= 0:
         return False
-
-    sample_path = next(
-        (p for name, p in stem_paths.items() if name not in skip_set),
-        None,
-    )
-    if sample_path is None:
+    if bpm <= 0 or bars <= 0 or beats_per_bar <= 0:
         return False
 
-    info = sf.info(str(sample_path))
-    sr = info.samplerate
-    fpb = frames_per_bar(bpm, sr, beats_per_bar=beats_per_bar)
-    chunk_frames = fpb * bars
-    if chunk_frames <= 0:
+    # Reference SR comes from the first stem path's sample rate normally;
+    # since we no longer open files for the RMS gate, we compute everything
+    # in beat-period space which is sample-rate-agnostic.
+    bar_period_sec = bars * beats_per_bar * 60.0 / bpm
+    if bar_period_sec <= 0:
         return False
-
-    leftover_frames = int(round(first_downbeat_sec * sr)) - n_pre_chunks * chunk_frames
-    if leftover_frames <= 0 or leftover_frames >= chunk_frames:
+    leftover_sec = first_downbeat_sec - n_pre_chunks * bar_period_sec
+    if leftover_sec <= 0 or leftover_sec >= bar_period_sec:
         return False
-
-    leftover_frac = leftover_frames / float(chunk_frames)
+    leftover_frac = leftover_sec / bar_period_sec
     if leftover_frac < MIN_LEFTOVER_FRAC:
         return False
-
-    floor_amp = 10.0 ** (SILENCE_THRESHOLD_DBFS / 20.0)
-    for name, path in stem_paths.items():
-        if name in skip_set:
-            continue
-        try:
-            data, _ = sf.read(str(path), start=0, stop=leftover_frames, always_2d=True)
-        except Exception:
-            continue
-        if data.size == 0:
-            continue
-        rms = float(np.sqrt(np.mean(data.astype(np.float64) ** 2)))
-        if rms >= floor_amp:
-            return True
-
-    return False
+    return True
 
 
 def prechop(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,6 +252,25 @@ def test_re_anchor_smoke_help():
     assert "Re-cut" in result.output or "re-anchor" in result.output.lower()
 
 
+def test_re_anchor_help_advertises_emit_partial_flag():
+    # Believer-bar-1 follow-up (2026-05-05): --emit-partial / --no-emit-partial
+    # must appear in the CLI help so users can override the new always-emit
+    # default when they specifically don't want a leading partial chunk.
+    runner = CliRunner()
+    result = runner.invoke(cli, ["re-anchor", "--help"])
+    assert result.exit_code == 0
+    assert "--emit-partial" in result.output
+    assert "--no-emit-partial" in result.output
+
+
+def test_split_help_advertises_emit_partial_flag():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["split", "--help"])
+    assert result.exit_code == 0
+    assert "--emit-partial" in result.output
+    assert "--no-emit-partial" in result.output
+
+
 # ── 9. split (heavy — needs torch/Demucs) ────────────────────────────────────
 
 

--- a/tests/test_prechop.py
+++ b/tests/test_prechop.py
@@ -11,7 +11,6 @@ import soundfile as sf
 from stemforge.manifest_schema import HASH_LENGTH, compute_audio_hash
 from stemforge.prechop import (
     MIN_LEFTOVER_FRAC,
-    SILENCE_THRESHOLD_DBFS,
     _decide_emit_partial,
     chunk_count_for,
     frames_per_bar,
@@ -608,9 +607,8 @@ def test_decide_emit_partial_first_downbeat_zero(tmp_path):
 
 
 def test_decide_emit_partial_threshold_is_zero():
-    """`MIN_LEFTOVER_FRAC=0` (Believer-bar-1-transient feedback 2026-05-04):
-    any non-silent leading audio gets a visible chunk_001 instead of being
-    hidden in the pad-stash. RMS gate is now the only content filter."""
+    """`MIN_LEFTOVER_FRAC=0` is the boundary-only gate floor. Any non-empty
+    leftover (`0 < leftover_frames < chunk_frames`) earns a visible chunk_001."""
     assert MIN_LEFTOVER_FRAC == 0.0
 
 
@@ -637,15 +635,18 @@ def test_decide_emit_partial_tiny_leftover_with_content_emits(tmp_path):
     assert decision is True
 
 
-def test_decide_emit_partial_silent_leading_region(tmp_path):
-    """Above leftover_frac threshold but the leading region itself is dead
-    air → RMS gate fires, no emit. Gives Track-3-style tracks identical
-    behavior to today."""
+def test_decide_emit_partial_silent_leading_region_now_emits(tmp_path):
+    """Believer regression (2026-05-05): the prior RMS gate flipped binary
+    on sub-dB Demucs noise-floor drift, so a silent-looking leading region
+    on one run dropped the chunk_001 partial that another run kept. The
+    gate is now boundary-only — when the user supplies an explicit
+    downbeat, we trust their intent and emit the partial regardless of
+    audio level. Tests this new behavior: silent leading region with a
+    non-empty leftover region still emits."""
     stem = tmp_path / "drums.wav"
-    # 8 bars, all silence — leading region is silence, RMS = 0 < floor.
     _write_silent_stem(stem, FPB * 8)
     bars = 4
-    leftover_bars = 2  # 50% leftover_frac (above threshold)
+    leftover_bars = 2  # 50% leftover_frac
     first_downbeat_sec = (FPB * leftover_bars) / float(SR)
     decision = _decide_emit_partial(
         {"drums": stem},
@@ -656,8 +657,26 @@ def test_decide_emit_partial_silent_leading_region(tmp_path):
         first_downbeat_sec=first_downbeat_sec,
         n_pre_chunks=0,
     )
+    assert decision is True
+
+
+def test_decide_emit_partial_zero_leftover_does_not_emit():
+    """When the downbeat is on a whole-bar boundary (leftover_frames == 0),
+    there's literally no intro material to put in a partial chunk."""
+    bars = 4
+    chunk_period_sec = (bars * FPB) / float(SR)
+    # first_downbeat exactly one chunk-period — leftover_frames == 0.
+    first_downbeat_sec = chunk_period_sec
+    decision = _decide_emit_partial(
+        {},
+        skip_set=set(),
+        bpm=BPM,
+        bars=bars,
+        beats_per_bar=4,
+        first_downbeat_sec=first_downbeat_sec,
+        n_pre_chunks=1,
+    )
     assert decision is False
-    assert SILENCE_THRESHOLD_DBFS == -60.0  # spec default
 
 
 def test_decide_emit_partial_above_threshold_with_content_emits(tmp_path):


### PR DESCRIPTION
## Summary

Fixes a real bug surfaced while testing the hardening pass: re-anchoring believer truncated the entire 0.28s of intro material before the locator. Root cause is a binary cliff in `_decide_emit_partial`'s RMS gate combined with sub-dB Demucs/MPS noise-floor drift between runs.

## Repro

User had `~/stemforge/processed/believer` with `leading_partial_emitted: True` (28 chunks). Re-running re-anchor on the same track with the same downbeat (0.282656s) flipped to `leading_partial_emitted: False` (27 chunks) — the entire intro disappeared.

Diagnosis showed:

| `--first-downbeat` | drums RMS in leading region | leading_partial_emitted |
|---|---|---|
| 0.300s | -19.7 dBFS (kick attack included) | True ✓ |
| 0.282656s | -60.9 dBFS (just stem noise floor) | **False ✗** |
| 0.282188s | -61.1 dBFS | **False ✗** |

The first kick attack lands at ~0.295s. With downbeat at 0.282656 the leading region is 0.28s of essentially-silent noise floor. The -60 dBFS threshold sat right at that noise floor — and Demucs/MPS produces sub-dB drift run-to-run, so the same downbeat flipped binary based on which Demucs session ran.

## Fix

`_decide_emit_partial` is now **boundary-only**:
- `first_downbeat_sec > 0`
- `0 < leftover_frames < chunk_frames`

No RMS / content gate. When the user supplies an explicit downbeat (`split --first-downbeat` or `re-anchor`), they intend to keep the intro regardless of audio level. The auto-gate fought user intent.

### CLI flag for explicit override

- New `--emit-partial / --no-emit-partial` on both `re-anchor` and `split`. Default: `True` (always emit when boundary conditions hold).
- Pass `--no-emit-partial` to drop the intro (the prior auto-gate behavior, now opt-in).
- `run_post_split_steps` threads the flag through.

### Code cleanup

- `SILENCE_THRESHOLD_DBFS` constant removed (no longer referenced).
- `MIN_LEFTOVER_FRAC = 0.0` retained as the boundary floor.

## End-to-end verification on three real tracks

| Track | BPM | first_downbeat | leading_partial | chunks/stem | audio_hash |
|---|---|---|---|---|---|
| definition | 90.23 | 3.780s | ✓ True | 21 | ✓ |
| ooh_la_la | 85.11 | 0.020s | ✓ True | 18 | ✓ |
| **believer** | 125.0 | 0.282656s | **✓ True** | **28** | ✓ |

**Believer's leading partial is back.** The 0.28s of intro before bar 1 now lives in `chunk_001`, no longer truncated.

## Tests

- Renamed `test_decide_emit_partial_silent_leading_region` → `..._silent_leading_region_now_emits`, flipped its assertion to True. The test now documents the new behavior + the regression context.
- New `test_decide_emit_partial_zero_leftover_does_not_emit` covers the on-bar-boundary case where there's literally no intro to emit.
- New `test_re_anchor_help_advertises_emit_partial_flag` + `test_split_help_advertises_emit_partial_flag` verify CLI surface.
- 25 prechop + 18 CLI + 582 total tests pass; pre-commit clean.

## Why default `True` (always emit)

When the user supplies an explicit `--first-downbeat`, that's intent. The previous gate was designed to skip emit when auto-detected downbeats landed on dead air — but auto-detect should be returning `first_downbeat=0` for those cases anyway, and the boundary check `first_downbeat <= 0 → False` already covers it. The RMS gate was solving a problem that didn't actually exist after the boundary check was tightened.

For the rare case where someone *does* want to drop a silent partial, `--no-emit-partial` gives explicit control.

## Honesty footer

**Verified by reading code:** the actual `_decide_emit_partial` source (lines 417-481 pre-fix). The believer reproduction script that traced RMS values per-stem at three downbeat values — confirmed the binary cliff empirically before designing the fix.

**Inferred from docs:** that user-supplied downbeats should be trusted by default. The previous gate treated user-supplied downbeats the same as auto-detected ones; that's the design error this PR corrects.

**Surprised by:** how dramatically the fix simplifies the function. Boundary-only is ~10 lines; the prior version was 65 lines including I/O for the RMS check. Less code, more deterministic, and now sample-rate-agnostic (no `sf.info` call needed since we compute everything in beat-period space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
