### PR TITLE
fix(curate): --pipeline implies layout_mode=production when injecting processing_config

### DIFF
--- a/tests/test_curate_pipeline_implies_production.py
+++ b/tests/test_curate_pipeline_implies_production.py
@@ -1,0 +1,122 @@
+"""Tests for `--pipeline` → `layout_mode: production` override.
+
+Regression: passing `--pipeline pipelines/production_idm.yaml` injects
+`processing_config` into the curated manifest, but the curation YAML's
+`layout_mode` defaulted to `"stems"`. The M4L loader dispatcher
+(stemforge_loader.v0.js) routes to the rack-aware `loadSong()` path
+ONLY when `layout_mode === "production"`, so the `processing_config`
+was silently ignored — no Drum Racks, no Simplers, no curated content
+loaded.
+
+Fix: detect when `--pipeline` will inject a non-empty `processing_config`
+and override `layout_mode` to `"production"` automatically. Removes the
+"remember both flags" footgun. Believer-bug regression 2026-05-06.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CURATE_BARS_PATH = REPO_ROOT / "v0" / "src" / "stemforge_curate_bars.py"
+
+
+@pytest.fixture(scope="module")
+def curate_bars():
+    """Load the curate_bars script as a module via importlib."""
+    spec = importlib.util.spec_from_file_location("stemforge_curate_bars", CURATE_BARS_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── _pipeline_injects_processing_config ──────────────────────────────────────
+
+
+def test_returns_false_when_pipeline_path_is_none(curate_bars):
+    assert curate_bars._pipeline_injects_processing_config(None) is False
+
+
+def test_returns_false_when_pipeline_file_missing(curate_bars, tmp_path: Path):
+    assert curate_bars._pipeline_injects_processing_config(tmp_path / "missing.yaml") is False
+
+
+def test_returns_true_for_yaml_with_stems_block(curate_bars, tmp_path: Path):
+    pipeline = tmp_path / "p.yaml"
+    pipeline.write_text("name: test\nstems:\n  drums:\n    targets: []\n")
+    assert curate_bars._pipeline_injects_processing_config(pipeline) is True
+
+
+def test_returns_false_for_yaml_without_stems_block(curate_bars, tmp_path: Path):
+    pipeline = tmp_path / "p.yaml"
+    pipeline.write_text("name: test\nglobal:\n  strategy: max-diversity\n")
+    assert curate_bars._pipeline_injects_processing_config(pipeline) is False
+
+
+def test_returns_false_for_yaml_with_empty_stems(curate_bars, tmp_path: Path):
+    pipeline = tmp_path / "p.yaml"
+    pipeline.write_text("name: test\nstems: null\n")
+    assert curate_bars._pipeline_injects_processing_config(pipeline) is False
+
+
+def test_returns_true_for_json_pipeline(curate_bars, tmp_path: Path):
+    pipeline = tmp_path / "p.json"
+    pipeline.write_text(json.dumps({"name": "test", "stems": {"drums": {}}}))
+    assert curate_bars._pipeline_injects_processing_config(pipeline) is True
+
+
+def test_falls_back_to_json_when_yaml_path_missing(curate_bars, tmp_path: Path):
+    """`--pipeline foo.yaml` works when only `foo.json` exists (compiled output)."""
+    json_path = tmp_path / "p.json"
+    json_path.write_text(json.dumps({"stems": {"drums": {}}}))
+    yaml_path_that_doesnt_exist = tmp_path / "p.yaml"
+    assert curate_bars._pipeline_injects_processing_config(yaml_path_that_doesnt_exist) is True
+
+
+def test_returns_false_on_malformed_yaml(curate_bars, tmp_path: Path):
+    pipeline = tmp_path / "p.yaml"
+    pipeline.write_text("not: valid: yaml: ::: stuff")
+    assert curate_bars._pipeline_injects_processing_config(pipeline) is False
+
+
+# ── Real-world fixture: production_idm.yaml ──────────────────────────────────
+
+
+def test_real_production_idm_yaml_returns_true(curate_bars):
+    """The production_idm.yaml that ships with the repo MUST trigger override."""
+    pipeline = REPO_ROOT / "pipelines" / "production_idm.yaml"
+    if not pipeline.exists():
+        pytest.skip("pipelines/production_idm.yaml not present in this checkout")
+    assert curate_bars._pipeline_injects_processing_config(pipeline) is True
+
+
+# ── Acceptance regression sentinel ───────────────────────────────────────────
+
+
+def test_believer_bug_anchor():
+    """Documentary anchor for the 2026-05-06 believer-bug regression.
+
+    User flow that broke:
+        stemforge_curate_bars.py --stems-dir ... --pipeline production_idm.yaml
+        # (no --curation flag — defaults curation_config.layout.mode to "stems")
+
+    Manifest produced (pre-fix):
+        layout_mode: "stems"           ← wrong: M4L routes to _loadCuratedV2
+        processing_config: {drums: ..} ← present but ignored by the dispatcher
+
+    Manifest expected (post-fix):
+        layout_mode: "production"      ← M4L routes to loadSong() / buildDrumRack
+        processing_config: {drums: ..} ← honored by loadSong()
+    """
+    # Sentinel: assert the implementation surface exists.
+    assert CURATE_BARS_PATH.exists()
+    src = CURATE_BARS_PATH.read_text()
+    assert "_pipeline_injects_processing_config" in src
+    assert 'layout_mode = "production"' in src

--- a/v0/src/stemforge_curate_bars.py
+++ b/v0/src/stemforge_curate_bars.py
@@ -63,6 +63,35 @@ def find_stems(stems_dir: Path) -> dict[str, Path]:
     return stems
 
 
+def _pipeline_injects_processing_config(pipeline: Path | None) -> bool:
+    """True if the given pipeline path will inject a `processing_config` into
+    the curated manifest.
+
+    The M4L loader's dispatcher (stemforge_loader.v0.js) routes to the
+    config-driven `loadSong()` path only when `layout_mode === "production"`.
+    Carrying a `processing_config` block without `layout_mode: production`
+    leaves the manifest in an impossible state — the legacy `_loadCuratedV2`
+    path runs, ignores the config, and tries to find pre-existing Simpler
+    templates that don't exist. Caller should override `layout_mode` to
+    "production" whenever this returns True.
+    """
+    if pipeline is None:
+        return False
+    candidate = pipeline if pipeline.exists() else pipeline.with_suffix(".json")
+    if not candidate.exists():
+        return False
+    try:
+        if candidate.suffix == ".json":
+            data = json.loads(candidate.read_text())
+        else:
+            import yaml as _yaml
+
+            data = _yaml.safe_load(candidate.read_text())
+    except Exception:
+        return False
+    return bool(isinstance(data, dict) and data.get("stems"))
+
+
 def _reslice_with_padding(
     *,
     source_stem_path: Path,
@@ -324,6 +353,20 @@ def run(
         schema_config = CurationSchemaConfig()
 
     layout_mode = curation_config.layout.mode
+
+    # If the caller supplied a `--pipeline` YAML that will inject a
+    # `processing_config` block, the intended consumer is loadSong() on the
+    # M4L side. loadSong() only fires when `layout_mode === "production"`,
+    # so override here so users don't have to remember `--curation` AND
+    # `--pipeline` together. Believer-bug regression 2026-05-06.
+    if _pipeline_injects_processing_config(pipeline) and layout_mode != "production":
+        if json_events:
+            emit({"event": "progress", "phase": "config", "pct": 0,
+                  "message": (f"--pipeline injects processing_config; "
+                              f"overriding layout_mode {layout_mode!r} -> 'production' "
+                              f"so the M4L loadSong() path triggers")})
+        layout_mode = "production"
+
     is_loops_only = layout_mode == "loops-only"
     is_production = layout_mode == "production"
 
@@ -513,7 +556,7 @@ def run(
         "bpm": bpm,
         "beat_count": len(beat_times),
         "time_signature_numerator": time_sig,
-        "layout_mode": curation_config.layout.mode,
+        "layout_mode": layout_mode,
         "stems": {},
     }
 


### PR DESCRIPTION
## Summary

Believer-load regression surfaced 2026-05-06: passing `--pipeline pipelines/production_idm.yaml` injects `processing_config` into the curated manifest, **but** `layout_mode` was defaulting to `"stems"` (from `CurationConfig.layout.mode` dataclass default). The M4L loader's dispatcher gates on `layout_mode === "production"` and routes everything else to a legacy path that ignores `processing_config`. Result: four empty Drum Rack tracks, `0 pads loaded across 4 racks`.

Fix: when `--pipeline` will inject a non-empty `processing_config`, override `layout_mode` to `"production"` automatically. Users no longer have to remember `--curation` AND `--pipeline` together.

## Loader dispatch context (the why)

[v0/src/m4l-js/stemforge_loader.v0.js:602](v0/src/m4l-js/stemforge_loader.v0.js#L602):
```js
if (mf.layout_mode === "production") {
    loadSong();              // config-driven; reads processing_config; auto-builds racks
} else if (isV2) {
    _loadCuratedV2(mf);      // expects pre-existing SF | {Stem} Rack templates with Simplers
} else {
    _loadCuratedManifest(mf); // v1 legacy flat-array path
}
```

`processing_config` is honored only by `loadSong()`. Carrying it without `layout_mode: "production"` is an impossible-state combination — the dispatcher routes around the data it depends on.

## Changes

### `v0/src/stemforge_curate_bars.py`

- New helper `_pipeline_injects_processing_config(pipeline)` — returns `True` when the pipeline YAML/JSON has a non-empty `stems:` block (the exact gate used elsewhere in the script to decide whether to embed `processing_config`).
- `run()` checks the helper early and overrides `layout_mode → "production"` before the `is_loops_only` / `is_production` booleans are computed AND before the manifest is written.
- Manifest write site (line 516) now uses the local `layout_mode` variable instead of re-reading `curation_config.layout.mode` (which would be stale after the override).
- Emits a clear progress event when the override fires:
  ```
  --pipeline injects processing_config; overriding layout_mode 'stems' -> 'production'
  so the M4L loadSong() path triggers
  ```

### Tests ([tests/test_curate_pipeline_implies_production.py](tests/test_curate_pipeline_implies_production.py), 10 cases)

- Helper returns `False` on `None` / missing file / no `stems:` block / empty `stems:` / malformed YAML.
- Returns `True` on YAML with `stems`, JSON with `stems`, .yaml-path-but-.json-fallback (compiled-output path that `generate-pipeline-json` produces).
- **Real pipelines/production_idm.yaml is a True case** — sentinel against future YAML-shape regressions in the shipped pipelines.
- Believer-bug documentary anchor (asserts the helper exists + the override line is present in source).

## End-to-end verification

Re-ran on all three of the user's tracks (`stemforge_curate_bars.py --pipeline pipelines/production_idm.yaml` only, no `--curation`):

| Track | Pre-fix `layout_mode` | Post-fix `layout_mode` |
|---|---|---|
| believer | `stems` ✗ | **`production` ✓** |
| definition | `stems` ✗ | **`production` ✓** |
| ooh_la_la | `stems` ✗ | **`production` ✓** |

The dispatcher will now route to `loadSong()` for any manifest produced by `--pipeline pipelines/production_idm.yaml`, and `buildDrumRack` will auto-create the Drum Rack + 16 chains + 16 Simplers + sample loads from scratch. **No template prep required on the user's side.**

## Test plan

- [x] `uv run --extra dev pytest tests/test_curate_pipeline_implies_production.py -v` — 10 passed
- [x] `uv run --extra dev --extra beat pytest -q` — 589 passed
- [x] `uv run ruff check stemforge tests` — All checks passed
- [x] End-to-end: re-curated 3 tracks; all 3 produced `layout_mode: "production"` + `processing_config` present
- [ ] Live test: drop `StemForge.amxd` onto a track, pick believer/definition/ooh_la_la, confirm Drum Rack auto-build with Simplers loaded

## Out of scope (tracked as follow-ups)

1. **Delete the legacy `_loadCuratedV2` / `_loadCuratedManifest` paths.** With `loadSong()` now reliably reachable for any production-mode manifest, the v1 + v2 quadrant paths (~230 LOC out of 2004 in stemforge_loader.v0.js) become dead weight. Live 12.3+ has been the project floor since 2026-04-20; the original justification for the template-pre-population path is gone.
2. **Loader-side defensive fallback.** Even with the curate-side fix in place, a hand-written manifest that has `processing_config` but `layout_mode != "production"` would still fall through to the wrong path. A small dispatcher patch to route on `processing_config` presence would be belt-and-suspenders. Requires `.amxd` rebuild; not blocking this PR.

## Stacking note

This PR is independent of #52 (curate-uses-stems-manifest-tempo) — they touch the same file but different functions. After both merge, a single `stemforge_curate_bars.py --pipeline production_idm.yaml` run produces:
- correct BPM (from `stems.json`, via #52)
- correct `layout_mode` (`production`, via this PR)
- correct `processing_config` (via existing pipeline-embed logic)
- → ready-to-load by the M4L `loadSong()` path with zero template prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
