### PR TITLE
feat(m4l): _collapseToLoopRegion — bake loop region into bounce

### DIFF
--- a/tests/js_mocks/test_bounce.test.js
+++ b/tests/js_mocks/test_bounce.test.js
@@ -1,0 +1,226 @@
+// test_bounce.test.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for _bounceCropTrack — specifically the loop-region collapse behavior
+// added 2026-05-11. When a clip is looping, the bounce should write the loop
+// bounds onto start_marker/end_marker BEFORE calling crop, so that the
+// resulting cropped WAV contains exactly the loop region. When a clip is not
+// looping, the markers must be left alone.
+//
+// Mirrors the harness style from test_commit.test.js (sandbox + seeded
+// liveTree + assertion against state.liveApiCalls / node._properties).
+// ─────────────────────────────────────────────────────────────────────────────
+
+'use strict';
+
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createSandbox, loadModule, maxApi } = require('./sandbox');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SF_LOADER = path.join(REPO_ROOT, 'v0', 'src', 'm4l-js', 'stemforge_loader.v0.js');
+
+function makeTrack(name, clipSlots) {
+    return { _properties: { name }, clip_slots: clipSlots || [] };
+}
+
+function makeClipSlot(clipProps) {
+    if (clipProps === null || clipProps === undefined) return { _properties: {} };
+    return { _properties: {}, clip: { _properties: clipProps } };
+}
+
+function loadBounce() {
+    maxApi.resetState();
+    const ctx = createSandbox();
+    loadModule(ctx, SF_LOADER);
+    return {
+        ctx,
+        bounceCropTrack: ctx._bounceCropTrack,
+        collapseToLoopRegion: ctx._collapseToLoopRegion,
+    };
+}
+
+// Convenience to walk the seeded tree and read a clip's _properties.
+// The seeded tree's root has `tracks` directly (no `live_set` wrapper);
+// _resolveNode in max_api.js just uses the first path seg as a sentinel
+// and walks from the tree root for the rest.
+function getClipProps(trackIdx, slotIdx) {
+    const tree = maxApi.getLiveTree();
+    if (!tree) return null;
+    const tracks = tree.tracks;
+    if (!tracks || !tracks[trackIdx]) return null;
+    const slot = tracks[trackIdx].clip_slots && tracks[trackIdx].clip_slots[slotIdx];
+    return slot && slot.clip && slot.clip._properties;
+}
+
+// ── 1. looping=1 + loop region differs from play region ─────────────────────
+
+test('_bounceCropTrack: looping=1 + divergent loop bounds → markers rewritten before crop', () => {
+    const { bounceCropTrack } = loadBounce();
+
+    // Build a tree with one track "A" containing one clip:
+    //   play region 0..8, loop region 2..6, warping=1 (so units are beats).
+    const clip = {
+        file_path: '/abs/clip.wav',
+        warping: 1,
+        start_marker: 0, end_marker: 8, length: 8,
+        looping: 1, loop_start: 2, loop_end: 6,
+    };
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot(clip)])],
+    });
+
+    // Snapshot crop firings — record marker state at each call.
+    const cropFires = [];
+    maxApi.setLiveCallHandler('crop', function (lomPath) {
+        // Pull the live state at the moment crop fires.
+        const props = getClipProps(0, 0);
+        cropFires.push({
+            path: lomPath,
+            start_marker: props.start_marker,
+            end_marker: props.end_marker,
+        });
+        return 0;
+    });
+
+    let onDoneCalled = false;
+    bounceCropTrack('A', function (ok /* , msg */) { onDoneCalled = ok; });
+
+    assert.equal(onDoneCalled, true, 'onDone should be called with ok=true');
+    assert.equal(cropFires.length, 1, 'crop should fire exactly once');
+    assert.equal(cropFires[0].start_marker, 2,
+        'start_marker should be loop_start (2) when crop fires');
+    assert.equal(cropFires[0].end_marker, 6,
+        'end_marker should be loop_end (6) when crop fires');
+});
+
+// ── 2. looping=0 → markers untouched (current behavior preserved) ────────────
+
+test('_bounceCropTrack: looping=0 → markers untouched, crop sees play region', () => {
+    const { bounceCropTrack } = loadBounce();
+
+    const clip = {
+        file_path: '/abs/clip.wav',
+        warping: 1,
+        start_marker: 0, end_marker: 8, length: 8,
+        looping: 0, loop_start: 2, loop_end: 6,  // loop bounds present but ignored
+    };
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot(clip)])],
+    });
+
+    const cropFires = [];
+    maxApi.setLiveCallHandler('crop', function (lomPath) {
+        const props = getClipProps(0, 0);
+        cropFires.push({
+            start_marker: props.start_marker,
+            end_marker: props.end_marker,
+        });
+        return 0;
+    });
+
+    bounceCropTrack('A', function () {});
+
+    assert.equal(cropFires.length, 1, 'crop should fire once');
+    assert.equal(cropFires[0].start_marker, 0,
+        'start_marker untouched at 0 when looping=0');
+    assert.equal(cropFires[0].end_marker, 8,
+        'end_marker untouched at 8 when looping=0');
+});
+
+// ── 3. looping=1 but loop bounds == play bounds → no-op write, safe ──────────
+
+test('_bounceCropTrack: looping=1 + loop bounds == play bounds → idempotent', () => {
+    const { bounceCropTrack } = loadBounce();
+
+    const clip = {
+        file_path: '/abs/clip.wav',
+        warping: 1,
+        start_marker: 0, end_marker: 4, length: 4,
+        looping: 1, loop_start: 0, loop_end: 4,
+    };
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot(clip)])],
+    });
+
+    const cropFires = [];
+    maxApi.setLiveCallHandler('crop', function () {
+        const props = getClipProps(0, 0);
+        cropFires.push({ start_marker: props.start_marker, end_marker: props.end_marker });
+    });
+
+    bounceCropTrack('A', function () {});
+
+    assert.equal(cropFires.length, 1);
+    assert.equal(cropFires[0].start_marker, 0);
+    assert.equal(cropFires[0].end_marker, 4);
+});
+
+// ── 4. Invalid loop bounds (le ≤ ls) → skip rewrite (safety) ─────────────────
+
+test('_bounceCropTrack: looping=1 with le<=ls → skip rewrite (safety guard)', () => {
+    const { bounceCropTrack } = loadBounce();
+
+    const clip = {
+        file_path: '/abs/clip.wav',
+        warping: 1,
+        start_marker: 0, end_marker: 4, length: 4,
+        looping: 1, loop_start: 5, loop_end: 5,  // degenerate: le == ls
+    };
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot(clip)])],
+    });
+
+    const cropFires = [];
+    maxApi.setLiveCallHandler('crop', function () {
+        const props = getClipProps(0, 0);
+        cropFires.push({ start_marker: props.start_marker, end_marker: props.end_marker });
+    });
+
+    bounceCropTrack('A', function () {});
+
+    assert.equal(cropFires.length, 1);
+    assert.equal(cropFires[0].start_marker, 0,
+        'degenerate loop bounds must NOT overwrite markers');
+    assert.equal(cropFires[0].end_marker, 4,
+        'degenerate loop bounds must NOT overwrite markers');
+});
+
+// ── 5. _collapseToLoopRegion direct unit test ────────────────────────────────
+
+test('_collapseToLoopRegion: unit — looping=1 writes loop bounds to markers', () => {
+    const { ctx, collapseToLoopRegion } = loadBounce();
+
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot({
+            warping: 1,
+            start_marker: 1, end_marker: 9,
+            looping: 1, loop_start: 3, loop_end: 7,
+        })])],
+    });
+    const clipApi = new ctx.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    collapseToLoopRegion(clipApi);
+
+    const props = getClipProps(0, 0);
+    assert.equal(props.start_marker, 3);
+    assert.equal(props.end_marker, 7);
+});
+
+test('_collapseToLoopRegion: unit — looping=0 leaves markers alone', () => {
+    const { ctx, collapseToLoopRegion } = loadBounce();
+
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot({
+            warping: 1,
+            start_marker: 1, end_marker: 9,
+            looping: 0, loop_start: 3, loop_end: 7,
+        })])],
+    });
+    const clipApi = new ctx.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    collapseToLoopRegion(clipApi);
+
+    const props = getClipProps(0, 0);
+    assert.equal(props.start_marker, 1, 'untouched when looping=0');
+    assert.equal(props.end_marker, 9, 'untouched when looping=0');
+});

--- a/tests/test_js_bridge.py
+++ b/tests/test_js_bridge.py
@@ -15,6 +15,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 JS_TEST = REPO_ROOT / "tests" / "js_mocks" / "test_preset_resolution.test.js"
 JS_ARRANGEMENT_LOADER_TEST = REPO_ROOT / "tests" / "js_mocks" / "test_arrangement_loader.test.js"
+JS_BOUNCE_TEST = REPO_ROOT / "tests" / "js_mocks" / "test_bounce.test.js"
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
@@ -62,6 +63,28 @@ def test_js_arrangement_loader_suite() -> None:
     if result.returncode != 0:
         pytest.fail(
             "JS arrangement-loader test suite failed\n"
+            f"exit code: {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    assert "pass " in result.stdout, "expected test summary in stdout; got:\n" + result.stdout
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_js_bounce_suite() -> None:
+    """Run the _bounceCropTrack / _collapseToLoopRegion suite and assert exit 0."""
+    assert JS_BOUNCE_TEST.is_file(), f"missing JS test file: {JS_BOUNCE_TEST}"
+
+    result = subprocess.run(
+        ["node", str(JS_BOUNCE_TEST)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "JS bounce test suite failed\n"
             f"exit code: {result.returncode}\n"
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"

--- a/v0/src/m4l-js/stemforge_loader.v0.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.js
@@ -1767,6 +1767,28 @@ function _warpBpmFromMarkers(clipApi) {
     return 0;
 }
 
+// Collapse the play region to the loop region when the clip is looping.
+// `clip.call("crop")` materializes start_marker → end_marker; this preserves
+// the loop region by writing loop_start/loop_end onto start_marker/end_marker
+// before crop, so the bounced WAV contains exactly the loop region.
+//
+// All four properties use the same unit (beats when warping=1, seconds
+// otherwise), so the swap is a 1:1 substitution. Loop bounds equal to play
+// bounds → no-op write but harmless.
+function _collapseToLoopRegion(clipApi) {
+    var looping = 0;
+    try { looping = _getLomNumber(clipApi, "looping") | 0; } catch (_) { return; }
+    if (!looping) return;
+    var ls, le;
+    try {
+        ls = _getLomNumber(clipApi, "loop_start");
+        le = _getLomNumber(clipApi, "loop_end");
+    } catch (_) { return; }
+    if (!isFinite(ls) || !isFinite(le) || le <= ls) return;
+    try { clipApi.set("start_marker", ls); } catch (_) {}
+    try { clipApi.set("end_marker", le); } catch (_) {}
+}
+
 function _bounceCropTrack(letter, onDone) {
     var trackIdx = findTrackByName(letter);
     if (trackIdx < 0) { onDone(false, "no track named " + letter); return; }
@@ -1785,6 +1807,7 @@ function _bounceCropTrack(letter, onDone) {
         try {
             // CAPTURE BEFORE CROP. warp_bpm becomes unreadable post-crop.
             _capturePreCropMeta(clipApi, _preCropKey(letter, "session", sj));
+            _collapseToLoopRegion(clipApi);
             clipApi.call("crop");
             cropped += 1;
         } catch (e) {
@@ -1807,6 +1830,7 @@ function _bounceCropTrack(letter, onDone) {
         if (!aClipApi || aClipApi.id === "0") continue;
         try {
             _capturePreCropMeta(aClipApi, _preCropKey(letter, "arrangement", ai));
+            _collapseToLoopRegion(aClipApi);
             aClipApi.call("crop");
             cropped += 1;
         } catch (e) {

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
@@ -1767,6 +1767,28 @@ function _warpBpmFromMarkers(clipApi) {
     return 0;
 }
 
+// Collapse the play region to the loop region when the clip is looping.
+// `clip.call("crop")` materializes start_marker → end_marker; this preserves
+// the loop region by writing loop_start/loop_end onto start_marker/end_marker
+// before crop, so the bounced WAV contains exactly the loop region.
+//
+// All four properties use the same unit (beats when warping=1, seconds
+// otherwise), so the swap is a 1:1 substitution. Loop bounds equal to play
+// bounds → no-op write but harmless.
+function _collapseToLoopRegion(clipApi) {
+    var looping = 0;
+    try { looping = _getLomNumber(clipApi, "looping") | 0; } catch (_) { return; }
+    if (!looping) return;
+    var ls, le;
+    try {
+        ls = _getLomNumber(clipApi, "loop_start");
+        le = _getLomNumber(clipApi, "loop_end");
+    } catch (_) { return; }
+    if (!isFinite(ls) || !isFinite(le) || le <= ls) return;
+    try { clipApi.set("start_marker", ls); } catch (_) {}
+    try { clipApi.set("end_marker", le); } catch (_) {}
+}
+
 function _bounceCropTrack(letter, onDone) {
     var trackIdx = findTrackByName(letter);
     if (trackIdx < 0) { onDone(false, "no track named " + letter); return; }
@@ -1785,6 +1807,7 @@ function _bounceCropTrack(letter, onDone) {
         try {
             // CAPTURE BEFORE CROP. warp_bpm becomes unreadable post-crop.
             _capturePreCropMeta(clipApi, _preCropKey(letter, "session", sj));
+            _collapseToLoopRegion(clipApi);
             clipApi.call("crop");
             cropped += 1;
         } catch (e) {
@@ -1807,6 +1830,7 @@ function _bounceCropTrack(letter, onDone) {
         if (!aClipApi || aClipApi.id === "0") continue;
         try {
             _capturePreCropMeta(aClipApi, _preCropKey(letter, "arrangement", ai));
+            _collapseToLoopRegion(aClipApi);
             aClipApi.call("crop");
             cropped += 1;
         } catch (e) {


### PR DESCRIPTION
## Summary

- New `_collapseToLoopRegion` helper in `stemforge_loader.v0.js` — when a clip is looping, writes `loop_start`/`loop_end` onto `start_marker`/`end_marker` **before** `clip.call(\"crop\")` so the loop region gets materialized into the bounced WAV.
- 6 JS mock tests cover the happy path (looping=1 + divergent bounds), looping=0 preserved, idempotent same-bounds, and the degenerate-bounds safety guard.
- Wired into pytest via `test_js_bounce_suite` in `tests/test_js_bridge.py` (pytest total: 843 passed).

**Hardware-validated 2026-05-12** on the `breaks-n-beats1.ppak` (46 pads across A=12 / B=12 / C=10 / D=12 with hold-to-play drum profile). One hour of live play, no issues.

Memory: [feedback_loop_region_canonical_for_materialize.md](https://github.com/ZacharySBrown/stemforge) records the implementation pattern.

## Test plan

- [x] `node tests/js_mocks/test_bounce.test.js` → 6/6 pass
- [x] `uv run pytest` → 843 passed, 11 skipped
- [x] Hardware validation: 46-clip deck bounce → COMMIT → deck-from-manifest → build-deck → load on EP-133 → play

🤖 Generated with [Claude Code](https://claude.com/claude-code)