### PR TITLE
docs: README polish + EP-133 workflow guide + CLI reference + spec migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ Three zones, one contract:
 - **M4L** (`m4l/`, `v0/`) — Max for Live devices + JS bridge. Reads `stems.json` manifests; never imports Core code.
 - **Tools** (`tools/`) — Standalone utilities and `sf-remote` (a UDP client for the M4L device). May call Core CLI; doesn't import M4L code.
 
+<details>
+<summary>Mermaid version (renders on GitHub)</summary>
+
+```mermaid
+flowchart LR
+    Audio[audio file] --> Core
+    subgraph Core["Core (stemforge/)"]
+        S[backend.separate] --> Sl[slice] --> Cu[curate] --> M[manifest]
+    end
+    Core -->|stems.json| M4L
+    Core -->|deck.yaml| Tools
+    subgraph M4L["M4L (m4l/, v0/)"]
+        D[Ableton clip auto-load + bounce + COMMIT]
+    end
+    subgraph Tools["Tools (tools/)"]
+        T[sf-remote, batch scripts, exports]
+    end
+    M4L --> Ableton[Ableton session]
+    Tools --> EP133[EP-133 .ppak]
+```
+
+</details>
+
 `stems.json` is the contract between zones. See [`CLAUDE.md`](CLAUDE.md) for the full conventions + agent-role write scopes.
 
 ## TLDR Install

--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
 # StemForge
 
-Stem splitting + beat slicing pipeline for Ableton Live IDM production.
+**StemForge is a stem-split + bar-curate + EP-133 K.O. II kit-builder for Ableton workflows.** Drop in a track, get loop-bank-ready stems and a hardware-ready `.ppak` in one pipeline.
 
-Drop a track in, get stems + beat-sliced WAVs out, auto-loaded into Ableton via Max for Live.
+Two surfaces share one core:
+
+- A Python CLI (`stemforge`) that separates stems via Demucs, slices at beat or bar boundaries, curates diverse loops, and synthesizes EP-133 `.ppak` kits.
+- A Max for Live device that watches Core's manifests and auto-loads clips onto template tracks in Ableton.
+
+## Architecture
+
+```
+              ┌─────────────────────────────────────────────────┐
+   audio →    │  Core (stemforge/)                              │
+              │    backend.separate → slice → curate → manifest │
+              └────────────────┬────────────────────┬───────────┘
+                               │                    │
+                  stems.json   │                    │  deck.yaml
+                               ▼                    ▼
+              ┌──────────────────────────┐  ┌──────────────────┐
+              │ M4L (m4l/)               │  │ Tools (tools/)   │
+              │ Ableton clip auto-load   │  │ sf-remote, batch │
+              │ + bounce + COMMIT        │  │ scripts, exports │
+              └──────────────────────────┘  └──────────────────┘
+                               │                    │
+                               ▼                    ▼
+                         Ableton session       EP-133 .ppak
+```
+
+Three zones, one contract:
+
+- **Core** (`stemforge/`) — CLI, backends, slicer, analyzer, curator, manifest. Zero M4L dependencies.
+- **M4L** (`m4l/`, `v0/`) — Max for Live devices + JS bridge. Reads `stems.json` manifests; never imports Core code.
+- **Tools** (`tools/`) — Standalone utilities and `sf-remote` (a UDP client for the M4L device). May call Core CLI; doesn't import M4L code.
+
+`stems.json` is the contract between zones. See [`CLAUDE.md`](CLAUDE.md) for the full conventions + agent-role write scopes.
 
 ## TLDR Install
 
@@ -70,7 +101,9 @@ stemforge list
 
 ## Pipelines
 
-Pipelines are in `pipelines/default.yaml` — edit to taste. Four presets included:
+Pipelines live in `pipelines/` as YAML, compiled to JSON for the M4L device. Two kinds:
+
+**Processing pipelines** (`pipelines/default.yaml`) — how stems get mixed/effected on auto-load. Four presets:
 
 | Pipeline | Vibe |
 |----------|------|
@@ -79,7 +112,15 @@ Pipelines are in `pipelines/default.yaml` — edit to taste. Four presets includ
 | `glitch` | Granular reverse textures — Four Tet / BoC |
 | `ambient` | Long reverbs, slow modulation — textural IDM |
 
-After editing the YAML, regenerate JSON for the M4L device:
+**Canonical pipelines** — top-level YAMLs that drive the major workflows:
+
+| Pipeline | Use this when... |
+|----------|------------------|
+| `arrangement.yaml` | You're stem-splitting a full song for Ableton arrangement view (drag-in N-bar chunks with padding bars for crossfading). |
+| `curation.yaml` / `curation_nopad*.yaml` | You want exact-bar loop banks (e.g. for EP-133, Launchpad, Push). `_nopad` variants are required for EP-133 export. |
+| `production_idm.yaml` | You want clips auto-loaded onto the 7 StemForge IDM template tracks (drums raw/crushed, bass, textures, vocals, beat-chop). |
+
+After editing any YAML, regenerate JSON for the M4L device:
 ```bash
 stemforge generate-pipeline-json
 ```
@@ -96,6 +137,32 @@ See [setup.md](setup.md) for template track recipes. You build 7 tracks once:
 - SF | Beat Chop Simpler
 
 The M4L device duplicates these per stem and loads audio automatically.
+
+## EP-133 K.O. II Workflow
+
+You can ship a curated multi-source kit straight to an EP-133 K.O. II. The headline flow:
+
+```bash
+# 1. Forge each source track (split + curate bar loops).
+stemforge forge ~/Music/track_01.wav --curation pipelines/curation.yaml
+
+# 2. In Ableton, arrange clips on session tracks A/B/C/D, then hit COMMIT
+#    in the M4L device (or sf-remote fire forge bounceTracks <manifest>).
+#    This bounces + writes curated/manifest.json with a session_tracks block.
+
+# 3. Generate the deck plan from the manifest.
+stemforge deck-from-manifest ~/stemforge/decks/my_kit/curated/manifest.json \
+  --project my_kit --project-slot 8
+
+# 4. (Optional) Override format profile — useful for single-source decks.
+stemforge deck-from-manifest ... --all-drum    # everything as drum pads
+stemforge deck-from-manifest ... --profile vocal   # everything as vocal
+
+# 5. Build the .ppak and drag into K.O. II Sample Tool → import as project.
+stemforge build-deck deck.yaml --out ~/Desktop/my_kit.ppak
+```
+
+End-to-end: ~12 seconds for a 46-clip deck. See [`docs/guides/ep133-workflow.md`](docs/guides/ep133-workflow.md) for the full walkthrough (caveats, format profiles, the 20s per-sample cap, warp-BPM capture).
 
 ## Contributing
 
@@ -131,3 +198,13 @@ For full pre-commit configuration see [`.pre-commit-config.yaml`](.pre-commit-co
 3. **VST param indices** — pipeline YAML uses descriptive names but M4L sets by index. Verify with the Inspect workflow in setup.md.
 4. **Beat slicing is grid-quantized** — uses musical beat positions, not transient onsets. Adjust silence threshold for complex polyrhythms.
 5. **Demucs first run** — downloads ~80MB model to `~/.cache/torch/hub/`. Cached after that.
+6. **EP-133 per-sample 20s cap** — clips longer than 20s are skipped (with warning) by the kit synthesizer. Force a shorter loop region in Ableton before COMMIT.
+
+## Pointers
+
+- **CLI reference** — every `stemforge` and `sf-remote` flag with examples: [`docs/guides/cli-reference.md`](docs/guides/cli-reference.md).
+- **EP-133 workflow guide** — full walkthrough from forge to `.ppak`: [`docs/guides/ep133-workflow.md`](docs/guides/ep133-workflow.md).
+- **M4L device development** — battle-tested pitfalls, container format, deploy pipeline: `memory/m4l_device_development_guide.md` (in your Claude project memory).
+- **EP-133 protocol findings** — `memory/project_ep133_*` entries cover SysEx, coupled fields, binary pad records.
+- **Conventions + agent roles** (for contributors) — [`CLAUDE.md`](CLAUDE.md).
+- **Latest session debrief** — what shipped and why: [`docs/sessions/2026-05-12_breaks_n_beats_complete.md`](docs/sessions/2026-05-12_breaks_n_beats_complete.md).

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -1,0 +1,458 @@
+# CLI Reference
+
+Every command, every flag, with example invocations. Two CLIs:
+
+- **`stemforge`** — the main pipeline (split, curate, build kits, etc.).
+- **`sf-remote`** — UDP client for the StemForge M4L device (log tail, fire messages, dump dicts).
+
+Last verified against the working tree on 2026-05-12. To regenerate this
+doc against current help output, run each subcommand with `--help`.
+
+---
+
+## `stemforge`
+
+```
+Usage: stemforge [OPTIONS] COMMAND [ARGS]...
+```
+
+### `stemforge split`
+
+Split an audio file into stems and slice at beat boundaries.
+
+**Synopsis:** `stemforge split [OPTIONS] AUDIO_FILE`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-m, --model TEXT` | `default` | Demucs model key. Options: `default`, `fine`, `6stem`. |
+| `-p, --pipeline TEXT` | — | Pipeline name from `pipelines/default.yaml` (baked into manifest). |
+| `-o, --output PATH` | `~/stemforge/processed` | Output root directory. |
+| `--no-slice` | off | Skip beat slicing — full stems only. |
+| `--no-normalize` | off | Skip peak normalization of stems before slicing. |
+| `-t, --silence-threshold FLOAT` | `0.001` | RMS threshold below which beat slices are discarded. |
+| `--bpm FLOAT` | (auto) | Manual BPM override. Bypasses auto-detection. |
+| `--first-downbeat FLOAT` | (auto) | Manual first-downbeat-time override (seconds). |
+| `--refine-downbeat` | off | Sub-beat refinement via kick-onset cross-correlation. Opt-in (assumes kick is ON the downbeat). |
+| `--pre-bars INTEGER` | (auto) | Bars of intro material BEFORE bar 1 to include as additional chunks. Pass `0` to drop intro. |
+| `--pad-pre-bars INTEGER` | `1` | Bars of pre-pad inside each chunk WAV (drag-extend headroom backward). |
+| `--pad-post-bars INTEGER` | `1` | Bars of post-pad inside each chunk WAV (drag-extend headroom forward). |
+| `--emit-partial / --no-emit-partial` | `--emit-partial` | Emit leading partial `chunk_001` capturing sub-chunk-period intro. |
+
+**Examples:**
+
+```bash
+stemforge split track.wav                                 # default Demucs
+stemforge split track.wav --model 6stem                   # 6-stem htdemucs_6s
+stemforge split track.wav --pipeline glitch               # use 'glitch' pipeline
+stemforge split track.wav --no-slice                      # full stems only
+stemforge split track.wav --bpm 85.11 --first-downbeat 0.1   # known-good manual
+```
+
+> **Note:** `stemforge split` is missing `--time-sig`; only `forge` has it.
+> See [`docs/issues/split-time-sig-flag.md`](../issues/split-time-sig-flag.md).
+
+---
+
+### `stemforge forge`
+
+Integrated end-to-end forge — split + slice + curate.
+
+**Synopsis:** `stemforge forge [OPTIONS] AUDIO_FILE`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--analysis PATH` | — | Ableton analysis JSON. If omitted, uses librosa beat detection. |
+| `-m, --model TEXT` | `default` | Demucs model key. |
+| `-s, --strategy [max-diversity\|rhythm-taxonomy\|sectional]` | `max-diversity` | Curation strategy. |
+| `-n, --n-bars INTEGER` | — | Number of bars to curate. |
+| `--time-sig TEXT` | `4/4` | Time signature (librosa fallback only). Format: `numerator/denominator`. |
+| `-o, --output PATH` | `~/stemforge/processed` | Output root. |
+| `--curation PATH` | — | Curation config YAML. When provided, delegates bar-slicing + curation to `v0/src/stemforge_curate_bars.py` and produces a production-mode manifest. Omit to use forge's built-in v1 curation path. |
+
+**Examples:**
+
+```bash
+stemforge forge ~/Music/track.wav --curation pipelines/curation.yaml
+stemforge forge ~/Music/track.wav --strategy rhythm-taxonomy -n 16
+stemforge forge ~/Music/track.wav --time-sig 7/4 --bpm 138    # odd meter
+```
+
+---
+
+### `stemforge re-anchor`
+
+Re-cut the prechop chunks of an already-forged track at user-supplied
+BPM + first_downbeat. Skips Demucs re-run.
+
+**Synopsis:** `stemforge re-anchor [OPTIONS] TRACK_DIR`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--bpm FLOAT` | **required** | Manual BPM override. |
+| `--first-downbeat FLOAT` | **required** | Where bar 1 starts in source audio (seconds). |
+| `--pre-bars INTEGER` | (auto) | Bars of intro material BEFORE bar 1 to include. Pass `0` to drop. |
+| `--pad-pre-bars INTEGER` | `1` | Bars of pre-pad inside each chunk WAV. |
+| `--pad-post-bars INTEGER` | `1` | Bars of post-pad inside each chunk WAV. |
+| `--emit-partial / --no-emit-partial` | `--emit-partial` | Emit leading partial `chunk_001`. |
+| `--keep-old` | off | Keep previous prechop output as `<stem>_prechop.bak/`. |
+| `--then-curate / --no-then-curate` | `--no-then-curate` | After re-anchor, run a fresh curation pass. Replays strategy/n_bars from the existing `curated/manifest.json`. |
+
+**Examples:**
+
+```bash
+stemforge re-anchor ~/stemforge/processed/track --bpm 85.11 --first-downbeat 0.1
+stemforge re-anchor ~/stemforge/processed/track --bpm 92 --first-downbeat 0.5 --then-curate
+```
+
+---
+
+### `stemforge reslice-curated`
+
+Re-cut curated bar loops at the current `stems.json` anchor. Preserves user picks.
+
+**Synopsis:** `stemforge reslice-curated [OPTIONS] TRACK_DIR`
+
+No flags. Use after `stemforge re-anchor` if you skipped auto-reslice
+(or pre-PR when re-anchor didn't sync curated/).
+
+For a fresh diversity selection (different picks), run
+`stemforge forge --curation ...` instead.
+
+---
+
+### `stemforge analyze`
+
+Analyze an audio file and recommend optimal stem split settings.
+
+**Synopsis:** `stemforge analyze [OPTIONS] AUDIO_FILE`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--json-out` | off | Output raw JSON instead of formatted table. |
+
+**Examples:**
+
+```bash
+stemforge analyze track.wav
+stemforge analyze track.wav --json-out
+stemforge analyze track.mp3                  # auto-converts to WAV
+```
+
+Requires the `analyzer` extra (`pip install 'stemforge[analyzer]'`).
+
+---
+
+### `stemforge deck-from-manifest`
+
+Generate a starter deck plan from a curated manifest.
+
+**Synopsis:** `stemforge deck-from-manifest [OPTIONS] MANIFEST_PATH`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--out PATH` | `deck.yaml` next to manifest | Where to write the deck plan. |
+| `--project TEXT` | (derived) | Project name. Default: derived from manifest filename / dir. |
+| `--project-slot INTEGER` | `8` | EP-133 project slot (1..9). |
+| `--project-bpm FLOAT` | (from manifest) | Project BPM. Default: manifest's `bpm` field, fallback `92`. |
+| `--format [yaml\|json]` | `yaml` | Output format. |
+| `--edit-after / --no-edit-after` | `--no-edit-after` | Open generated plan in `$EDITOR`. |
+| `--profile [vocal\|drum\|texture\|preserve_source]` | (per-group default) | Override format_profile on every group. |
+| `--all-drum` | off | Shortcut for `--profile drum`. Mutually exclusive with `--profile`. |
+| `--play-mode [oneshot\|key\|loop]` | (per-profile default) | Override play_mode on every pad row. |
+
+**Examples:**
+
+```bash
+stemforge deck-from-manifest ~/stemforge/processed/track/curated/manifest.json
+stemforge deck-from-manifest <manifest> --project my_kit --project-slot 8
+stemforge deck-from-manifest <manifest> --all-drum                    # all drum profile
+stemforge deck-from-manifest <manifest> --profile vocal --play-mode key
+```
+
+---
+
+### `stemforge build-deck`
+
+Build a multi-source EP-133 kit (`.ppak`) from a deck plan.
+
+**Synopsis:** `stemforge build-deck [OPTIONS] DECK_PLAN`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--out PATH` | **required** | Output `.ppak` path. |
+| `--reference-template PATH` | — | Captured reference `.ppak` for byte-template fields. |
+| `--project INTEGER` | (from plan) | Override project slot (1..9). |
+| `--write-spec / --no-write-spec` | `--write-spec` | Also write abstract `ProjectSpec` JSON next to the `.ppak`. |
+
+**Examples:**
+
+```bash
+stemforge build-deck deck.yaml --out ~/Desktop/my_kit.ppak
+stemforge build-deck deck.json --out kit.ppak \
+  --reference-template tests/ep133/fixtures/reference.ppak
+```
+
+---
+
+### `stemforge export-song`
+
+Build an EP-133 K.O. II song-mode `.ppak` from an Ableton arrangement snapshot.
+
+**Synopsis:** `stemforge export-song [OPTIONS]`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--arrangement PATH` | **required** | `snapshot.json` from M4L arrangement reader. |
+| `--manifest PATH` | **required** | `stems.json` with a `session_tracks` block. |
+| `--reference-template PATH` | — | Captured reference `.ppak` for byte template. |
+| `--project INTEGER` | `1` | EP-133 project slot (1..9). |
+| `--out PATH` | **required** | Output `.ppak` path. |
+| `--mode [locator]` | `locator` | Scene-derivation mode. v1 only supports `locator`. |
+| `--write-spec / --no-write-spec` | `--write-spec` | Also write ProjectSpec JSON sidecar. |
+
+**Example:**
+
+```bash
+stemforge export-song \
+  --arrangement snapshot.json \
+  --manifest stems.json \
+  --reference-template tests/ep133/fixtures/reference.ppak \
+  --project 1 --out song.ppak
+```
+
+---
+
+### `stemforge export`
+
+Export stems/slices for hardware samplers. Supports EP-133 and Chompi targets.
+
+**Synopsis:** `stemforge export [OPTIONS] [INPUT_PATH]`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-t, --target [ep133\|chompi\|both]` | **required** | Target device. |
+| `-w, --workflow [compose\|perform]` | — | `compose`=single track deep; `perform`=multi-track curated. |
+| `-o, --output PATH` | — | Output directory. |
+| `--budget` | off | EP-133: render at 22050 Hz to double memory capacity. |
+| `--firmware [tempo\|tape]` | — | Chompi firmware variant. |
+| `--dry-run` | off | Show plan without writing files. |
+| `--upload` | off | EP-133: upload samples via USB-MIDI SysEx after export. |
+| `--start-slot INTEGER` | `1` | EP-133: starting sound slot for upload. |
+| `--manifest PATH` | — | EP-133 v2: manifest-driven export. Loads a curated `manifest.json` and produces per-loop WAVs + `SETUP.md`. |
+| `--config PATH` | — | EP-133 v2: curation config YAML. Reads `ep133_export:` block. Pairs with `--manifest`. |
+
+**Examples:**
+
+```bash
+stemforge export track_dir/ --target ep133 --workflow compose
+stemforge export processed/ --target chompi --workflow perform
+stemforge export --target ep133 --manifest curated/manifest.json \
+  --config pipelines/curation.yaml --output export/ep133/
+```
+
+> **Note:** for full deck-builder workflows prefer
+> `deck-from-manifest` + `build-deck`. `export --target ep133` is the older
+> per-slot direct-upload path.
+
+---
+
+### `stemforge export-koala`
+
+Export a curated stemforge project as a Koala Sampler bank set (`.zip`).
+
+**Synopsis:** `stemforge export-koala [OPTIONS] PROJECT_DIR`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--loops-per-stem INTEGER` | `4` | Loops per stem in bank 1 (4 stems × N must be ≤ 16). |
+| `--oneshots-per-part INTEGER` | (auto-fill) | Cap oneshots per drum part. |
+| `--output-dir DIRECTORY` | `koala_exports` | Where to write the `.zip`. |
+| `--keep-unzipped` | off | Leave staging folder next to the zip (debugging). |
+
+**Examples:**
+
+```bash
+stemforge export-koala ~/stemforge/processed/bel
+stemforge export-koala ~/stemforge/processed/bel/curated --loops-per-stem 3
+```
+
+---
+
+### `stemforge clean-beats`
+
+Delete silent beat slices from processed folders.
+
+**Synopsis:** `stemforge clean-beats [OPTIONS]`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-t, --threshold FLOAT` | `0.001` | RMS threshold. Beats below this are deleted. |
+| `-d, --dir PATH` | `~/stemforge/processed` | Directory to clean. |
+| `--dry-run` | off | Show what would be deleted without deleting. |
+
+**Examples:**
+
+```bash
+stemforge clean-beats --dry-run
+stemforge clean-beats --threshold 0.002 --dir ~/stemforge/processed
+```
+
+---
+
+### `stemforge create-templates`
+
+Build the 7 StemForge template tracks in Ableton Live.
+
+**Synopsis:** `stemforge create-templates [OPTIONS]`
+
+No flags. If AbletonOSC is running, sends a trigger to the M4L builder
+device. Otherwise prints step-by-step instructions.
+
+---
+
+### `stemforge generate-pipeline-json`
+
+Compile YAML → JSON for M4L device. Processes both `pipelines/` and `presets/`.
+
+**Synopsis:** `stemforge generate-pipeline-json [OPTIONS]`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--pipeline-dir PATH` | `pipelines/` | Source directory. |
+
+**Example:** run after editing any pipeline YAML.
+
+```bash
+stemforge generate-pipeline-json
+```
+
+---
+
+### `stemforge list`
+
+Show available Demucs models.
+
+**Synopsis:** `stemforge list`
+
+No flags.
+
+---
+
+## `sf-remote`
+
+Headless remote debug client for the StemForge M4L device. Talks UDP on
+port 7420 (device) / 7421 (dump return).
+
+```
+Usage: sf-remote [-h] {log, fire, dump, setstate, status} ...
+```
+
+### `sf-remote log`
+
+Tail or clear the device's debug log.
+
+**Synopsis:** `sf-remote log [-h] [--follow] [--clear]`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--follow, -f` | off | Follow new log lines (like `tail -f`). |
+| `--clear` | off | Truncate the log locally AND send `clear` via UDP to `sf_logger`. |
+
+**Examples:**
+
+```bash
+sf-remote log -f               # tail
+sf-remote log --clear          # truncate locally + remote
+```
+
+---
+
+### `sf-remote fire`
+
+Send a UDP message to a module inside the device.
+
+**Synopsis:** `sf-remote fire TARGET MESSAGE...`
+
+Targets: `state`, `forge`, `preset-loader`, `manifest-loader`, `settings`,
+`ui`, `logger`.
+
+**Examples:**
+
+```bash
+sf-remote fire forge bounceTracks /path/to/curated/manifest.json
+sf-remote fire state markStemDone bass
+sf-remote fire ui setMode forging
+sf-remote fire logger clear
+```
+
+---
+
+### `sf-remote dump`
+
+Dump a Max `dict` into the log and print the captured block.
+
+**Synopsis:** `sf-remote dump DICTNAME [--timeout SECONDS]`
+
+Dict names: `sf_state`, `sf_preset`, `sf_manifest`, `sf_settings`.
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--timeout SECONDS` | `3` | Seconds to wait for `DUMP END` marker. |
+
+**Example:**
+
+```bash
+sf-remote dump sf_state
+sf-remote dump sf_manifest --timeout 5
+```
+
+---
+
+### `sf-remote setstate`
+
+Push `sf_state` JSON into the v8ui.
+
+**Synopsis:** `sf-remote setstate TARGET`
+
+`TARGET` is either a shortcut (`empty`, `idle`, `forging`, `done`, `error`)
+or a path to a `.json` file.
+
+**Examples:**
+
+```bash
+sf-remote setstate idle
+sf-remote setstate ./test-states/forging-with-progress.json
+```
+
+---
+
+### `sf-remote status`
+
+Print last N log lines + dump `sf_state`.
+
+**Synopsis:** `sf-remote status [--lines N]`
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--lines, -n` | `60` | How many log lines to print. |
+
+**Example:**
+
+```bash
+sf-remote status -n 100
+```
+
+---
+
+## Install variants
+
+| Command | Includes | Use when |
+|---------|----------|----------|
+| `pip install 'stemforge[native]'` | Core + torch + demucs | Standard install — local Demucs stem separation. |
+| `pip install 'stemforge[analyzer]'` | Core + transformers + CLAP | You want `stemforge analyze` (genre / instrument detection). |
+| `pip install 'stemforge[native,analyzer]'` | Core + native + analyzer | Local Demucs and analyzer. |
+| `pip install 'stemforge[native,analyzer,dev]'` | Everything + test/lint/build tooling | Developing on StemForge. |
+
+Running `stemforge split` without the `native` extra prints a friendly
+error pointing you at the right install command. Same for `stemforge
+analyze` without the `analyzer` extra.

--- a/docs/guides/ep133-workflow.md
+++ b/docs/guides/ep133-workflow.md
@@ -48,6 +48,18 @@ and the `project_ep133_*` entries in your Claude project memory.
             └────────────────────────────────────────────────────────┘
 ```
 
+Or as Mermaid (renders on GitHub):
+
+```mermaid
+flowchart TD
+    A[audio file] -->|stemforge forge --curation| B[curated/ + manifest.json]
+    B -->|Ableton: arrange clips on A/B/C/D| C[Session view]
+    C -->|COMMIT in M4L device| D[manifest.json with session_tracks]
+    D -->|stemforge deck-from-manifest| E[deck.yaml]
+    E -->|stemforge build-deck| F[kit.ppak + .projectspec.json]
+    F -->|drag into K.O. II Sample Tool| G[Project on device slot]
+```
+
 End-to-end timing for a 46-clip deck: ~12 seconds for the bounce + plan
 + build phases. Sample Tool import takes another 10–20 seconds depending
 on payload size.

--- a/docs/guides/ep133-workflow.md
+++ b/docs/guides/ep133-workflow.md
@@ -1,0 +1,216 @@
+# EP-133 K.O. II Workflow
+
+How to take one or more audio tracks from a raw `.wav` to a hardware-ready
+`.ppak` kit on the Teenage Engineering EP-133 K.O. II.
+
+This is the user-facing guide. For the technical depth (LOM quirks,
+SysEx protocol findings, byte-level pad records), see the
+[session debrief](../sessions/2026-05-12_breaks_n_beats_complete.md)
+and the `project_ep133_*` entries in your Claude project memory.
+
+## What you need
+
+- **Ableton Live 12** with the StemForge `.als` template loaded
+  ([setup.md](../../setup.md) walks the 7-track build).
+- **StemForge M4L device** installed (the installer drops it into the
+  StemForge Max Package under `~/Documents/Max 9/Packages/StemForge/`).
+- **EP-133 K.O. II** hardware on OS 2.0.5 or later, connected over USB-MIDI.
+- **K.O. II Sample Tool** (Teenage Engineering's desktop import app).
+- StemForge installed with the `native` extra (`pip install 'stemforge[native]'`)
+  so Demucs is available.
+
+## The headline flow
+
+```
+            ┌────────────────────────────────────────────────────────┐
+   audio →  │ stemforge forge <track> --curation pipelines/curation  │
+            │   → stems + curated/ + curated/manifest.json           │
+            └─────────────────────────┬──────────────────────────────┘
+                                      │
+                  (Ableton: drag clips, arrange on tracks A/B/C/D)
+                                      │
+            ┌─────────────────────────▼──────────────────────────────┐
+   COMMIT → │ M4L device → bounce + collapse + commit                │
+            │   → curated/manifest.json with session_tracks block    │
+            └─────────────────────────┬──────────────────────────────┘
+                                      │
+            ┌─────────────────────────▼──────────────────────────────┐
+   plan →   │ stemforge deck-from-manifest <manifest>                │
+            │   → deck.yaml                                          │
+            └─────────────────────────┬──────────────────────────────┘
+                                      │
+            ┌─────────────────────────▼──────────────────────────────┐
+   build →  │ stemforge build-deck deck.yaml --out kit.ppak          │
+            └─────────────────────────┬──────────────────────────────┘
+                                      │
+            ┌─────────────────────────▼──────────────────────────────┐
+   import → │ K.O. II Sample Tool → import as project → slot 8       │
+            └────────────────────────────────────────────────────────┘
+```
+
+End-to-end timing for a 46-clip deck: ~12 seconds for the bounce + plan
++ build phases. Sample Tool import takes another 10–20 seconds depending
+on payload size.
+
+## Step-by-step
+
+### 1. Forge each source track
+
+```bash
+stemforge forge ~/Music/track_01.wav --curation pipelines/curation.yaml
+# … repeat per source track
+```
+
+Each `forge` run produces `~/stemforge/processed/<slug>/curated/manifest.json`
+plus per-stem `bar_NNN.wav` files. Use `pipelines/curation_nopad.yaml` or one
+of its `*_perf`, `*_phrase2`, `*_section`, `*_session_drums4` variants —
+they're tuned for hardware export (`trim_pad.bars = 0` so the curated WAVs
+are exact-bar slices, not padded chunks).
+
+### 2. Arrange in Ableton
+
+Open the StemForge `.als` template. The forge device's manifest dropdown
+picks up your new processed tracks automatically (sorted alphabetically).
+Drag clips into session view, layout them on tracks **A, B, C, D**
+(up to 12 per track — that's the EP-133's group capacity).
+
+### 3. COMMIT
+
+Either hit the COMMIT button in the M4L device, or fire it via:
+
+```bash
+uv run sf-remote fire forge bounceTracks \
+  ~/stemforge/processed/<slug>/curated/manifest.json
+```
+
+The device walks tracks A/B/C/D, bounces each clip with the loop region
+baked in (via `_collapseToLoopRegion`), captures `warp_bpm` from
+`warp_markers` slope, and writes a `session_tracks` block back into the
+manifest.
+
+### 4. Generate the deck plan
+
+```bash
+stemforge deck-from-manifest \
+  ~/stemforge/processed/<slug>/curated/manifest.json \
+  --project my_kit \
+  --project-slot 8 \
+  --out deck.yaml
+```
+
+This emits a `deck.yaml` mapping every committed clip to EP-133 group
+A/B/C/D pads 1..12.
+
+#### Format profile use cases
+
+The default layout is `A=vocal, B=vocal, C=drum, D=texture` — appropriate
+for a verse-swap deck with one drum row. Override when your kit is more
+uniform:
+
+| Flag | Use case |
+|------|----------|
+| `--profile drum` or `--all-drum` | Single-source breakbeats kit (e.g. just chopped Funky Drummer variants). All pads get drum-profile envelopes (`envelope.release=15`, `key` play-mode). |
+| `--profile vocal` | All-vocal kit (acapella stack, ad-libs). One-shot key-trigger. |
+| `--profile texture` | Pads, drones, foley. Long release; one-shot. |
+| `--profile preserve_source` | Keep whatever was in the manifest's per-clip metadata (useful when you've hand-tagged clips upstream). |
+| `--play-mode oneshot\|key\|loop` | Override play mode on every pad row, independent of profile. |
+
+After generation, edit `deck.yaml` directly if you need finer per-pad
+control (e.g. swap two pads, override BPM for a single clip).
+
+### 5. Build + import
+
+```bash
+stemforge build-deck deck.yaml --out ~/Desktop/my_kit.ppak
+```
+
+Output is a `.ppak` plus a sidecar `.projectspec.json` (the abstract
+ProjectSpec dump — useful for diffing arrangement → projection during
+debugging).
+
+Drag the `.ppak` into K.O. II Sample Tool, choose "import as project",
+pick a project slot (1..9), wait for upload. Drag the project from the
+device's project list onto your active session and you're done.
+
+## Caveats — things you can hit, and what to do
+
+### Per-sample 20-second cap
+
+The EP-133 Sample Tool breaks partway when a sample exceeds 20s.
+`build-deck` skips oversize clips with a warning rather than truncating.
+Fix: shorten the loop region in Ableton (the loop region is what gets
+materialized — see "loop-region collapse" below) and re-COMMIT.
+
+Memory: `feedback_ep133_per_sample_cap_20s.md`.
+
+### warp_bpm capture
+
+`clip.call("crop")` renders at the clip's warp BPM, **not** the project
+BPM. The bounce flow captures `warp_bpm` from `warp_markers` slope
+*before* calling crop, then tags it into the bounced WAV (TNGE chunk)
+and the per-pad record (bytes 12–15 as float32). If you've ever wondered
+why a bounced clip plays at the right tempo on the device even when the
+project BPM disagrees with the source BPM — this is why.
+
+If a clip is unwarped, the kit synthesizer falls back to bar-count
+inference (snapping duration to `{0.25, 0.5, 1, 2, 3, 4, 8}` bars).
+5/6/7-bar candidates are explicitly excluded — they steal scoring
+wins from real 4-bar interpretations.
+
+Memory: `feedback_clip_crop_renders_at_warp_bpm.md`,
+`feedback_bar_inference_candidates.md`.
+
+### Loop-region collapse semantics
+
+If you set a loop region in Ableton, **that's what gets bounced** — not
+the full clip start→end. `_collapseToLoopRegion` writes
+`loop_start`/`loop_end` onto `start_marker`/`end_marker` before crop, so
+the loop region is materialized into the bounced WAV.
+
+Practical implication: dial in your loop region first, then COMMIT. The
+clip's start/end markers can stay wide; loop bounds win.
+
+### Coupled fields on the device
+
+`playmode` and `envelope.release` must be written as a pair. The on-device
+UI handles this atomically, but naive SysEx writes drop the coupling and
+gate behavior fails silently. `build-deck` always writes pairs — but if
+you're writing your own pad records via raw SysEx, beware.
+
+Memory: `feedback_ep133_coupled_fields.md`,
+`feedback_ep133_emit_vs_accept.md` (strings vs ints).
+
+### `.ppak` import vs user-paks
+
+Sample Tool's "import as project" only accepts `.ppak` files with
+`pak_type = "project"`. `build-deck` sets this correctly. The older
+`"user"` pak format will be silently rejected (or fail partway).
+
+Memory: `feedback_ppak_writer_pak_type_default.md`.
+
+### BPM auto-detection on odd-meter / extreme-tempo material
+
+`stemforge forge` uses beat-this:drums (preferred) with a librosa
+fallback. It misses on:
+
+- **Doubled BPM** on krautrock-style steady pulses (e.g. detected 282,
+  real 141).
+- **Halved BPM** on slow ballads (e.g. detected 66, real 132).
+- **7/4 or other odd meters** — the 4/4 grid bias confuses both detectors.
+
+Fix: pass `--bpm` directly on `stemforge forge`, or use `stemforge re-anchor`
+after the fact. `--time-sig` is `forge`-only today; `stemforge split` is
+missing the flag (tracked at [`docs/issues/split-time-sig-flag.md`](../issues/split-time-sig-flag.md)).
+
+## Pointers
+
+- **Session debrief** (technical depth, file-level changes):
+  [`docs/sessions/2026-05-12_breaks_n_beats_complete.md`](../sessions/2026-05-12_breaks_n_beats_complete.md)
+- **CLI reference** (every `stemforge` and `sf-remote` flag):
+  [`docs/guides/cli-reference.md`](cli-reference.md)
+- **EP-133 protocol findings** (in Claude project memory):
+  - `project_ep133_sysex_upload.md`
+  - `project_ep133_protocol_findings.md`
+  - `project_ep133_pad_record_correct.md`
+  - `project_ep133_binary_pad_record.md`
+- **M4L device development**: `memory/m4l_device_development_guide.md`


### PR DESCRIPTION
## Summary

Phase 3 documentation polish pass. Doc-only — no code touched.

- **README.md** — adds elevator pitch (StemForge as stem-split + bar-curate + EP-133 kit-builder), 3-zone architecture diagram (ASCII + Mermaid collapsible), pipeline catalog distinguishing processing pipelines from canonical workflow pipelines, EP-133 K.O. II workflow section, Pointers section, and one new Known Limitation (20s per-sample cap). Phase 1's Contributing section preserved verbatim. Grew from 133 to ~210 lines.
- **docs/guides/ep133-workflow.md** (new) — user-facing walkthrough of the EP-133 deck pipeline. What you need, the 5-step flow (ASCII + Mermaid), `deck-from-manifest --profile` use cases, caveats (20s cap, warp_bpm capture, loop-region collapse, coupled fields, ppak pak_type, BPM-detection edge cases) — each with a "what to do" remediation. ~230 lines.
- **docs/guides/cli-reference.md** (new) — hand-curated reference for all 14 `stemforge` subcommands and all 5 `sf-remote` subcommands. Per-flag tables with defaults and 1-2 examples each. Includes the Phase 1 additions on `deck-from-manifest` (`--profile`, `--all-drum`, `--play-mode`). ~458 lines.
- **Mermaid diagrams** — added alongside existing ASCII for the 3-zone architecture (README) and EP-133 flow (workflow guide). One source of truth, two renderings.

## What is NOT in this PR

- **Spec migration (Task 4)**: the 3 files the brief asked to move (`specs/ep133_morning_briefing_2026-04-26.md`, `specs/ep133_session_handoff_2026-04-25_eod.md`, `specs/tlw_rebounce_handoff_2026-04-26.md`) do not exist as tracked files on `integration/handoff-2026-05-12`. They appear in the user's working tree as untracked items but aren't part of the worktree base. No `git mv` is possible. Two tracked candidates with similar names exist (`ep133_session_handoff_2026-04-24_eod.md`, `ep133_session_state_2026-04-24.md`) — I left them alone since the brief was specific. Recommend a follow-up PR if those tracked files should also migrate to `docs/sessions/`.

## Memory hygiene (Task 6) — done outside this branch

Memory files live in `~/.claude/projects/-Users-zak-zacharysbrown-stemforge/memory/` (per-user, not in repo). Retired 4 clearly-obsolete entries:

- `project_ui_v2_debug_state.md` — 18-day-old EOS snapshot; UI v2 has shipped through ~30 commits since.
- `project_bounce_v1_state.md` — 16-day-old "awaiting user OK to commit" note; the fix shipped via PR #62 and Phase 1 hardening landed the atomic-rename followup.
- `project_session_handoff_2026_04_24.md` — 17-day-old handoff; canonical handoffs live in `docs/sessions/` now.
- `project_ep133_playwright_state.md` — workflow superseded by SysEx per the entry's own description.

`MEMORY.md` index trimmed from 67 to 63 entries. Two flagged entries left untouched because they're still actionable:

- `project_curation_library_v2_state.md` — recommends retire-branch action that hasn't happened yet.
- `feedback_canonical_tempos_full_suite_env.md` — 3 days old; the full-suite flake it warns about still reproduces locally.

## Test plan

- [x] `uv run pytest -q -k "not canonical_tempos" --ignore=tests/test_canonical_tempos.py` — 834 passed, 10 skipped.
- [x] `git diff --name-only` shows only docs touched (README.md + 2 new files under `docs/guides/`).
- [x] Phase 1 Contributing section grep-verified intact in final README.
- [ ] Spot-check Mermaid renders on GitHub PR view.

PR target is `integration/handoff-2026-05-12`, not `main`.