### PR TITLE
fix(tempo): prefer drums first_downbeat when phase-equivalent to mix (GH #55)

### DIFF
--- a/stemforge/tempo_reconciler.py
+++ b/stemforge/tempo_reconciler.py
@@ -610,15 +610,9 @@ def reconcile_tempo(
             #     on grid alignment, off by a sub-bar amount) → keep mix
             #     and downgrade confidence. This is rare and usually means
             #     a tempo change or odd-time material; flag for the user.
-            mix_fdb = (
-                float(mix_est.downbeat_times[0])
-                if len(mix_est.downbeat_times) > 0
-                else 0.0
-            )
+            mix_fdb = float(mix_est.downbeat_times[0]) if len(mix_est.downbeat_times) > 0 else 0.0
             drums_fdb = (
-                float(drums_est.downbeat_times[0])
-                if len(drums_est.downbeat_times) > 0
-                else 0.0
+                float(drums_est.downbeat_times[0]) if len(drums_est.downbeat_times) > 0 else 0.0
             )
             bar_period = 60.0 * 4 / mix_est.bpm
             is_equiv, n_bars_offset = _phase_equivalence(mix_fdb, drums_fdb, bar_period)

--- a/stemforge/tempo_reconciler.py
+++ b/stemforge/tempo_reconciler.py
@@ -135,6 +135,44 @@ def _is_suspicious_ratio(a: float, b: float) -> tuple[bool, float | None]:
     return False, None
 
 
+def _phase_equivalence(
+    fdb_a: float, fdb_b: float, bar_period: float, *, tolerance_bars: float = 0.10
+) -> tuple[bool, int]:
+    """Test whether two first_downbeat candidates fall on the same bar grid.
+
+    Returns ``(is_equivalent, n_bars_offset)`` where:
+
+    * ``n_bars_offset = round((fdb_b - fdb_a) / bar_period)`` — how many
+      bars apart the two picks are when snapped to integer.
+    * ``is_equivalent`` is True iff the residual after snapping is within
+      ``tolerance_bars`` (= 10% of a bar by default).
+
+    Use case: when mix and drums detectors agree on BPM but disagree on
+    first_downbeat, this function distinguishes "same grid, different
+    'bar 1' picks" (= ``is_equivalent=True, n_bars_offset != 0``) from
+    "actually different grid alignments" (= ``is_equivalent=False``). The
+    Definition pattern (mix=3.78s, drums=8.94s, bar_period=2.66s) gives
+    ``(True, 2)`` — same grid, drums picked the second-stable-downbeat
+    that's also the song's true bar 1.
+
+    Why 10% and not 5%: empirically (Definition 2026-05-08), beat-this's
+    per-frame quantization of downbeat positions can produce residuals
+    of ~6-7% of a bar when the structural offset is a clean integer.
+    Tighter tolerances reject the very pattern this helper exists to
+    catch. 10% is still well below half-a-bar (= the threshold beyond
+    which the offset would round to a different integer), so widening
+    here doesn't introduce false-positive bar-jumps.
+
+    ``n_bars_offset == 0`` with ``is_equivalent=True`` means the two
+    picks agree within tolerance.
+    """
+    if bar_period <= 0:
+        return False, 0
+    delta_bars = (fdb_b - fdb_a) / bar_period
+    n_bars = round(delta_bars)
+    return (abs(delta_bars - n_bars) < tolerance_bars, int(n_bars))
+
+
 def _bar_period_from_downbeats(downbeats: np.ndarray) -> float | None:
     """Mean bar period (seconds per bar) from downbeat IBIs.
 
@@ -550,14 +588,85 @@ def reconcile_tempo(
         bpm_close = abs(mix_est.bpm - drums_est.bpm) / max(mix_est.bpm, drums_est.bpm) < 0.005
 
         if bpm_close:
-            # They agree — high confidence in the mix estimate.
+            # BPMs agree. Now check whether mix and drums picked the same
+            # first_downbeat — if not, decide which to trust.
+            #
+            # Background (Definition + Ooh La La regression, 2026-05-08):
+            # On hip-hop tracks with intro material before bar 1, mix often
+            # locks onto an early synth/vocal/sample transient that beat-this
+            # interprets as a plausible downbeat. The drums stem (post-Demucs)
+            # has nothing meaningful before the actual first kick, so its
+            # downbeat[0] is usually the song's true bar 1.
+            #
+            # Strategy:
+            #   - If mix and drums agree on first_downbeat (within ~5% of a
+            #     bar) → use mix as before. High confidence.
+            #   - If they're PHASE-EQUIVALENT (= same grid, different "bar 1"
+            #     picks, mix's pick is N bars off drums') → prefer drums.
+            #     Same-grid means the user can re-anchor either to mix's or
+            #     drums' pick if the auto-pick is wrong, but drums is
+            #     statistically the cleaner choice.
+            #   - If they're NOT phase-equivalent (= they actually disagree
+            #     on grid alignment, off by a sub-bar amount) → keep mix
+            #     and downgrade confidence. This is rare and usually means
+            #     a tempo change or odd-time material; flag for the user.
+            mix_fdb = (
+                float(mix_est.downbeat_times[0])
+                if len(mix_est.downbeat_times) > 0
+                else 0.0
+            )
+            drums_fdb = (
+                float(drums_est.downbeat_times[0])
+                if len(drums_est.downbeat_times) > 0
+                else 0.0
+            )
+            bar_period = 60.0 * 4 / mix_est.bpm
+            is_equiv, n_bars_offset = _phase_equivalence(mix_fdb, drums_fdb, bar_period)
+
+            if is_equiv and n_bars_offset == 0:
+                # First_downbeats agree — original behavior.
+                return ReconciledTempo(
+                    bpm=mix_est.bpm,
+                    beat_times=mix_est.beat_times,
+                    downbeat_times=mix_est.downbeat_times,
+                    source=mix_est.source,
+                    confidence="high",
+                    all_estimates=estimates,
+                )
+
+            if is_equiv:
+                # Phase-equivalent disagreement → prefer drums.
+                return ReconciledTempo(
+                    bpm=drums_est.bpm,
+                    beat_times=drums_est.beat_times,
+                    downbeat_times=drums_est.downbeat_times,
+                    source=drums_est.source,
+                    confidence="high",
+                    all_estimates=estimates,
+                    warning=(
+                        f"mix and drums agreed on BPM ({mix_est.bpm:.2f}) but "
+                        f"differed on first_downbeat: mix={mix_fdb:.3f}s, "
+                        f"drums={drums_fdb:.3f}s ({n_bars_offset:+d} bars apart). "
+                        f"Preferred drums (cleaner kick signal)."
+                    ),
+                )
+
+            # Not phase-equivalent — sub-bar grid disagreement.
+            # Keep mix but downgrade to medium confidence and flag the
+            # diagnostic so the user can override with --first-downbeat.
             return ReconciledTempo(
                 bpm=mix_est.bpm,
                 beat_times=mix_est.beat_times,
                 downbeat_times=mix_est.downbeat_times,
                 source=mix_est.source,
-                confidence="high",
+                confidence="medium",
                 all_estimates=estimates,
+                warning=(
+                    f"mix and drums agreed on BPM ({mix_est.bpm:.2f}) but their "
+                    f"first_downbeats are NOT phase-equivalent: mix={mix_fdb:.3f}s, "
+                    f"drums={drums_fdb:.3f}s, sub-bar offset. "
+                    f"Using mix; consider --first-downbeat override."
+                ),
             )
 
         if ratio_suspicious and kick_tiebreaker and drums_path is not None:

--- a/tests/fixtures/known_tempos.py
+++ b/tests/fixtures/known_tempos.py
@@ -82,7 +82,7 @@ CANONICAL_TRACKS: list[CanonicalTempo] = [
         truth_first_downbeat_sec=8.934,
         bpm_tolerance=0.15,  # mean estimator + refine_bpm typically lands within 0.05
         fdb_tolerance_sec=0.05,
-        fdb_assert_pending_fix=True,  # GH #55 not yet implemented
+        fdb_assert_pending_fix=False,  # GH #55 not yet implemented
         pending_fix_issue=55,
     ),
     CanonicalTempo(
@@ -96,7 +96,7 @@ CANONICAL_TRACKS: list[CanonicalTempo] = [
         # beat-this:mix returns ~0.02s (a phantom transient at the very
         # start of the long intro); beat-this:drums returns ~22.60s
         # (the actual first kick). The reconciler currently picks mix.
-        fdb_assert_pending_fix=True,
+        fdb_assert_pending_fix=False,
         pending_fix_issue=55,
     ),
     CanonicalTempo(

--- a/tests/test_tempo_reconciler.py
+++ b/tests/test_tempo_reconciler.py
@@ -13,6 +13,7 @@ from stemforge.tempo_reconciler import (
     TempoEstimate,
     _bar_period_from_downbeats,
     _is_suspicious_ratio,
+    _phase_equivalence,
     reconcile_tempo,
     refine_bpm,
 )
@@ -75,12 +76,70 @@ class TestSuspiciousRatio:
             assert abs(matched - r) / r < RATIO_TOLERANCE
 
 
+# ── _phase_equivalence (GH #55 picker helper) ───────────────────────────────
+
+
+class TestPhaseEquivalence:
+    """The Definition fix (GH #55) hinges on this helper: given two
+    first_downbeat candidates, decide whether they're "same grid, different
+    bar 1 picks" (phase-equivalent at non-zero bar offset) vs "actually
+    misaligned grids" (sub-bar offset, no integer bar count fits).
+    """
+
+    def test_zero_offset_when_first_downbeats_match(self):
+        # Same fdb → 0 bars apart, phase-equivalent.
+        is_eq, n = _phase_equivalence(0.28, 0.28, bar_period=2.66)
+        assert is_eq
+        assert n == 0
+
+    def test_within_tolerance_still_zero_offset(self):
+        # 5% of 2.66 = 0.133s. Diff of 0.05s is well within tolerance.
+        is_eq, n = _phase_equivalence(0.28, 0.33, bar_period=2.66)
+        assert is_eq
+        assert n == 0
+
+    def test_phase_equivalent_at_two_bars(self):
+        # The Definition pattern: drums fdb is exactly 2 bars after mix.
+        is_eq, n = _phase_equivalence(3.78, 3.78 + 2 * 2.66, bar_period=2.66)
+        assert is_eq
+        assert n == 2
+
+    def test_phase_equivalent_negative_offset(self):
+        # If drums lands BEFORE mix on the grid, n is negative.
+        is_eq, n = _phase_equivalence(8.94, 8.94 - 2 * 2.66, bar_period=2.66)
+        assert is_eq
+        assert n == -2
+
+    def test_not_equivalent_when_off_by_sub_bar(self):
+        # Diff of 0.7s at bar_period 2.0s = 0.35 bars: nearest int = 0,
+        # residual 0.35 = 35%, well outside 5% tolerance.
+        is_eq, n = _phase_equivalence(0.5, 1.2, bar_period=2.0)
+        assert not is_eq
+        # n is the rounded value but is_eq=False guards callers from acting on it.
+        assert n == 0
+
+    def test_handles_zero_bar_period_safely(self):
+        # Defensive — zero bar_period would otherwise divide-by-zero.
+        is_eq, n = _phase_equivalence(0.28, 5.0, bar_period=0.0)
+        assert not is_eq
+        assert n == 0
+
+
 # ── reconcile_tempo behavior with mocked detectors ──────────────────────────
 
 
-def _make_estimate(source: str, bpm: float, n_beats: int = 100) -> TempoEstimate:
-    """Build a TempoEstimate stand-in. Beat times are evenly spaced to match BPM."""
-    beats = np.arange(n_beats, dtype=float) * (60.0 / bpm)
+def _make_estimate(
+    source: str,
+    bpm: float,
+    n_beats: int = 100,
+    *,
+    first_downbeat_sec: float = 0.0,
+) -> TempoEstimate:
+    """Build a TempoEstimate stand-in. Beat times are evenly spaced to match BPM,
+    starting at `first_downbeat_sec` (= where downbeat[0] lives).
+    """
+    beat_period = 60.0 / bpm
+    beats = first_downbeat_sec + np.arange(n_beats, dtype=float) * beat_period
     detector = "beat-this" if "beat-this" in source else "librosa"
     audio_label = source.split(":")[-1]
     return TempoEstimate(
@@ -100,8 +159,11 @@ class TestReconcileTempo:
         with pytest.raises(ValueError):
             reconcile_tempo(mix_path=None, drums_path=None)
 
-    def test_high_confidence_when_mix_and_drums_agree(self, tmp_path):
-        """The Definition case: mix and drums both at 90 BPM → high confidence."""
+    def test_high_confidence_when_mix_and_drums_fully_agree(self, tmp_path):
+        """When mix and drums agree on BOTH BPM and first_downbeat → use
+        mix at high confidence. Believer pattern: bpm 125, fdb ~0.28s on
+        both detectors.
+        """
         mix = tmp_path / "mix.wav"
         drums = tmp_path / "drums.wav"
         # Files don't need real audio — we mock the detectors.
@@ -110,16 +172,82 @@ class TestReconcileTempo:
 
         with mock.patch("stemforge.tempo_reconciler._detect_beat_this") as m:
             m.side_effect = [
-                _make_estimate("beat-this:mix", 90.91),
-                _make_estimate("beat-this:drums", 90.91),
+                _make_estimate("beat-this:mix", 125.0, first_downbeat_sec=0.28),
+                _make_estimate("beat-this:drums", 125.0, first_downbeat_sec=0.28),
             ]
             result = reconcile_tempo(mix, drums, kick_tiebreaker=False)
 
         assert result.confidence == "high"
-        assert abs(result.bpm - 90.91) < 0.01
+        assert abs(result.bpm - 125.0) < 0.01
         assert result.source == "beat-this:mix"
         assert result.warning is None
         assert len(result.all_estimates) == 2
+
+    def test_phase_equivalent_first_downbeat_disagreement_prefers_drums(self, tmp_path):
+        """The Definition pattern (GH #55, fixed 2026-05-08):
+
+        mix and drums agree on BPM (90) but mix locks onto a phantom
+        downbeat 5.16s before the song's true bar 1; drums correctly
+        identifies the actual first kick. Both pick "bar 1" on the same
+        underlying grid (offset = 2 bars), so the picks are phase-equivalent
+        — prefer drums.
+        """
+        mix = tmp_path / "mix.wav"
+        drums = tmp_path / "drums.wav"
+        mix.touch()
+        drums.touch()
+
+        # Mix says fdb=3.78s, drums says fdb=8.94s. bar_period = 60/90*4 = 2.667s.
+        # Diff = 5.16s = 1.94 bars; rounds to 2 bars; residual is 0.06 bars
+        # = 6%, just outside the 5% tolerance band. To make this cleanly
+        # phase-equivalent (within tolerance), use mix=3.78s drums=3.78s+2*2.667=9.114s.
+        bar_period = 60.0 * 4 / 90.0
+        mix_fdb = 3.78
+        drums_fdb = mix_fdb + 2 * bar_period
+
+        with mock.patch("stemforge.tempo_reconciler._detect_beat_this") as m:
+            m.side_effect = [
+                _make_estimate("beat-this:mix", 90.0, first_downbeat_sec=mix_fdb),
+                _make_estimate("beat-this:drums", 90.0, first_downbeat_sec=drums_fdb),
+            ]
+            result = reconcile_tempo(mix, drums, kick_tiebreaker=False)
+
+        assert result.source == "beat-this:drums", "phase-equivalent disagreement → drums must win"
+        assert result.confidence == "high"
+        # Returned downbeat[0] should be drums' pick.
+        assert abs(float(result.downbeat_times[0]) - drums_fdb) < 1e-6
+        assert result.warning is not None and "Preferred drums" in result.warning
+        assert "+2 bars apart" in result.warning
+
+    def test_non_phase_equivalent_first_downbeat_keeps_mix_with_warning(self, tmp_path):
+        """When mix and drums agree on BPM but their first_downbeats are
+        OFF BY A SUB-BAR AMOUNT (= they don't align on the same grid at any
+        integer bar offset), keep mix but flag medium confidence.
+
+        This is the rare case where one detector locked onto a syncopated
+        hit and the other onto a true downbeat. Hard to disambiguate
+        automatically — defer to the user via --first-downbeat override.
+        """
+        mix = tmp_path / "mix.wav"
+        drums = tmp_path / "drums.wav"
+        mix.touch()
+        drums.touch()
+
+        # bar_period = 60/120*4 = 2.0s. Diff of 0.7s = 0.35 bars (= residual
+        # 0.35 from nearest int 0; well outside the 5% tolerance).
+        with mock.patch("stemforge.tempo_reconciler._detect_beat_this") as m:
+            m.side_effect = [
+                _make_estimate("beat-this:mix", 120.0, first_downbeat_sec=0.5),
+                _make_estimate("beat-this:drums", 120.0, first_downbeat_sec=1.2),
+            ]
+            result = reconcile_tempo(mix, drums, kick_tiebreaker=False)
+
+        assert result.source == "beat-this:mix", (
+            "non-phase-equivalent disagreement → mix kept (no auto-pick possible)"
+        )
+        assert result.confidence == "medium"
+        assert result.warning is not None
+        assert "NOT phase-equivalent" in result.warning
 
     def test_low_confidence_with_fuzzy_disagreement(self, tmp_path):
         """The Alright case: mix=111 vs drums=115. Not a round factor — falls


### PR DESCRIPTION
## Summary

Closes GH #55. When `beat-this:mix` and `beat-this:drums` agree on BPM but disagree on `first_downbeat`, the reconciler used to always pick mix's downbeats. That was wrong for tracks like Definition and Ooh La La where mix locks onto a phantom intro transient several bars before the song's true bar 1, while drums correctly identifies the first kick.

This PR adds a phase-equivalence check: when mix's and drums' first_downbeats are an integer-bar offset apart (= same grid, different "bar 1" picks), prefer drums.

## Empirical impact (canonical regression fixtures)

| Track | first_downbeat before | first_downbeat after | Truth | Status |
|-------|---------------------|--------------------|-------|--------|
| Definition | 3.78s (mix phantom) | **8.94s** (drums) | 8.934s | ✅ within 6ms |
| Ooh La La | 0.020s (mix phantom) | **22.59s** (drums) | 22.594s | ✅ within 4ms |
| Believer | 0.28s | **0.28s** | 0.283s | ✅ unchanged (no regression) |

User-visible: Definition + Ooh La La (and likely many other intro-heavy hip-hop tracks) now forge correctly without needing a manual re-anchor.

## Implementation

1. **New helper** `_phase_equivalence(fdb_a, fdb_b, bar_period)` returns `(is_equivalent, n_bars_offset)`. Tolerance is 10% of a bar (raised from initial 5% — beat-this's per-frame quantization of downbeat positions can produce 6-7% residuals on real material; tighter tolerances rejected the very pattern this exists to catch).

2. **Picker change** in `reconcile_tempo`'s BPM-agreement branch:
   - n_bars_offset == 0 (within tolerance) → mix as before, high confidence
   - is_equivalent=True with non-zero offset → drums wins, high confidence + warning
   - is_equivalent=False (sub-bar mismatch) → keep mix at medium confidence, warning suggests `--first-downbeat` override

3. **Test additions** in `tests/test_tempo_reconciler.py`:
   - `TestPhaseEquivalence` — 6 helper unit tests
   - `TestReconcileTempo` — 2 picker behavior tests covering phase-equivalent and non-equivalent disagreement

4. **Canonical fixtures flipped** — Definition and Ooh La La in `tests/fixtures/known_tempos.py` now strict-truth (was `fdb_assert_pending_fix=True`).

## Test plan

- [x] Reconciler unit tests: 33 pass (was 25 = +8 new)
- [x] Full Python suite: 651 pass
- [x] Canonical regression tests against real audio (~4.5 min): all 6 pass on Definition / Ooh La La / Believer
- [x] User confirmed end-to-end on all 3 tracks: forge → curate → load in Live works without re-anchor

## Why a separate PR

This commit was authored on the `fix/curate-recurate-with-stems-tempo` branch (PR #58) but missed the merge window. Cherry-picked onto its own branch off post-#58 main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
