### PR TITLE
docs(curation-library): cherry-pick song-form specs + exec-plan + recipes from stale router branch

### DIFF
--- a/docs/exec-plans/curation-library-device-changes.md
+++ b/docs/exec-plans/curation-library-device-changes.md
@@ -1,0 +1,128 @@
+# Device-side changes for curation library — exec plan
+
+Three device-touching changes follow the curation-router work landing on
+`feat/curation-library-v2`. None are written yet. **This doc is review-
+gate** — once you sign off on a change set, we cut a focused branch and
+follow the standard pipeline (debug patch in standalone Max → build_amxd.py →
+build-pkg.sh → install). Per the Test & Deploy Discipline memory, no manual
+.amxd copies, no skipped steps.
+
+## Change 1 — Export-vs-distribute toggle (smallest, do first)
+
+**What it does:** UI control on the device that picks one of three modes:
+
+| Mode | Behavior |
+|---|---|
+| `export only` (default) | Bounce writes to `~/stemforge/exports/<song>/`. Library untouched. |
+| `distribute only` | Bounce writes to a tmp dir, then router relocates everything into `~/mus/Samples/`, then tmp dir is cleaned up. |
+| `export and distribute` | Bounce writes to `~/stemforge/exports/<song>/` AND router copies into `~/mus/Samples/`. (Default after first use, probably.) |
+
+**Where it lives:**
+- `sf_clip_export.js` (in BOTH `v0/src/m4l-js/` and `v0/src/m4l-package/StemForge/javascript/` — JS dual-location sync)
+- The bounce spec (`spec.json` written by sf_clip_export.js → consumed by `tools/m4l_export_clips.py`) gains a new field:
+  ```
+  "post_action": "export_only" | "distribute_only" | "export_and_distribute",
+  "library_root": "/Users/zak/mus"     # only present when post_action != export_only
+  ```
+- After the bouncer finishes, sf_clip_export.js issues a second `[shell]` call:
+  ```
+  uv run stemforge route <export_dir> --library <library_root>
+  ```
+  (Or, in `distribute_only` mode, runs route then deletes the temp dir.)
+
+**Risk assessment:**
+- **Low** for the JS UI control — adding one umenu/dropdown to the bounce panel.
+- **Low** for the spec.json schema additions — bouncer ignores unknown fields.
+- **Low** for the second shell call — independent of bounce, errors don't cascade.
+- **Medium** for the dual-location sync discipline — easy to forget to copy JS into both `v0/src/m4l-js/` and `v0/src/m4l-package/`. Will run the existing build-pkg.sh which copies for us.
+
+**Configurability question** (your earlier ask): the export dir path
+(`~/stemforge/exports/`) becomes a device-level setting too, in case you
+later want it inside `~/mus/Exports/` to consolidate everything in `~/mus/`.
+Default stays at `~/stemforge/exports/`.
+
+## Change 2 — Raw-stem loader target type (medium)
+
+**What it does:** Adds a new `target.type === "stem"` (or `"raw_stem"`)
+handler in `stemforge_loader.v0.js`. When the preset says
+`{ "type": "stem" }`, the loader skips curation entirely and loads the
+full stem WAV onto a single track, in clip slot 1.
+
+**Why this matters:** unblocks the *real* `stems_only.json` preset (drop
+each main stem on its own track, no slicing) AND the
+`drums_only_split.json` preset (one track per LarsNet sub-stem). Today's
+`stems_only.json` is a workaround that drops one curated 8-bar phrase per
+stem because there's no raw-stem path.
+
+**What changes:**
+- `v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js` —
+  add a third branch alongside `target.type === "clips"` and `"rack"`:
+  ```javascript
+  } else if (target.type === "stem") {
+      var stemWavPath = manifest.stems[stemName].wav_path;
+      if (!stemWavPath) { status("    skipped (no stem wav)"); continue; }
+      var trackIdx = trackCount();
+      createAudioTrack(trackIdx);
+      renameTrack(trackIdx, targetName + " | " + songName, targetColor);
+      if (chain.length > 0) applyInsertChain(trackIdx, chain);
+      loadClipToTrack(trackIdx, stemWavPath, /*slotIdx*/ 0);
+      loaded += 1;
+  }
+  ```
+- `stems_only.json` — change all 4 targets from `"type": "clips"` to
+  `"type": "stem"`, drop the curation params.
+- `drums_only_split.json` — new preset with 6 stem-type tracks (drums +
+  kick/snare/hat/toms/cymbals via sub-stem refs, see Change 3) on top of
+  the existing 6 curated drum tracks.
+
+**Risk assessment:**
+- **Medium**. Touches the core loader's main switch. New code path = new
+  failure mode. Mitigation: small, isolated branch, debug in standalone
+  Max with the existing harness, add a debug-bang test before deploying
+  via build-pkg.sh.
+- The loader memory ("M4L Device Development Guide" — 20 pitfalls) is
+  the required reading before this branch. Especially the [shell]+[js]
+  architecture and the build_amxd.py → build-pkg.sh discipline.
+
+## Change 3 — Sub-stem paths in manifest (small, blocks Change 2 for sub-stems)
+
+**What it does:** When LarsNet runs (today, only as part of one-shot
+extraction in `stemforge/oneshot.py`), persist the sub-stem WAV paths
+into `stems.json` so the loader can find them.
+
+**What changes:**
+- `stemforge/manifest.py` — extend `StemInfo` with optional
+  `sub_stems: dict[str, str]` field (e.g. `{"kick": "/path/to/kick.wav", ...}`)
+- `stemforge/oneshot.py` — after `separate_drums()` returns the sub-stem
+  paths, surface them up to the manifest writer.
+- `stemforge_loader.v0.js` — when `target.params.source_substem === "kick"`
+  is set on a `"stem"`-type target, look up `stem.sub_stems[<key>]` instead
+  of `stem.wav_path`.
+
+**Risk assessment:**
+- **Low** for the manifest schema (additive field, ignored by old readers).
+- **Low** for oneshot.py (we already have the paths, just plumbing).
+- **Low** for the loader change once Change 2 is in (it's an extension of
+  the new `"stem"` branch).
+
+## Recommended order
+
+1. **Change 1** first — small, reversible, immediately useful. Land it,
+   use it for a couple of bounces, build confidence in the JS shell-call
+   pattern before touching the loader.
+2. **Change 3** second — pure pipeline change, no device behavior change
+   yet. Sub-stem paths show up in manifests.
+3. **Change 2** last — the loader extension. By this point we have JS
+   call patterns proven (Change 1) and sub-stem paths available (Change 3),
+   so the loader change can do everything in one branch.
+
+## Things I'm explicitly NOT doing without your sign-off
+
+- Touching `stemforge_loader.v0.js`
+- Touching `sf_clip_export.js`
+- Modifying the .amxd
+- Running build-pkg.sh or installing a new package
+- Changing the manifest writer in `stemforge/manifest.py`
+
+Sign off per change number (e.g. "Change 1 yes, Change 2 hold") and I'll
+cut a focused branch off this one for whichever you want to start.

--- a/docs/song-forms/README.md
+++ b/docs/song-forms/README.md
@@ -1,0 +1,51 @@
+# Song-Form Templates
+
+Five Ableton Live `.als` templates for guided song-idea sketching. Each
+defines: target tempo, total length, locator placements (Ableton arrangement
+markers), recommended sample-set inputs, and a starter processing chain.
+
+The templates themselves are `.als` files the user builds in Ableton; this
+directory holds the **specs** — bar-counts, locator labels, instrument and
+chain recommendations — so the templates can be rebuilt or migrated
+deterministically.
+
+| Form | Genre | BPM | Bars |
+|---|---|---|---|
+| [`ambient_long_form`](ambient_long_form.md) | Ambient | 60–80 | 128 |
+| [`lofi_aaba`](lofi_aaba.md) | Lo-fi hip hop | 80–95 | 84 |
+| [`idm_squarepusher`](idm_squarepusher.md) | Glitch IDM | 140–170 | 80 |
+| [`idm_fourtet_evolve`](idm_fourtet_evolve.md) | Slow-burn IDM | 110–130 | 96 |
+| [`big_beat_drop`](big_beat_drop.md) | Big Beat | 120–140 | 128 |
+
+## Workflow these templates support
+
+1. **Pick the form** that matches the mood/energy you want.
+2. **Open the template** — `.als` already has tempo, locators, track lanes,
+   and processing chains laid out.
+3. **Drop in 4–5 sample sets** — typically curated runs from the StemForge
+   library at `~/mus/Samples/`, dragged into the designated palette tracks.
+4. **Sketch by section** — the locators force you to make A different from B
+   different from BREAK before you've over-committed to a single loop.
+5. **Bounce / commit** when a section feels right.
+
+The intent: escape "one-loop mentality" by surfacing structural variety up
+front. Empty named sections in the timeline are a stronger arrangement
+prompt than a blank canvas.
+
+## Conventions used in the per-form specs
+
+- **Locator names** become arrangement-view markers in Live (set via the
+  Insert Locator menu, or the `+` icon in the arrangement toolbar)
+- **Tempo range** is the genre's typical span; pick one and commit
+- **Track recommendations** name the *role* (e.g. "drum loops", "bass mono")
+  not specific Live devices — see `chains.md` per form for actual devices
+- **Sample-set slots** name how many palette tracks to dedicate to dragged-in
+  curation outputs
+
+## Related
+
+- `~/mus/Samples/` — StemForge library where curated palettes live
+- `~/mus/Templates/` — where the actual `.als` files should live, named to
+  match the slugs above (e.g. `ambient_long_form Project/`)
+- `stemforge/router.py` — the curation router that distributes outputs
+  into the library these templates pull from

--- a/docs/song-forms/ambient_long_form.md
+++ b/docs/song-forms/ambient_long_form.md
@@ -1,0 +1,57 @@
+# `ambient_long_form` — Ambient (Eno / Hecker / Basinski)
+
+Long-form, no hard transitions. The "form" is *which layers are present
+when* — locators mark layer entries, not section changes.
+
+## Tempo & length
+
+- **BPM:** 60–80 (recommended start: 70 — slow enough for evolution, fast
+  enough that 128 bars is ~7.3 min)
+- **Total bars:** 128 (≈ 7 min at 70 BPM)
+- **Time signature:** 4/4 (or 6/8 if you want lilt)
+
+## Locators (layer-entry markers, not section breaks)
+
+| Bar | Name | What enters |
+|---:|---|---|
+|   1 | `BED`     | drone bed only — long pad or field recording |
+|  33 | `LAYER1`  | second textural element (granular, choir, broken radio) |
+|  65 | `LAYER2`  | melodic motif (sparse, repeating) — first hint of pulse |
+|  97 | `DECAY`   | strip back to BED + tail; let reverbs ring out |
+
+## Tracks
+
+1. **Drone Bed** — Wavetable pad on a long sustained note, *or* a sampled
+   pad/choir loop with cross-fades to mask repetition
+2. **Granular Texture 1** — Granulator II on a found-sound source
+3. **Granular Texture 2** — second Granulator II, different source, panned opposite
+4. **Field Recording** — looped environmental audio (rain, street, room)
+5. **Melodic Motif** — sparse single-note sample on Simpler, triggered slowly
+6. **Bass Drone Sub** — optional 60–80 Hz sine, very low level
+7. **Convolution Reverb Send** — long IR (10–15 s tail)
+8. **Delay/Spectral Send** — Spectral Resonator or long Echo
+
+## Starter chains
+
+- **Pad / Drone:** Hybrid Reverb (large hall, 100% wet on send) → Auto Filter
+  with very slow LFO (0.05 Hz, full sweep) → Saturator (subtle warmth)
+- **Granular textures:** Spectral Resonator → Erosion (high-pass noise mode)
+  → wide stereo Echo (1/8d both sides)
+- **Field recording:** EQ Eight (high-pass at 200 Hz, low-pass at 8 kHz to
+  fit) → Compressor (gentle) → reverb send
+- **Master:** broad EQ smile → very gentle bus compression (1.5:1, slow
+  attack) → tape saturator
+- **No drums.** If you must have a pulse: a single shaker, mute it 80% of
+  the time.
+
+## Sample-set inputs
+
+- `Samples/Ambient/<source>_*.wav` — pads, drones, atmospheres
+- `Samples/Loops/Melodic/<song>_melodyloop_*.wav` — sparse motifs
+- `Samples/Vocals/<song>_vocalshot_*.wav` — choir-like or breath fragments
+
+## Sketching cue
+
+Resist drums. Resist tempo-locked elements. The form lives in *very long*
+crossfades and the way Reverb tails carry energy across locators. If you
+catch yourself adding a fourth element before bar 65, mute one.

--- a/docs/song-forms/ambient_long_form.md
+++ b/docs/song-forms/ambient_long_form.md
@@ -55,3 +55,29 @@ when* — locators mark layer entries, not section changes.
 Resist drums. Resist tempo-locked elements. The form lives in *very long*
 crossfades and the way Reverb tails carry energy across locators. If you
 catch yourself adding a fourth element before bar 65, mute one.
+
+## Building this template in Live (~25 min)
+
+1. **New Set** → tempo **70 BPM**, time signature **4/4**.
+2. **Arrangement view** (Tab).
+3. **Locators** (jump to bar, `Cmd+L`, rename):
+   - bar 1 → `BED`
+   - bar 33 → `LAYER1`
+   - bar 65 → `LAYER2`
+   - bar 97 → `DECAY`
+4. **Arrangement loop end** at bar 128.
+5. **Tracks** (audio unless noted):
+   - `Drone Bed` (purple) — destination for Wavetable or sampled pad
+   - `Granular 1` (light purple) — Granulator II target
+   - `Granular 2` (light purple)
+   - `Field Rec` (gray)
+   - `Melodic Motif` (mint) — Simpler with sparse single-note source
+   - `Bass Drone Sub` (dark blue, optional)
+6. **Three return tracks**: Convolution Reverb (long IR, 10-15s tail);
+   Spectral / Delay (Spectral Resonator OR very long Echo with feedback);
+   Texture (subtle saturator + filter sweep send).
+7. **Master**: gentle bus comp 1.5:1 slow → broad EQ smile → tape saturator.
+   Set Master output ceiling at -6 dBFS — ambient lives in low-RMS territory.
+8. **Insert chains per track** (see chains section above). Especially
+   important: Auto Filter with very slow LFO (~0.05 Hz) on the Drone Bed.
+9. **Save** to `~/mus/Templates/ambient_long_form Project/ambient_long_form.als`.

--- a/docs/song-forms/big_beat_drop.md
+++ b/docs/song-forms/big_beat_drop.md
@@ -1,0 +1,67 @@
+# `big_beat_drop` — Big Beat (Chemical Brothers / Prodigy / Fatboy Slim)
+
+Drum-led, breakbeat-heavy, EXTREME dynamic contrast. The breakdown→drop
+move is the genre's defining engine. Drop must land on a 16-bar boundary
+or the whole structure deflates.
+
+## Tempo & length
+
+- **BPM:** 120–140 (recommended start: 132)
+- **Total bars:** 128 (≈ 3:53 at 132 BPM)
+
+## Locators
+
+| Bar | Name | What's happening |
+|---:|---|---|
+|   1 | `INTRO`        | filter intro, drums build, no full break yet |
+|  17 | `A`            | first full break drops, main groove |
+|  33 | `BREAKDOWN`    | drums STRIP — bass+pad only, build with riser/sweep |
+|  49 | `DROP`         | full energy: break + bass + stab + vocal sample |
+|  81 | `BREAK`        | short stripped passage, 8 bars, drum fill at end |
+|  89 | `DROP'`        | second drop, more elements, climax |
+| 121 | `OUT`          | filter sweep, drum fill, hard cut at 128 |
+
+## Tracks
+
+1. **Break Loop** — sliced Amen / Apache / Funky Drummer on Simpler (slice mode)
+2. **Break Crushed** — parallel of #1 with heavy bus comp + saturator
+3. **Bass 303** — TB-303 emulation (Operator or external) with squelchy filter automation
+4. **Bass Sub** — sustained sub-bass for the DROP sections
+5. **Stab Sample** — short orchestra hit / horn stab on Simpler (one-shot)
+6. **Vocal Sample** — chopped vocal phrase, classic big beat ad-lib
+7. **Riser / FX** — automation lane lives here, builds at end of each section
+8. **Reverb Send** — large bright plate
+9. **Compressor Bus (drums+bass)** — heavy bus compression, fast attack
+
+## Starter chains
+
+- **Break Loop:** Glue Comp (4:1 fast attack, ratio 4) → Saturator (drive 0.5) → EQ Eight (low-shelf +2 dB at 80 Hz, slight 2 kHz cut)
+- **Break Crushed:** Compressor (8:1, hard) → Redux 4-bit → Filter (low-pass at 6 kHz, automated)
+- **Bass 303:** Filter automation lane is everything — start closed at INTRO, full open at DROP
+- **Bass Sub:** EQ low-pass 200 Hz → Compressor heavy → Saturator (sub fatness)
+- **Stabs:** EQ Eight (slight high-shelf bump) → short Reverb send → Auto Pan (subtle)
+- **Master:** Glue Comp 3:1 fast → tape saturator → limiter (push it)
+
+## Automation lanes (CRITICAL)
+
+Big Beat lives in automation. Set up lanes in advance:
+
+- Master low-pass filter — closes during BREAKDOWN, opens at DROP
+- Drum bus volume — drops to silence for last beat of every 16-bar block
+- Riser FX — increases over each pre-DROP build
+- 303 filter cutoff — sweeps continuously
+
+## Sample-set inputs
+
+- `Samples/Breaks/{Classic,Modern}/*.wav` — Amen/Apache/Funky Drummer family
+- `Samples/Oneshots/Kicks/<song>_kick_*.wav` — for parallel layered kick
+- `Samples/Loops/Bass/*.wav` — sub-bass for DROP sections
+- `Samples/Vocals/<song>_vocalshot_*.wav` — chopped ad-libs
+- Ableton's stock Operator preset library has TB-303 starters
+
+## Sketching cue
+
+Build BACKWARDS from the DROP. Lock bar 49 first — full energy, every track
+on, the moment everything "lands." THEN work backward to the BREAKDOWN
+strip-down. Most failed Big Beat sketches put energy too early — the drop
+is only powerful BECAUSE the breakdown was empty.

--- a/docs/song-forms/big_beat_drop.md
+++ b/docs/song-forms/big_beat_drop.md
@@ -65,3 +65,34 @@ Build BACKWARDS from the DROP. Lock bar 49 first — full energy, every track
 on, the moment everything "lands." THEN work backward to the BREAKDOWN
 strip-down. Most failed Big Beat sketches put energy too early — the drop
 is only powerful BECAUSE the breakdown was empty.
+
+## Building this template in Live (~35 min)
+
+1. **New Set** → tempo **132 BPM**, time signature **4/4**.
+2. **Arrangement view**.
+3. **Locators**:
+   - bar 1 → `INTRO`
+   - bar 17 → `A`
+   - bar 33 → `BREAKDOWN`
+   - bar 49 → `DROP`
+   - bar 81 → `BREAK`
+   - bar 89 → `DROP'`
+   - bar 121 → `OUT`
+4. **Arrangement loop end** at bar 128.
+5. **Tracks**:
+   - `Break Loop` (red) — Simpler slice mode (Amen/Apache/Funky Drummer)
+   - `Break Crushed` (dark red)
+   - `Bass 303` (blue) — Operator with squelchy filter automation
+   - `Bass Sub` (dark blue) — for DROP sections only
+   - `Stab Sample` (orange) — Simpler one-shot
+   - `Vocal Sample` (yellow) — chopped phrase
+   - `Riser / FX` (gray) — automation lives here
+6. **Returns**: Reverb (large bright plate), Drum+Bass Bus (heavy parallel
+   compression).
+7. **Master**: Glue Comp 3:1 fast → tape saturator → limiter (push it).
+8. **Set up automation lanes — CRITICAL for this form**:
+   - Master low-pass filter (closes at BREAKDOWN, opens at DROP)
+   - Drum bus volume (drops to silence end of every 16-bar block)
+   - Riser FX (increases over each pre-DROP build)
+   - 303 filter cutoff (continuous sweep)
+9. **Save** to `~/mus/Templates/big_beat_drop Project/big_beat_drop.als`.

--- a/docs/song-forms/idm_fourtet_evolve.md
+++ b/docs/song-forms/idm_fourtet_evolve.md
@@ -1,0 +1,58 @@
+# `idm_fourtet_evolve` — Horizontal IDM (Four Tet / Caribou)
+
+Horizontal evolution: organic accumulation of layers over time. Unlike the
+Squarepusher form (which keeps the bed constant and varies drums), this
+form lets every element grow and decay across the track.
+
+## Tempo & length
+
+- **BPM:** 110–130 (recommended start: 120)
+- **Total bars:** 96 (≈ 3:12 at 120 BPM)
+
+## Locators
+
+| Bar | Name | Layer state |
+|---:|---|---|
+|   1 | `SEED`       | one looping element only — typically a melodic chop |
+|  17 | `BUILD`      | + perc / shaker / texture |
+|  33 | `ESTABLISH`  | + drums (kick/snare appear), motif locks |
+|  49 | `VARIATION`  | melody mutates: pitch shift, new chop, harmony layer |
+|  65 | `BLOOM`      | full arrangement, all elements present, biggest density |
+|  81 | `DECAY`      | strip back: melody alone returns, ringing tails |
+
+## Tracks
+
+1. **Drums Loop** — sliced organic break (acoustic, soft transients)
+2. **Drums Crushed** — parallel saturator/bitcrush of #1 (low send pre-BLOOM)
+3. **Percussion** — shaker / tambourine / found-sound rhythm
+4. **Bass** — sub OR upright sample on Simpler
+5. **Melodic Chop A** — main motif on Simpler, slice mode
+6. **Melodic Chop B** — pitched/chopped variant of A (5th up, octave down, etc.)
+7. **Pad / Texture** — long evolving pad, gradual filter sweep
+8. **Vocal Chop** — wordless vocal sample, used sparingly
+9. **Reverb Send** — medium plate (3–5 s)
+10. **Delay Send** — synced 1/8d with feedback ~0.5
+
+## Starter chains
+
+- **Drums Loop:** Compressor (gentle 2:1) → EQ Eight (gentle low-shelf) → Reverb send pre-fader
+- **Drums Crushed:** Redux + Saturator + Auto Filter (gradually open over the track)
+- **Bass:** EQ low-pass at 200 Hz → Compressor → subtle Saturator (warmth not grit)
+- **Melodic Chops:** Simpler (slice) → Auto Pan (slow LFO) → Spectral Resonator (subtle shimmer) → Reverb send
+- **Pad:** Wavetable → Hybrid Reverb (massive) → Frequency Shifter (cents range, slow)
+- **Master:** Glue Comp gentle → broad warm EQ → soft limiter
+
+## Sample-set inputs
+
+- `Loops/Drums/<song>_drumloop_*.wav` — soft, organic, acoustic-leaning
+- `Loops/Bass/<song>_bassloop_*.wav` — preferably acoustic/sub
+- `Loops/Melodic/<song>_melodyloop_*.wav` — the SEED chop is critical here
+- `Loops/Vocal/<song>_vocalloop_*.wav` — sparse use
+- `Samples/Ambient/*.wav` — for the pad layer
+
+## Sketching cue
+
+The SEED chop carries the entire track. Spend 80% of your sketch time picking
+it (Loops/Melodic/ is your friend). Once it's chosen, every other element
+exists to support, vary, or decay around it. Resist adding drums before
+bar 33 — the long lead-in is the genre's signature.

--- a/docs/song-forms/idm_fourtet_evolve.md
+++ b/docs/song-forms/idm_fourtet_evolve.md
@@ -56,3 +56,29 @@ The SEED chop carries the entire track. Spend 80% of your sketch time picking
 it (Loops/Melodic/ is your friend). Once it's chosen, every other element
 exists to support, vary, or decay around it. Resist adding drums before
 bar 33 — the long lead-in is the genre's signature.
+
+## Building this template in Live (~30 min)
+
+1. **New Set** → tempo **120 BPM**, time signature **4/4**.
+2. **Arrangement view**.
+3. **Locators**:
+   - bar 1 → `SEED`
+   - bar 17 → `BUILD`
+   - bar 33 → `ESTABLISH`
+   - bar 49 → `VARIATION`
+   - bar 65 → `BLOOM`
+   - bar 81 → `DECAY`
+4. **Arrangement loop end** at bar 96.
+5. **Tracks**:
+   - `Drums Loop` (red) — Simpler slice mode
+   - `Drums Crushed` (dark red) — parallel saturator/bitcrush
+   - `Percussion` (orange) — shaker / tambourine / found-sound
+   - `Bass` (blue) — Simpler upright OR Operator sub
+   - `Melodic Chop A` (yellow) — main motif Simpler
+   - `Melodic Chop B` (yellow) — pitched variant
+   - `Pad / Texture` (purple) — Wavetable, slow attack
+   - `Vocal Chop` (orange, optional)
+6. **Returns**: Reverb (medium plate, 3-5s), Delay (1/8d feedback ~0.5),
+   Spectral Send (Spectral Resonator).
+7. **Master**: Glue Comp gentle → broad warm EQ → soft limiter.
+8. **Save** to `~/mus/Templates/idm_fourtet_evolve Project/idm_fourtet_evolve.als`.

--- a/docs/song-forms/idm_squarepusher.md
+++ b/docs/song-forms/idm_squarepusher.md
@@ -53,3 +53,29 @@ Lock the bass and pad EARLY (bars 1–8) — they will not change for the whole
 track. Spend the rest of the session ONLY on drum variation. The drum
 complexity arc (A → A' → CLIMAX) is the song's only real engine. If you
 find yourself reaching for a chord change, you're writing a different form.
+
+## Building this template in Live (~30 min)
+
+1. **New Set** → tempo **160 BPM**, time signature **4/4**.
+2. **Arrangement view**.
+3. **Locators**:
+   - bar 1 → `INTRO`
+   - bar 9 → `A`
+   - bar 25 → `A'`
+   - bar 41 → `BREAK`
+   - bar 49 → `CLIMAX`
+   - bar 73 → `OUT`
+4. **Arrangement loop end** at bar 80.
+5. **Tracks**:
+   - `Drums Loop` (red) — Simpler slot, slice mode
+   - `Drums Granular` (red) — Granulator II
+   - `Drums Repeat` (crimson) — Beat Repeat host
+   - `Drums Stretch` (crimson) — Simpler, texture mode
+   - `Sub Bass` (blue) — Operator FM
+   - `Pad / Chord Bed` (mint) — Wavetable
+6. **Returns**: Glitch FX (Spectral Time + Frequency Shifter), Drum Bus
+   parallel comp (Compressor 8:1 fast attack), Reverb.
+7. **Master**: Glue Comp 3:1 fast → tape saturator → limiter pushed.
+8. **Set up an automation lane** on the drum bus volume — you'll want it
+   later for the BREAK silence and CLIMAX ducks.
+9. **Save** to `~/mus/Templates/idm_squarepusher Project/idm_squarepusher.als`.

--- a/docs/song-forms/idm_squarepusher.md
+++ b/docs/song-forms/idm_squarepusher.md
@@ -1,0 +1,55 @@
+# `idm_squarepusher` — Vertical IDM (Squarepusher / early Aphex)
+
+Vertical evolution: same harmonic bed, drum chaos escalates. The bass and
+chords stay relatively constant; what changes is rhythmic complexity.
+
+## Tempo & length
+
+- **BPM:** 140–170 (recommended start: 160)
+- **Total bars:** 80 (≈ 2 min at 160 BPM — tight, dense)
+
+## Locators
+
+| Bar | Name | Drum complexity |
+|---:|---|---|
+|   1 | `INTRO`     | bass + pad only, no drums |
+|   9 | `A`         | basic drum pattern, 1/16 hats |
+|  25 | `A'`        | drum pattern doubles in density: ratchets, fills, time-stretched hits |
+|  41 | `BREAK`     | drums fully out — bass/pad solo, cliff-edge tension |
+|  49 | `CLIMAX`    | drum pattern at MAXIMUM — granular drums, glitch repeats, parallel stacks |
+|  73 | `OUT`       | drums cut, bass+pad ring, hard cut at 80 |
+
+## Tracks
+
+1. **Drums Loop** — sliced break on Simpler (slice mode, transient)
+2. **Drums Granular** — Granulator II on the same break, modulated grain size
+3. **Drums Repeat** — clone with Beat Repeat (chance 0.6, grid 1/32)
+4. **Drums Time-Stretch** — Simpler (texture mode), pitched chops
+5. **Sub Bass** — Operator FM (Algo 4, mod=carrier ratio 1:1, fast envelopes)
+6. **Pad / Chord Bed** — Wavetable, slow attack, 4–8 bar hold notes
+7. **Glitch FX Send** — Spectral Time + Frequency Shifter
+8. **Compressor Bus (drums)** — parallel compression, fast attack
+
+## Starter chains
+
+- **Drums Loop:** Compressor (4:1, fast) → Saturator → EQ Eight (slight bump 2 kHz)
+- **Drums Granular:** Granulator II → Auto Filter with envelope follower → Reverb (small bright)
+- **Drums Repeat:** Beat Repeat (Chance 0.6, Grid 7=1/32, Variation 5) → Compressor
+- **Drums Time-Stretch:** Simpler texture mode → Erosion → Stereo Imager
+- **Sub Bass:** Operator → EQ Eight (low-pass 200 Hz, sub focus) → Compressor (heavy 8:1)
+- **Pad:** Wavetable → Hybrid Reverb (large) → Auto Filter slow LFO
+- **Master:** Glue Comp (3:1, fast) → tape saturator → limiter
+
+## Sample-set inputs
+
+- `Samples/Breaks/Sliced/<song>_break*.wav` or `Loops/Drums/` — main break
+- `Samples/Oneshots/{Kicks,Snares,Hats,Percussion}/<song>_*.wav` — for granular/repeat tracks
+- `Samples/Loops/Bass/<song>_bassloop_*.wav` — sub-bass alternative
+- `Samples/Loops/Melodic/<song>_melodyloop_*.wav` — pad bed
+
+## Sketching cue
+
+Lock the bass and pad EARLY (bars 1–8) — they will not change for the whole
+track. Spend the rest of the session ONLY on drum variation. The drum
+complexity arc (A → A' → CLIMAX) is the song's only real engine. If you
+find yourself reaching for a chord change, you're writing a different form.

--- a/docs/song-forms/lofi_aaba.md
+++ b/docs/song-forms/lofi_aaba.md
@@ -53,3 +53,36 @@ Lock A into 16 bars, COPY to A' and A'' positions immediately, THEN start
 varying. The temptation is to build A and stop — the locators exist to
 force you into B and BREAK. Spend 80% of the time on those, not on
 perfecting A.
+
+## Building this template in Live (~25 min)
+
+1. **New Set** → set tempo to **86 BPM**, time signature **4/4**.
+2. **Switch to Arrangement view** (Tab).
+3. **Insert locators** at the bars below. Easiest: type the bar number into
+   the position display (top of arrangement), hit Enter to jump there, then
+   `Cmd+L` to insert a locator. Right-click the locator to rename it:
+   - bar 1 → `INTRO`
+   - bar 5 → `A`
+   - bar 21 → `B`
+   - bar 37 → `A'`
+   - bar 53 → `BREAK`
+   - bar 61 → `A''`
+   - bar 77 → `OUT`
+4. **Set arrangement loop end** at bar 84 (so playback stops there).
+5. **Create tracks** (Cmd+T audio, Cmd+Shift+T MIDI). Name + color each:
+   - `Drums Loop` (red)
+   - `Drums Crushed` (dark red)
+   - `Bass Mono` (blue)
+   - `Keys` (yellow)
+   - `Sample Loop A` (orange) — palette slot for dragged-in curation
+   - `Sample Loop B` (orange)
+   - `Texture` (gray) — vinyl/room tone send target
+6. **Add three return tracks** (Cmd+Alt+T): Reverb (short plate), Delay
+   (1/8d slap), Texture (vinyl crackle bus).
+7. **Insert chains per track** (see [Starter chains](#starter-chains-per-track-type)
+   above). For lo-fi, Tape Saturator + Glue Comp + low-pass at 8 kHz on
+   the master is the lo-fi-defining move.
+8. **File → Save Live Set As…** → save to
+   `~/mus/Templates/lofi_aaba Project/lofi_aaba.als`.
+9. To use as a template start point, **File → Save Current Set as Default**
+   *or* just `Cmd+O` and open this `.als` directly when sketching.

--- a/docs/song-forms/lofi_aaba.md
+++ b/docs/song-forms/lofi_aaba.md
@@ -1,0 +1,55 @@
+# `lofi_aaba` — Lo-fi Hip Hop AABA
+
+Loop-faithful lo-fi sketch. The artistry is in *almost-identical* repetition
+with subtle drops at the BREAK. J Dilla / Nujabes territory.
+
+## Tempo & length
+
+- **BPM:** 80–95 (recommended start: 86)
+- **Total bars:** 84 (≈ 4 min at 86 BPM, 4/4)
+
+## Locators
+
+| Bar | Name | Notes |
+|---:|---|---|
+|   1 | `INTRO`  | drums in slowly, no bass, vinyl crackle present |
+|   5 | `A`      | full beat, all elements |
+|  21 | `B`      | reharmonization or new sample focus, drums same |
+|  37 | `A'`     | back to A material with one subtle variation (filter, swap) |
+|  53 | `BREAK`  | drums drop out OR bass drops, vocal/melodic exposed |
+|  61 | `A''`    | full return, biggest moment of the track |
+|  77 | `OUT`    | filter sweep / tape stop / fade to vinyl crackle |
+
+## Tracks (order top → bottom in arrangement)
+
+1. **Drums Loop** — sliced break or programmed kit; chops on a Simpler
+2. **Drums Crushed** — parallel of #1 with heavy saturation/bitcrush
+3. **Bass Mono** — sampled upright bass or Operator sub
+4. **Keys** — Rhodes/Wurli sampled, slightly detuned
+5. **Sample Loop A** — palette slot for dragged-in curation output (vocal chops / instrumental hook)
+6. **Sample Loop B** — second palette slot
+7. **Texture Send** — vinyl crackle, room tone, tape hiss
+8. **Reverb Send** — short plate
+9. **Delay Send** — analog-modeled slap
+
+## Starter chains (per track type)
+
+- **Drums:** Tape saturator (Drive ≈ 0.4) → Glue Comp (4:1, fast attack) → low-pass at 8 kHz
+- **Drums Crushed:** Redux (8-bit) → Saturator (drive 0.7) → low-pass at 4 kHz
+- **Bass Mono:** EQ Eight (high-cut at 2 kHz) → Glue Comp (2:1) → subtle saturator
+- **Keys:** Multiband compressor → tape saturator → slap-delay send (1/8d)
+- **Master:** Glue Comp (gentle, 1.2:1) → vinyl crackle on a parallel send → low-shelf -1 dB at 60 Hz
+
+## Sample-set inputs (drag from `~/mus/Samples/`)
+
+- `Loops/Drums/<song>_drumloop_4bar_*.wav` — main loop variants
+- `Loops/Bass/<song>_bassloop_4bar_*.wav` — bass options for B section
+- `Loops/Melodic/<song>_melodyloop_*.wav` — keys/sample chops
+- `Loops/Vocal/<song>_vocalloop_*.wav` — optional vocal chops for hooks
+
+## Sketching cue
+
+Lock A into 16 bars, COPY to A' and A'' positions immediately, THEN start
+varying. The temptation is to build A and stop — the locators exist to
+force you into B and BREAK. Spend 80% of the time on those, not on
+perfecting A.


### PR DESCRIPTION
## Summary

Cherry-picks the 3 doc-only commits from the long-stale `feat/curation-library-router` branch onto `main`. These add value independently of the router/CLI feature commits and have no code conflicts.

**Picked:**
- `docs(song-forms): five song-form template specs` — `docs/song-forms/{README,ambient_long_form,big_beat_drop,idm_fourtet_evolve,idm_squarepusher,lofi_aaba}.md`
- `docs(exec-plan): device-side changes for curation library (review gate)` — `docs/exec-plans/curation-library-device-changes.md`
- `docs(song-forms): per-template "Build in Live" step-by-step recipes` — recipes under `docs/song-forms/`

**Deferred — needs careful resolution:**
- `feat(router): library-curation router + stemforge route CLI` — conflicts with `stemforge/cli.py` (Phase 1 also touched cli.py with `deck-from-manifest --profile` work). Needs hand-resolution combining both feature additions.
- `feat(presets,tools): stems_only preset + init_library bootstrap` — possibly conflict-free but depends on the router CLI commit semantically. Defer until the router commit lands.
- Two `chore(lint)` commits — depend on the two feature commits above; defer along with them.

After this lands, the long-stale `feat/curation-library-router` worktree at `.claude/worktrees/curation-library-router/` can be retired (or kept for the deferred-feature-commit resolution).

Per memory `feedback_curation_library_v2_branch_direction.md`: explicit user go-ahead obtained before this push.

## Test plan

- [x] No code changes; pure doc additions.
- [x] `uv run pytest` unchanged (doc-only).
- [x] Cherry-pick provenance preserved (each commit's original author + date intact).

Generated with [Claude Code](https://claude.com/claude-code)
