### PR TITLE
fix(curate): use stems.json tempo instead of re-detecting BPM/downbeat

### DIFF
--- a/tests/test_curate_uses_stems_manifest.py
+++ b/tests/test_curate_uses_stems_manifest.py
@@ -1,0 +1,172 @@
+"""Tests for `stemforge_curate_bars._load_stems_manifest_tempo` +
+`_synthesize_beat_grid` (2026-05-06 fix).
+
+Curation must use the same beat detection as `stemforge split`/`re-anchor`.
+The script's helpers, loaded via importlib (since v0/src/ is not a package),
+are what we audit here. End-to-end behavior against the real script is
+covered by manual re-runs documented in the PR.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CURATE_BARS_PATH = REPO_ROOT / "v0" / "src" / "stemforge_curate_bars.py"
+
+
+@pytest.fixture(scope="module")
+def curate_bars():
+    """Load the curate_bars script as a module via importlib."""
+    spec = importlib.util.spec_from_file_location("stemforge_curate_bars", CURATE_BARS_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── _load_stems_manifest_tempo ───────────────────────────────────────────────
+
+
+def test_load_tempo_from_well_formed_stems_manifest(curate_bars, tmp_path: Path):
+    (tmp_path / "stems.json").write_text(
+        json.dumps(
+            {
+                "track_name": "x",
+                "bpm": 125.0,
+                "tempo": {
+                    "source": "user-override",
+                    "first_downbeat_sec": 0.282656,
+                    "confidence": "high",
+                },
+            }
+        )
+    )
+    out = curate_bars._load_stems_manifest_tempo(tmp_path)
+    assert out == {
+        "bpm": 125.0,
+        "first_downbeat_sec": 0.282656,
+        "source": "user-override",
+    }
+
+
+def test_load_tempo_returns_none_when_manifest_missing(curate_bars, tmp_path: Path):
+    assert curate_bars._load_stems_manifest_tempo(tmp_path) is None
+
+
+def test_load_tempo_returns_none_on_malformed_json(curate_bars, tmp_path: Path):
+    (tmp_path / "stems.json").write_text("{not valid json")
+    assert curate_bars._load_stems_manifest_tempo(tmp_path) is None
+
+
+def test_load_tempo_returns_none_when_bpm_missing(curate_bars, tmp_path: Path):
+    (tmp_path / "stems.json").write_text(json.dumps({"track_name": "x", "tempo": {}}))
+    assert curate_bars._load_stems_manifest_tempo(tmp_path) is None
+
+
+def test_load_tempo_defaults_first_downbeat_to_zero(curate_bars, tmp_path: Path):
+    (tmp_path / "stems.json").write_text(json.dumps({"bpm": 120.0, "tempo": {}}))
+    out = curate_bars._load_stems_manifest_tempo(tmp_path)
+    assert out is not None
+    assert out["bpm"] == 120.0
+    assert out["first_downbeat_sec"] == 0.0
+
+
+def test_load_tempo_falls_back_through_source_field(curate_bars, tmp_path: Path):
+    (tmp_path / "stems.json").write_text(json.dumps({"bpm": 90.0, "backend": "demucs"}))
+    out = curate_bars._load_stems_manifest_tempo(tmp_path)
+    assert out is not None
+    assert out["source"] == "demucs"
+
+
+# ── _synthesize_beat_grid ────────────────────────────────────────────────────
+
+
+def test_synthesize_beat_grid_first_downbeat_zero(curate_bars):
+    # 120 BPM, 4 beats/bar, 16 sec → 32 beats, 8 downbeats.
+    beats, downbeats = curate_bars._synthesize_beat_grid(
+        bpm=120.0,
+        first_downbeat_sec=0.0,
+        duration_sec=16.0,
+        time_sig=4,
+    )
+    assert beats[0] == pytest.approx(0.0)
+    assert np.diff(beats) == pytest.approx(np.full(len(beats) - 1, 0.5))
+    assert downbeats[0] == pytest.approx(0.0)
+    assert np.diff(downbeats) == pytest.approx(np.full(len(downbeats) - 1, 2.0))
+
+
+def test_synthesize_beat_grid_with_first_downbeat_offset(curate_bars):
+    # 125 BPM (0.48 s/beat), first_downbeat=0.282656, 16 sec.
+    beats, downbeats = curate_bars._synthesize_beat_grid(
+        bpm=125.0,
+        first_downbeat_sec=0.282656,
+        duration_sec=16.0,
+        time_sig=4,
+    )
+    # The first downbeat must be present in `downbeats` exactly (anchoring
+    # the grid).
+    assert any(abs(d - 0.282656) < 1e-9 for d in downbeats)
+    # Beat period = 60/125 = 0.48s.
+    assert np.allclose(np.diff(beats), 0.48, atol=1e-9)
+
+
+def test_synthesize_beat_grid_extrapolates_beats_before_downbeat(curate_bars):
+    # first_downbeat=2.5s should yield beats at 2.5, 2.0, 1.5, 1.0, 0.5 (and 0.0 if exact).
+    beats, downbeats = curate_bars._synthesize_beat_grid(
+        bpm=120.0,  # 0.5 s/beat
+        first_downbeat_sec=2.5,
+        duration_sec=10.0,
+        time_sig=4,
+    )
+    # Should include beats below first_downbeat.
+    assert beats[0] < 2.5
+    # First downbeat appears in the downbeats list.
+    assert any(abs(d - 2.5) < 1e-9 for d in downbeats)
+
+
+def test_synthesize_beat_grid_zero_bpm_raises(curate_bars):
+    with pytest.raises(ValueError, match="bpm"):
+        curate_bars._synthesize_beat_grid(
+            bpm=0.0, first_downbeat_sec=0.0, duration_sec=10.0, time_sig=4
+        )
+
+
+def test_synthesize_beat_grid_zero_duration_raises(curate_bars):
+    with pytest.raises(ValueError, match="duration_sec"):
+        curate_bars._synthesize_beat_grid(
+            bpm=120.0, first_downbeat_sec=0.0, duration_sec=0.0, time_sig=4
+        )
+
+
+# ── Acceptance regression sentinel ───────────────────────────────────────────
+
+
+def test_believer_regression_anchor(curate_bars, tmp_path: Path):
+    # Believer's exact tempo block from stems.json after the user's
+    # re-anchor. Curate must read 125.0 / 0.282656, not re-detect.
+    (tmp_path / "stems.json").write_text(
+        json.dumps(
+            {
+                "track_name": "believer",
+                "bpm": 125.0,
+                "tempo": {
+                    "source": "user-override",
+                    "first_downbeat_sec": 0.282656,
+                    "confidence": "high",
+                    "warning": "re-anchored from bpm=125.0 first_downbeat=0.3s",
+                },
+            }
+        )
+    )
+    out = curate_bars._load_stems_manifest_tempo(tmp_path)
+    assert out is not None
+    assert out["bpm"] == 125.0  # NOT 126.05 (the librosa drift the bug caused)
+    assert out["first_downbeat_sec"] == 0.282656

--- a/v0/src/stemforge_curate_bars.py
+++ b/v0/src/stemforge_curate_bars.py
@@ -63,6 +63,80 @@ def find_stems(stems_dir: Path) -> dict[str, Path]:
     return stems
 
 
+def _load_stems_manifest_tempo(stems_dir: Path) -> dict | None:
+    """Read tempo from `stems_dir/stems.json` if present and well-formed.
+
+    Curation must use the same beat detection as `stemforge split`/`re-anchor`
+    so curated bar boundaries align exactly with the prechop/arrangement
+    grid. Re-running librosa/beat-this here drifts BPM by 1-30 BPM and
+    silently overrides user `--bpm`/`--first-downbeat` overrides — Believer
+    truncation regression on 2026-05-05.
+
+    Returns ``{"bpm": float, "first_downbeat_sec": float, "source": str}``
+    or ``None`` if the manifest is missing / malformed / has no BPM.
+    """
+    manifest_path = stems_dir / "stems.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    bpm = data.get("bpm")
+    if not isinstance(bpm, (int, float)) or bpm <= 0:
+        return None
+    tempo = data.get("tempo") or {}
+    fdb = tempo.get("first_downbeat_sec")
+    if fdb is None or not isinstance(fdb, (int, float)) or fdb < 0:
+        fdb = 0.0
+    source = tempo.get("source") or data.get("backend") or "stems.json"
+    return {
+        "bpm": float(bpm),
+        "first_downbeat_sec": float(fdb),
+        "source": str(source),
+    }
+
+
+def _synthesize_beat_grid(
+    bpm: float,
+    first_downbeat_sec: float,
+    duration_sec: float,
+    time_sig: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build (beat_times, downbeat_times) deterministically from a BPM + first
+    downbeat anchor. Mirrors how `stemforge split` lays its grid: beats every
+    ``60/bpm`` seconds, downbeats every ``time_sig`` beats, anchored on
+    ``first_downbeat_sec``. Beats earlier than the first downbeat are
+    extrapolated backwards (so a track with first_downbeat=2.5s gets beats
+    at 2.5, 1.5, 0.5 etc. — `slice_at_bars` uses these for pre-bar-1 slicing).
+    """
+    if bpm <= 0:
+        raise ValueError(f"bpm must be > 0, got {bpm}")
+    if duration_sec <= 0:
+        raise ValueError(f"duration_sec must be > 0, got {duration_sec}")
+    beat_period = 60.0 / float(bpm)
+    if first_downbeat_sec < 0:
+        first_downbeat_sec = 0.0
+
+    # Backwards-extrapolate so beats can be placed before first_downbeat.
+    n_back = int(np.ceil(first_downbeat_sec / beat_period))
+    earliest = first_downbeat_sec - n_back * beat_period
+    if earliest < 0:
+        earliest += beat_period
+        n_back -= 1
+
+    n_total = int(np.ceil((duration_sec - earliest) / beat_period)) + 1
+    beat_times = earliest + np.arange(n_total, dtype=np.float64) * beat_period
+    beat_times = beat_times[beat_times <= duration_sec + 1e-6]
+
+    # Downbeat times: every `time_sig` beats starting from first_downbeat.
+    if n_back >= 0:
+        downbeats = beat_times[n_back::time_sig]
+    else:
+        downbeats = beat_times[::time_sig]
+    return beat_times, downbeats
+
+
 def _reslice_with_padding(
     *,
     source_stem_path: Path,
@@ -348,12 +422,24 @@ def run(
         })
 
     # Step 1: Detect BPM and beats.
-    # beat-this (neural downbeat detection) needs the FULL MIX for harmonic
-    # context — it hallucinates half/double time on isolated drum stems.
-    # Librosa beat_track() works better on drums stems (onset-based).
+    #
+    # PREFERRED PATH (2026-05-06): use the values stems.json already wrote.
+    # `stemforge split` (and `re-anchor`) run the tempo reconciler — beat-this
+    # neural downbeat detection on full mix → librosa fallback → user
+    # overrides — and persist the winning bpm + first_downbeat into stems.json
+    # under `tempo.source`. Re-running detection here drifted BPM by up to
+    # 30 BPM and silently ignored user `--bpm`/`--first-downbeat` overrides
+    # (Believer regression). Curated bars now slice on the same grid the
+    # arrangement-mode prechop uses → no phase between curated loops and
+    # arrangement clips, no off-grid kicks.
+    #
+    # FALLBACK PATH (no stems.json or no bpm field): keep the legacy librosa
+    # + beat-this comparison. Used by callers running curate_bars on a raw
+    # stems-dir that bypassed split.
     bpm_source = stems.get("drums", next(iter(stems.values())))
 
-    # Look for original source audio for beat-this
+    # Look for original source audio for beat-this fallback (only used when
+    # stems.json doesn't carry tempo — see below).
     source_audio = None
     source_manifest = stems_dir / "stems.json"
     if source_manifest.exists():
@@ -365,71 +451,106 @@ def run(
         except (json.JSONDecodeError, KeyError):
             pass
 
-    # Try neural downbeat detection on full mix first.
-    # beat-this needs harmonic context — always prefer full mix over drums stem.
-    # Only keep neural results if bar CV is better than librosa fallback.
     downbeat_times = None
+    bpm: float
+    beat_times: np.ndarray
 
-    # Always get librosa beats as baseline (fast, reliable on drums)
-    bpm, beat_times = detect_bpm_and_beats(bpm_source)
+    manifest_tempo = _load_stems_manifest_tempo(stems_dir)
+    if manifest_tempo is not None:
+        bpm = manifest_tempo["bpm"]
+        first_downbeat_sec = manifest_tempo["first_downbeat_sec"]
+        # Use the longest stem as the duration anchor for grid synthesis.
+        max_duration = max(
+            float(sf.info(str(p)).duration) for p in stems.values()
+        )
+        beat_times, downbeat_times = _synthesize_beat_grid(
+            bpm=bpm,
+            first_downbeat_sec=first_downbeat_sec,
+            duration_sec=max_duration,
+            time_sig=time_sig,
+        )
+        if json_events:
+            emit({
+                "event": "progress",
+                "phase": "alignment",
+                "pct": 2,
+                "message": (
+                    f"using stems.json tempo: bpm={bpm:.2f}, "
+                    f"first_downbeat={first_downbeat_sec:.4f}s "
+                    f"(source: {manifest_tempo['source']}) — "
+                    f"{len(beat_times)} beats, {len(downbeat_times)} downbeats"
+                ),
+            })
+    else:
+        # No usable stems.json — fall back to in-process detection.
+        # Always get librosa beats as baseline (fast, reliable on drums).
+        bpm, beat_times = detect_bpm_and_beats(bpm_source)
 
-    try:
-        from stemforge.beat_detect import detect_beats_and_downbeats
-        bt_source = source_audio or bpm_source
-        bt_bpm, bt_beats, bt_downbeats = detect_beats_and_downbeats(bt_source)
+        try:
+            from stemforge.beat_detect import detect_beats_and_downbeats
+            bt_source = source_audio or bpm_source
+            bt_bpm, bt_beats, bt_downbeats = detect_beats_and_downbeats(bt_source)
 
-        if len(bt_downbeats) > 2:
-            # Compare bar CV: beat-this downbeats vs librosa stride
-            lib_bar_durs = np.diff(beat_times[::time_sig])
-            lib_cv = lib_bar_durs[:-1].std() / lib_bar_durs[:-1].mean() if len(lib_bar_durs) > 2 else 1
-            bt_bar_durs = np.diff(bt_downbeats)
-            bt_cv = bt_bar_durs[:-1].std() / bt_bar_durs[:-1].mean() if len(bt_bar_durs) > 2 else 1
+            if len(bt_downbeats) > 2:
+                # Compare bar CV: beat-this downbeats vs librosa stride
+                lib_bar_durs = np.diff(beat_times[::time_sig])
+                lib_cv = (
+                    lib_bar_durs[:-1].std() / lib_bar_durs[:-1].mean()
+                    if len(lib_bar_durs) > 2
+                    else 1
+                )
+                bt_bar_durs = np.diff(bt_downbeats)
+                bt_cv = (
+                    bt_bar_durs[:-1].std() / bt_bar_durs[:-1].mean()
+                    if len(bt_bar_durs) > 2
+                    else 1
+                )
 
-            if bt_cv < lib_cv:
-                bpm = bt_bpm
-                beat_times = bt_beats
-                downbeat_times = bt_downbeats
-                if json_events:
-                    src_label = "full mix" if source_audio else "drums stem"
+                if bt_cv < lib_cv:
+                    bpm = bt_bpm
+                    beat_times = bt_beats
+                    downbeat_times = bt_downbeats
+                    if json_events:
+                        src_label = "full mix" if source_audio else "drums stem"
+                        emit({"event": "progress", "phase": "alignment", "pct": 2,
+                              "message": f"beat-this ({src_label}): {len(downbeat_times)} downbeats, CV {bt_cv*100:.1f}% (librosa was {lib_cv*100:.1f}%)"})
+                elif json_events:
                     emit({"event": "progress", "phase": "alignment", "pct": 2,
-                          "message": f"beat-this ({src_label}): {len(downbeat_times)} downbeats, CV {bt_cv*100:.1f}% (librosa was {lib_cv*100:.1f}%)"})
-            elif json_events:
-                emit({"event": "progress", "phase": "alignment", "pct": 2,
-                      "message": f"beat-this CV {bt_cv*100:.1f}% > librosa {lib_cv*100:.1f}%, using librosa"})
-    except ImportError:
-        pass
+                          "message": f"beat-this CV {bt_cv*100:.1f}% > librosa {lib_cv*100:.1f}%, using librosa"})
+        except ImportError:
+            pass
 
-    if downbeat_times is None:
-        # Experimental: beat grid corrections (only needed without neural downbeats).
-        # Apply ghost filtering + downbeat offset, but only keep if bar CV improves.
-        # Some tracks (syncopated, odd-time) get worse with corrections — revert those.
-        def _bar_cv(beats, ts):
-            bars = np.diff(beats[::ts])
-            return bars[:-1].std() / bars[:-1].mean() if len(bars) > 2 else 0
+        if downbeat_times is None:
+            # Experimental: beat grid corrections (only needed without neural downbeats).
+            # Apply ghost filtering + downbeat offset, but only keep if bar CV improves.
+            # Some tracks (syncopated, odd-time) get worse with corrections — revert those.
+            def _bar_cv(beats, ts):
+                bars = np.diff(beats[::ts])
+                return bars[:-1].std() / bars[:-1].mean() if len(bars) > 2 else 0
 
-        original_cv = _bar_cv(beat_times, time_sig)
-        corrected = beat_times.copy()
+            original_cv = _bar_cv(beat_times, time_sig)
+            corrected = beat_times.copy()
 
-        # Step 1a: Ghost beat filtering
-        corrected, ghosts_removed = filter_ghost_beats(corrected)
+            # Step 1a: Ghost beat filtering
+            corrected, ghosts_removed = filter_ghost_beats(corrected)
 
-        # Step 1b: Downbeat offset
-        downbeat_offset = find_best_downbeat_offset(bpm_source, corrected, time_sig)
-        if downbeat_offset > 0:
-            corrected = apply_downbeat_offset(corrected, downbeat_offset)
-
-        # Only keep corrections if they improved bar regularity
-        corrected_cv = _bar_cv(corrected, time_sig)
-        if corrected_cv < original_cv and (ghosts_removed > 0 or downbeat_offset > 0):
-            beat_times = corrected
-            corrections = []
-            if ghosts_removed > 0:
-                corrections.append(f"removed {ghosts_removed} ghost beats")
+            # Step 1b: Downbeat offset
+            downbeat_offset = find_best_downbeat_offset(bpm_source, corrected, time_sig)
             if downbeat_offset > 0:
-                corrections.append(f"shifted {downbeat_offset} beat(s)")
-            if json_events:
-                emit({"event": "progress", "phase": "alignment", "pct": 2,
-                      "message": f"beat grid corrected: {', '.join(corrections)} (CV {original_cv*100:.1f}%→{corrected_cv*100:.1f}%)"})
+                corrected = apply_downbeat_offset(corrected, downbeat_offset)
+
+            # Only keep corrections if they improved bar regularity
+            corrected_cv = _bar_cv(corrected, time_sig)
+            if corrected_cv < original_cv and (ghosts_removed > 0 or downbeat_offset > 0):
+                beat_times = corrected
+                corrections = []
+                if ghosts_removed > 0:
+                    corrections.append(f"removed {ghosts_removed} ghost beats")
+                if downbeat_offset > 0:
+                    corrections.append(f"shifted {downbeat_offset} beat(s)")
+                if json_events:
+                    emit({"event": "progress", "phase": "alignment", "pct": 2,
+                          "message": f"beat grid corrected: {', '.join(corrections)} (CV {original_cv*100:.1f}%→{corrected_cv*100:.1f}%)"})
 
     if json_events:
         emit({"event": "bpm", "bpm": bpm, "beat_count": len(beat_times)})


### PR DESCRIPTION
## Summary

`v0/src/stemforge_curate_bars.py` was running its own librosa+beat-this beat detection, ignoring the `bpm` + `first_downbeat_sec` that `stemforge split` / `re-anchor` already write into `stems.json`. Result: curated bars sliced on a different grid than the prechop/arrangement output, with BPM drift of 1–30 BPM, **and** silent override of user `--bpm` / `--first-downbeat` flags.

This PR is the **first half of "ensure curation tracks arrangement-mode beat detection"** — the other half (auto-retrigger curation when re-anchor mutates `stems.json`) is deferred until after hardening per user direction.

## Reproduction (pre-fix)

User flow surfaced today:
1. `stemforge split --bpm 125.0 --first-downbeat 0.282656 ...` → stems.json records 125.0.
2. `python v0/src/stemforge_curate_bars.py --stems-dir ...` → curated/manifest.json records **126.05** BPM.
3. Curated bars phase against prechop chunks in Live.

Same drift on definition (90.23 → 120.19) and ooh_la_la (85.11 → 85.71).

## Fix

`v0/src/stemforge_curate_bars.py`:

- New `_load_stems_manifest_tempo(stems_dir)` reads `bpm`, `tempo.first_downbeat_sec`, and source provenance from `stems.json`. Returns `None` cleanly when the manifest is missing/malformed or has no BPM.
- New `_synthesize_beat_grid(bpm, fdb, duration, time_sig)` lays beats deterministically every `60/bpm` seconds anchored on `first_downbeat_sec`, with **backward extrapolation** for beats before the first downbeat (so `slice_at_bars` can reach pre-bar-1 material exactly the way prechop does).
- `run()` calls the helper first; when the manifest provides tempo, the legacy librosa+beat-this comparison block is **skipped entirely**. Emits a clear NDJSON event:
  ```
  using stems.json tempo: bpm=125.00, first_downbeat=0.2827s
  (source: user-override) — 426 beats, 107 downbeats
  ```
- Falls back to in-script detection only when `stems.json` is absent or malformed (callers running curate on a raw stems-dir that bypassed split).

## End-to-end verification

| Track | stems.json BPM | pre-fix curated BPM | post-fix curated BPM |
|---|---|---|---|
| definition | 90.23 (user-override) | 120.19 | **90.23 ✓** |
| ooh_la_la | 85.11 (user-override) | 85.71 | **85.11 ✓** |
| believer | 125.00 (user-override) | 126.05 | **125.00 ✓** |

The `first_downbeat_sec` from each track's reanchor flows through too — definition's 8.93s, ooh_la_la's 22.59s, believer's 0.28s — all confirmed in the alignment NDJSON event during the verification run.

## Tests

[tests/test_curate_uses_stems_manifest.py](tests/test_curate_uses_stems_manifest.py) — 12 cases:

- Helper round-trips well-formed manifest; returns `None` on missing/malformed/no-BPM.
- Defaults `first_downbeat` to 0 when tempo block is missing but BPM present.
- Falls back through the `backend` field for source label when `tempo.source` absent.
- `_synthesize_beat_grid` first_downbeat=0 case, non-zero offset, backward extrapolation, zero-bpm + zero-duration error paths.
- **Believer regression sentinel** — locks the `125.0 / 0.282656` contract; will fail loud if curate ever re-detects again.

## Scope notes

**In scope:** the BPM/downbeat-detection contract change. Curation now uses the same numbers as arrangement-mode loading. The bar grids align.

**Out of scope (per user direction):**
- "Pick up re-anchor changes from arrangement mode and retrigger curation" — that's a separate post-hardening piece. When re-anchor mutates `stems.json`, the `curated/manifest.json` is now *stale* but still references the old (pre-anchor) tempo. Future PR: detect staleness and retrigger.
- Bar boundary verification against the actual prechop output. Bar grids should align by construction since both consume the same numbers, but a paranoia test could pin chunk-boundaries-vs-curated-bar-boundaries within ±sample-period tolerance. Worth doing if you've seen sub-millisecond drift in Live.

## Why is `v0/src/` not under ruff?

`v0/src/stemforge_curate_bars.py` is a script, not a package. The project's [.pre-commit-config.yaml](.pre-commit-config.yaml) scopes ruff to `^(stemforge|tests)/`. I left the formatter's preferred reformatting unapplied to keep the diff focused on the actual fix; if you want format normalization, easiest is one targeted `ruff format v0/src/stemforge_curate_bars.py` in a separate commit.

## Honesty footer

**Verified by reading code:** the actual rogue detection block at [v0/src/stemforge_curate_bars.py:354-432](v0/src/stemforge_curate_bars.py#L354-L432) (pre-fix); confirmed `stemforge split` writes `tempo.first_downbeat_sec` + `bpm` to stems.json via `manifest.write_manifest`; verified `re-anchor` updates the same fields with `source: "user-override"`.

**Inferred from docs:** that the user's "curation should use the same beat detection" maps cleanly to "read stems.json's tempo block, synthesize the grid from it, skip re-detection." The deferred follow-up (auto-retrigger on re-anchor) is the user's explicit scope direction; I'm not solving it here.

**Surprised by:** how much code the rogue-detection block was — 80 lines of librosa+beat-this comparison + experimental ghost-beat + downbeat-offset corrections. The new path is 30 lines including the helper. Less surface area for drift.

**Stacked-PR awareness:** independent of #51 (leading-partial fix) and the 3 still-open hardening PRs (#48 D.1, #49 C.3, #50 D.2). Touches no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
