### PR TITLE
docs(release): CHANGELOG.md + manual-release runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,31 @@ All notable changes to StemForge. Follows [Keep a Changelog](https://keepachange
 
 ## [Unreleased]
 
-The marquee delivery in this cycle is the **EP-133 K.O. II hardware pipeline** — Ableton arrangement → bounced WAVs → multi-pad `.ppak` deck imported on-device — fully hardware-validated against real hip-hop verse-swap kits. Beneath that, substantial hardening, schema work, and beat-detection corrections shipped across ~160 commits since `v0.0.2-beta`.
+Follow-ons after v0.2.0 ship.
+
+### Added
+
+- `stemforge split --time-sig N/D` flag for parity with `forge` and `curate-bars` (PR #76, Lane 2A). Plumbs the numerator into prechop's `beats_per_bar`. Help text explicitly disclaims `beat-this` effect — librosa-fallback path only.
+- `stemforge ep133-clear-pad PROJECT_SLOT PAD [--dry-run]` (PR #76, Lane 2A). Clears a single pad's sample slot via USB-MIDI SysEx using the byte-tested `build_assign_pad` path with slot=0 sentinel. Accepts `A1`..`D12` letter form or `1`..`48` numeric. Hardware round-trip validation pending; dry-run is regression-tested.
+- `function reload()` in `stemforge_loader.v0.js` (PR #74, Lane 2B). Toggles `this.autowatch` 0→1 to re-arm Max's file-watcher so `sf-remote fire forge reload` actually reloads the JS from disk. Mirrored to deploy path. On-device validation pending. CAVEAT block in `sf_forge.js:reload()` trimmed accordingly.
+- 9 mock test cases in `tests/js_mocks/test_reload.test.js` (PR #74).
+- `stemforge deck-from-manifest` end-to-end test (PR #75, Lane 2C) with a session-mode COMMIT-flow fixture at `tests/ep133/fixtures/session_mode_manifest.json` matching `_sessionTrackEntryFromClip` exactly. 5 new pytest cases covering `--profile`, `--all-drum`, `--play-mode`, per-clip BPM preservation.
+- `CHANGELOG.md` (this file) and `docs/releases/RELEASE_RUNBOOK.md` (PR #71).
+- Tracking issues #73 (PyPI upload), #78 (notarize v0.2.0), #79 (replace heavyweight `release.yml` with `release-minimal.yml`), #80 (sf-remote round-trip test), #81 (dispatcher target audit).
+
+### Changed
+
+- `tools/sf_remote.py:_osc_encode` docstring updated — removed dead `/tmp/udp_probe.maxpat` reference; replaced with prose explaining the empirical OSC route check via `nc -u`.
+- `sf-remote dump` error messages now include a 3-step diagnostic checklist on timeout, and distinguish the empty-dict case from the not-initialized case.
+- `docs/issues/` reorganized — 8 fully-resolved issue files moved to `docs/issues/closed/` (PR #82) to keep the active list focused on actionable work.
+
+### Fixed
+
+- `tests/test_canonical_tempos.py` ruff-format compliance (PR #77 — pure formatting follow-up to PR #70).
+
+## [v0.2.0] — 2026-05-12
+
+First real StemForge release. `pyproject.toml` had been at `0.2.0` since the initial commit but was never published; this tag is the first real cut. The marquee delivery is the **EP-133 K.O. II hardware pipeline** — Ableton arrangement → bounced WAVs → multi-pad `.ppak` deck imported on-device — fully hardware-validated against real hip-hop verse-swap kits. Beneath that, substantial hardening, schema work, and beat-detection corrections shipped across ~160 commits since `v0.0.2-beta`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,133 @@
+# Changelog
+
+All notable changes to StemForge. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+The marquee delivery in this cycle is the **EP-133 K.O. II hardware pipeline** — Ableton arrangement → bounced WAVs → multi-pad `.ppak` deck imported on-device — fully hardware-validated against real hip-hop verse-swap kits. Beneath that, substantial hardening, schema work, and beat-detection corrections shipped across ~160 commits since `v0.0.2-beta`.
+
+### Added
+
+#### EP-133 K.O. II pipeline
+- Full SysEx upload library — WAV → device over USB-MIDI, slots 1..255 (89 tests).
+- `stemforge export-song` — arrangement-view snapshot → song-mode `.ppak`.
+- `stemforge deck-from-manifest` + `stemforge build-deck` — session-view manifest → multi-pad deck `.ppak` with per-clip warp BPM, projectspec sidecar.
+- `--profile drum|vocal|texture|preserve_source`, `--all-drum`, `--play-mode oneshot|key|legato` flags on `deck-from-manifest` to retire inline regex patches.
+- `tools/ep133_load_project.py` — batch loader with project-archive round-trip; pad layout `bar_001='.'` ascending bottom-left.
+- Reference-ppak capture flow + integration tests + workflow doc.
+- Protocol additions: `time.mode=bpm` clip stretching, `playmode`↔`envelope.release` auto-pairing, per-pad BPM decoder, project-file reader, per-slot BPM tagging.
+- Per-sample 20s cap enforced with skip-warning rather than truncate.
+- Drum-profile defaults locked in: `key` play-mode + `envelope.release=15` + float32→clip→int16 conversion (hardware-validated).
+- `.ppak` writer hardening: `pak_type=project` default, `patterns/d05` marker collision fix, off-by-one in `project_reader` corrected.
+
+#### M4L device
+- COMMIT, BOUNCE, EXPORT, ANCH buttons + supporting JS.
+- `_collapseToLoopRegion` — bakes Live's loop region into bounced WAVs (looping clips materialize correctly).
+- Atomic-rename bounce-stub flow (`<manifest>.tmp` → final) — readers can no longer race a half-written manifest.
+- Arrangement-view loader for prechop output + arrangement-view snapshot reader for EP-133 export.
+- v8ui patcher builder — matrix UI + native preset/source dropdowns + COMMIT button + per-target track colors + pill-color migration to Ableton palette.
+- In-Ableton locator-anchor workflow for re-cutting bar 1; ANCH as pure timeline shift (no source rewrite).
+- Wipe prior stemforge clips before placing new ones on (re)load.
+- Per-stem `warp_mode` (`drums`/`bass` = Beats) via `BAR_WARP_MODES`.
+- `sf_remote` UDP receiver + `sf-remote fire forge {bounceTracks,reload,...}` forwarder.
+- `_alFindClipAtBeat` reverse-walk (kills O(N²) load cost).
+- Hardened LiveAPI mock with backing liveTree (Hardening Stream B.2).
+
+#### CLI & pipelines
+- `stemforge route` — library-curation router (cherry-picked from `feat/curation-library-router`).
+- `stemforge prechop` with padded chunks + `--emit-partial` flag.
+- `stemforge reslice-curated` subcommand + auto-reslice on re-anchor.
+- `arrangement` mode runs prechop with configurable padding; downbeat-anchored.
+- `refine_bpm` always-on + locator bar-snap.
+- Vibe-preset library: `ambient_veil`, `brutalism`, `dub_echo`, `spectral_glitch`.
+- Session-mode + production-mode curation YAMLs; outlier filter + duration normalize + ref-stem onset alignment.
+- Koala sampler bank-zip exporter.
+- Bulk re-anchor tool for all processed tracks.
+- Five song-form template specs + per-template "Build in Live" recipes.
+
+#### Beat detection / tempo
+- Multi-source tempo reconciler (`beat-this:mix` + `beat-this:drums` + librosa fallback) with mean-not-median estimator.
+- Bar-period BPM + manual `--bpm` / `--first-downbeat` overrides.
+- Mode-walk downbeat + refine-downbeat audit.
+- Canonical real-world tempo regression fixtures (Definition / Ooh La La / Believer) gated by `@pytest.mark.has_phase3_inputs`.
+- Drums-first-downbeat preference when phase-equivalent to mix (resolves GH #55).
+
+#### Hardening Streams A–E
+- A.1 — `audio_hash` on `ChunkMeta`.
+- A.2 — Pydantic schemas for the three undocumented JSON contracts.
+- B.1 — synthetic-song fixture.
+- B.2 — hardened LiveAPI mock with backing liveTree.
+- B.3+B.4 — CliRunner smoke + `@pytest.mark.live` opt-in.
+- C.1 — vendored `forge_device.audit` + wired to CLI entry points.
+- C.2 — vendored `forge_device.verifiers` + non-blocking CI gate.
+- C.3 — vendored `forge_device.load_verifier` + CLI wiring.
+- D.1 — `m4l.button.commit` Tier-3 tests against the hardened LiveAPI mock.
+- D.2 — path-coverage audit + triage closures.
+- E — canonical tempo regression fixtures + `refine_bpm` always-on + locator bar-snap.
+- HW-3 (.amxd→.maxpat) + HW-4 (`sf_remote` UDP receiver) closed.
+
+#### Configurator (Phases 1–2.5)
+- `AbstractProjector` + `Ep133Projector` wrapping song-export; byte-identity acceptance gate.
+- `scene_model` schema + serialize (Project / Song / SceneSpec / GroupSpec / PadSpec / ClipRef).
+- `Ep133Projector.project_from_spec` + byte-identity test.
+- `export-song --write-spec` flag for ProjectSpec dump.
+- JS reader emits `songs[]` wrapper + Python shape detector.
+- `--then-curate` flag + re-anchor flow.
+- COMMIT now walks arrangement view (closes the session_tracks gap).
+
+#### Repo, DX & docs
+- Top-level README augmented with elevator pitch, 3-zone architecture, pipeline catalog, EP-133 workflow section, pointers.
+- New guides: `docs/guides/ep133-workflow.md`, `docs/guides/cli-reference.md`.
+- Mermaid architecture + EP-133 flow diagrams.
+- Configurator docs rehomed under `docs/configurator/{research,archive}/`.
+- `.local/mus/{mus_tree,mus_events,mus_setup}` split out of monolithic `DUMP` + `tools/refresh_mus_dump.sh`.
+- `.pre-commit-config.yaml` with `ruff format --check` gate.
+- JS-mock suite auto-discovery in `test_js_bridge.py` — 3 → 8 wired files, 48 → 116 individual cases.
+- Phase 2 root-level inventory at `docs/cleanup/2026-05-12_root_inventory.md`.
+
+### Changed
+
+- Backends: dropped LALAL.AI and Music.AI; Demucs is the only stem backend on main (Modal cloud backend preserved on `experimental/cloud-compute`).
+- M4L loader: dropped legacy v1/v2 paths — production-mode is the only supported layout.
+- `pyproject.toml`: setuptools find scope tightened from `tools*` → `tools`.
+- `stemforge curate` uses `stems.json` tempo instead of re-detecting BPM/downbeat.
+- `--pipeline` implies `layout_mode=production` when injecting `processing_config`.
+
+### Fixed
+
+- canonical_tempos full-suite torch-double-init flake — tests now run `stemforge split` in a subprocess for guaranteed isolation (PR #70).
+- Bounce stub race — atomic rename via `<manifest>.tmp` → final.
+- `_getLomString` returned the string `"undefined"` for missing LOM props; now returns `""`.
+- `clip.call("crop")` renders at `warp_bpm`, not session BPM — pipeline captures per-clip `warp_bpm` pre-crop and tags WAV TNGE + pad-record bytes 12–15.
+- M4L file reader: chunked `readstring`/`writestring` at signed-short cap (32767).
+- M4L file reader: robust single-read fast path + position-guarded loop.
+- `prechop` `musical_bar_1_chunk_index` is 0-indexed (was 1-indexed).
+- `prechop` silence-pads pre-source region; restores `pad_pre_bars=1` default.
+- `prechop` always emits leading partial chunk by default.
+- Clip-export: wrap-around source when `loop_end` exceeds source length; bpm-derived seconds_per_beat; rotate bounce to `start_marker`.
+- EP-133 song-export: post-merge integration of tracks A+C; full byte-level rewrite; soft-skip slots whose WAVs are missing on disk; silent groups reference empty pattern, not 0; prefer `loop_start/end_sec` over `clip_length_sec`.
+- M4L: arrangement-view loader honors padded chunks + correct LOM units.
+- M4L: warp markers via `move_warp_marker` + beats-unit for clip bounds; drop write to read-only `Clip.length`; clip start at `raw_start`, clear auto-warp before setting markers.
+- M4L: shift right-column button stack up 20px so LOAD/ANCH clears chrome.
+- Curation: normalize stem shape + defer torch import in `drum_separator`.
+- EP-133: revert integer wire encoding — device accepts strings only; `sound.playmode` uses integer wire encoding only on the specific field where the device demands it.
+- M4L: unwrap Max named-dict root envelope in loader.
+
+### Removed
+
+- `EP133_DEBRIEF.md` from repo root (superseded by `docs/sessions/2026-05-12_breaks_n_beats_complete.md`).
+- Stale 28-day-old `.claude/sessions/` files.
+- 18 empty orphan worktree shells from prior multi-agent sessions.
+- `STEMFORGE_CONFIGURATOR_SPEC_v{2,3}.md` from root (archived to `docs/configurator/archive/`; superseded by v4).
+
+### Hardware validation
+
+End-to-end pipeline validated on EP-133 K.O. II hardware 2026-05-12 with `breaks-n-beats1.ppak` (46 pads across A=12 / B=12 / C=10 / D=12 with hold-to-play drum profile). One hour of live play, no issues.
+
+## [v0.0.2-beta] — earlier
+
+See git tag `v0.0.2-beta`.
+
+## [v0.0.1-beta] — earlier
+
+See git tag `v0.0.1-beta`.

--- a/docs/releases/RELEASE_RUNBOOK.md
+++ b/docs/releases/RELEASE_RUNBOOK.md
@@ -1,0 +1,206 @@
+# Manual release runbook — v0.X.0
+
+This is the **one-time manual flow** for the next StemForge release. We picked manual over CI for this cut so we can ship without first auditing/fixing the heavyweight `release.yml` or wiring up new PyPI automation. After we've shipped one release this way, we revisit and automate.
+
+## Prereqs (one-time)
+
+- [ ] **PyPI account + project ownership.** Confirm you own (or can publish to) `stemforge` on PyPI. If the name is unclaimed, register it now via PyPI's web UI — claim the name **before** uploading anything.
+- [ ] **PyPI API token.** Generate a project-scoped token at <https://pypi.org/manage/account/token/>. Save to `~/.pypirc`:
+  ```ini
+  [pypi]
+  username = __token__
+  password = pypi-AgEIcHl...your-token-here
+  ```
+  Or export `TWINE_USERNAME=__token__ TWINE_PASSWORD=pypi-...` for the upload command.
+- [ ] **`uv build` and `twine` installed.** `uv` is already a project dep. `twine` is not — install with `uv tool install twine` (preferred) or `pipx install twine`.
+- [ ] **macOS signing identities ready** (only if attaching a notarized `.pkg`). Need `Developer ID Application` for the binary and `Developer ID Installer` for the .pkg. Check with `security find-identity -v -p codesigning`.
+
+## Step 1 — Decide the version
+
+Right now the source-of-truth is split:
+
+| Where | Value |
+|---|---|
+| `pyproject.toml` | `0.2.0` |
+| `v0/build/build-pkg.sh` default | `0.0.1` |
+| `v0/src/installer/distribution.xml` | `0.0.1` |
+| Git tags | `v0.0.1-beta`, `v0.0.2-beta` |
+
+Pick one of:
+- `0.1.0` — first real minor release (matches your earlier preference; means downgrading `pyproject.toml` from `0.2.0`, which is safe because `0.2.0` was never published).
+- `0.2.0` — accept what `pyproject.toml` already says.
+- `0.0.3` — continue the existing tag sequence; conservative.
+
+Record your pick here: `STEMFORGE_VERSION=___`.
+
+## Step 2 — Align all version sources
+
+```bash
+export STEMFORGE_VERSION=0.X.0  # your pick from step 1
+
+# pyproject.toml
+sed -i '' -e "s/^version = \".*\"/version = \"${STEMFORGE_VERSION}\"/" pyproject.toml
+
+# v0/build/build-pkg.sh — default fallback
+sed -i '' -e "s/^VERSION=\"\${STEMFORGE_VERSION:-.*}\"/VERSION=\"\${STEMFORGE_VERSION:-${STEMFORGE_VERSION}}\"/" v0/build/build-pkg.sh
+
+# v0/src/installer/distribution.xml — 3 references
+sed -i '' -e "s/StemForge 0\\.0\\.1/StemForge ${STEMFORGE_VERSION}/" v0/src/installer/distribution.xml
+sed -i '' -e "s/version=\"0\\.0\\.1\"/version=\"${STEMFORGE_VERSION}\"/g" v0/src/installer/distribution.xml
+```
+
+Verify:
+```bash
+grep -nE "0\.[012]\.[0-9]|0\.0\.0" pyproject.toml v0/build/build-pkg.sh v0/src/installer/distribution.xml
+```
+
+Commit on a branch:
+```bash
+git checkout -b release/v${STEMFORGE_VERSION}
+git add pyproject.toml v0/build/build-pkg.sh v0/src/installer/distribution.xml
+git commit -m "chore(release): bump version to ${STEMFORGE_VERSION}"
+```
+
+## Step 3 — Update CHANGELOG.md
+
+Open `CHANGELOG.md`, rename `## [Unreleased]` to `## [v${STEMFORGE_VERSION}] — YYYY-MM-DD`, and add a fresh empty `## [Unreleased]` section at the top for future work.
+
+Verify locally:
+```bash
+head -50 CHANGELOG.md
+```
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): cut v${STEMFORGE_VERSION}"
+```
+
+## Step 4 — Tests must be green
+
+```bash
+uv run pytest -q
+uv run ruff check .
+uv run ruff format --check .
+```
+
+If `canonical_tempos` fails with content mismatches (not torch double-init), the `/private/tmp/phase3_inputs/*.wav` fixtures may be missing or stem-reconstructed. Make sure the originals are present before claiming green. The torch flake itself should be gone post-PR #70.
+
+If anything red, stop. Fix, recommit, restart this step.
+
+## Step 5 — Build the Python distributions
+
+```bash
+rm -rf dist/ build/ *.egg-info
+uv build  # produces dist/stemforge-${STEMFORGE_VERSION}.tar.gz and ...-py3-none-any.whl
+ls -lh dist/
+```
+
+Sanity-check the wheel installs cleanly into a fresh venv:
+```bash
+uv venv /tmp/sftest && /tmp/sftest/bin/pip install dist/stemforge-${STEMFORGE_VERSION}-py3-none-any.whl
+/tmp/sftest/bin/stemforge --help | head -20
+rm -rf /tmp/sftest
+```
+
+## Step 6 — Build the .pkg
+
+```bash
+STEMFORGE_VERSION=${STEMFORGE_VERSION} bash v0/build/build-pkg.sh
+ls -lh v0/build/StemForge-${STEMFORGE_VERSION}.pkg
+```
+
+Optional: codesign + notarize the .pkg. Skip if this is an internal/preview release. If notarizing:
+```bash
+xcrun notarytool submit v0/build/StemForge-${STEMFORGE_VERSION}.pkg \
+  --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_PW" \
+  --wait
+xcrun stapler staple v0/build/StemForge-${STEMFORGE_VERSION}.pkg
+```
+
+## Step 7 — Open + merge a release PR
+
+```bash
+git push -u origin release/v${STEMFORGE_VERSION}
+gh pr create --base main --head release/v${STEMFORGE_VERSION} \
+  --title "release: v${STEMFORGE_VERSION}" \
+  --body "Version bump + CHANGELOG cut. See CHANGELOG.md for the full delta."
+# Wait for CI green, then merge via GitHub UI or:
+gh pr merge --squash --delete-branch
+git checkout main && git pull
+```
+
+## Step 8 — Tag
+
+```bash
+git tag -a "v${STEMFORGE_VERSION}" -m "StemForge v${STEMFORGE_VERSION}"
+git push origin "v${STEMFORGE_VERSION}"
+```
+
+**Note:** the existing heavyweight `.github/workflows/release.yml` triggers on `v*` tags. It may attempt the ONNX→universal2-native→notarize→.pkg→GitHub-release pipeline and **fail** because some of its referenced scripts are broken (e.g. `v0/src/installer/build-pkg.sh` doesn't exist; the actual script is at `v0/build/build-pkg.sh`). If the workflow fails, that's expected — we ship the GitHub release manually in step 10 below. Optionally disable the workflow first by renaming it or pushing a tag like `v${STEMFORGE_VERSION}-skip-ci` then re-tagging.
+
+## Step 9 — Publish to PyPI
+
+```bash
+twine check dist/*
+twine upload dist/*
+```
+
+Verify by installing from PyPI in a fresh venv:
+```bash
+uv venv /tmp/sf-pypi && /tmp/sf-pypi/bin/pip install stemforge==${STEMFORGE_VERSION}
+/tmp/sf-pypi/bin/stemforge --help | head -10
+rm -rf /tmp/sf-pypi
+```
+
+## Step 10 — Publish the GitHub release
+
+```bash
+gh release create "v${STEMFORGE_VERSION}" \
+  v0/build/StemForge-${STEMFORGE_VERSION}.pkg \
+  dist/stemforge-${STEMFORGE_VERSION}-py3-none-any.whl \
+  dist/stemforge-${STEMFORGE_VERSION}.tar.gz \
+  --title "v${STEMFORGE_VERSION}" \
+  --notes-from-tag  # uses the tag annotation; or use --notes-file CHANGELOG.md
+```
+
+Or open the release in the browser to write a richer description that links to CHANGELOG sections:
+```bash
+gh release create "v${STEMFORGE_VERSION}" \
+  v0/build/StemForge-${STEMFORGE_VERSION}.pkg \
+  dist/* \
+  --title "v${STEMFORGE_VERSION}" \
+  --draft
+gh release view --web "v${STEMFORGE_VERSION}"
+```
+
+## Step 11 — Post-release smoke
+
+- [ ] `pip install stemforge==${STEMFORGE_VERSION}` works on a fresh machine / fresh venv.
+- [ ] `stemforge --help`, `stemforge split --help`, `stemforge build-deck --help` all render.
+- [ ] `.pkg` installs cleanly on a fresh Ableton-equipped Mac (only if notarized).
+- [ ] EP-133 deck workflow runs end-to-end on at least one new track.
+- [ ] Announce in whatever channel makes sense (Slack / Discord / Twitter / nowhere).
+
+## Step 12 — Cleanup
+
+- [ ] Delete the `release/v${STEMFORGE_VERSION}` branch on origin if not auto-deleted by the merge.
+- [ ] If you bumped `pyproject.toml` to a new development version (e.g. `0.X.1.dev0`), commit that to main now to mark "next release in progress."
+
+## Rollback (if anything breaks)
+
+- **Bad PyPI upload:** PyPI doesn't allow re-uploading a deleted version. Yank with `twine yank stemforge ${STEMFORGE_VERSION} --reason "..."` and ship `${NEXT_PATCH}` with a fix.
+- **Bad GitHub release:** `gh release delete "v${STEMFORGE_VERSION}" --yes --cleanup-tag`. Delete the tag locally too: `git tag -d "v${STEMFORGE_VERSION}"`. Then redo.
+- **Bad .pkg:** edit the release on GitHub, delete the asset, upload a corrected one with `gh release upload`.
+
+---
+
+## Followups for the next release (out of scope this time)
+
+- Replace this runbook with a working `release-minimal.yml` workflow:
+  - Trigger on `v*` tag push.
+  - Build wheel + sdist via `uv build`.
+  - Publish to PyPI via `pypa/gh-action-pypi-publish` (use OIDC trusted publisher; no API token in secrets).
+  - Build the `.pkg` via the existing `v0/build/build-pkg.sh`.
+  - Create GitHub release with auto-generated notes + attach `.pkg` + dist artifacts.
+- Either fix the broken paths in `.github/workflows/release.yml` and consolidate, or delete it once `release-minimal.yml` covers the same ground.
+- Adopt `python-semantic-release` or similar if you want to automate version bumps from conventional-commit messages.


### PR DESCRIPTION
## Summary

Two release-prep docs ahead of the next StemForge tag.

### `CHANGELOG.md`

[Keep-a-Changelog](https://keepachangelog.com/en/1.1.0/) format. Captures the ~160 commits since `v0.0.2-beta` organized by area:

- **EP-133 K.O. II pipeline** — the marquee delivery (SysEx upload library, `deck-from-manifest` + `build-deck` + `export-song`, `.ppak` writer hardening, protocol additions, drum-profile defaults, 20s cap, hardware validation).
- **M4L device** — COMMIT / BOUNCE / EXPORT / ANCH buttons, `_collapseToLoopRegion`, atomic-rename bounce stub, v8ui patcher builder, locator-anchor workflow, `sf_remote`.
- **CLI & pipelines** — `stemforge route`, `stemforge prechop` padding, `stemforge reslice-curated`, vibe presets, session-mode + production-mode curation YAMLs, song-form template specs.
- **Beat detection / tempo** — multi-source reconciler, `refine_bpm` always-on, mode-walk downbeat, canonical real-world tempo regression fixtures.
- **Hardening Streams A–E** — full ledger of the hardening work.
- **Configurator (Phases 1–2.5)** — Ep133Projector + byte-identity gate, scene_model, project_translator.
- **Repo, DX & docs** — README polish, `docs/guides/{ep133-workflow,cli-reference}.md`, Mermaid diagrams, configurator rehome, DUMP split, pre-commit hook, JS-suite auto-discovery.

Plus standard **Changed**, **Fixed**, **Removed** sections and a hardware-validation note. Header is `## [Unreleased]` — the actual version pick is held per `docs/releases/RELEASE_RUNBOOK.md` step 1.

### `docs/releases/RELEASE_RUNBOOK.md`

12-step manual runbook for the next release (we picked manual over CI for this cut). Covers:

- Prereqs (PyPI token, twine, signing identities).
- Version alignment across `pyproject.toml` + `v0/build/build-pkg.sh` + `v0/src/installer/distribution.xml` — currently split between `0.0.1` / `0.2.0` / tag history.
- Wheel + sdist build (`uv build`), .pkg build (`bash v0/build/build-pkg.sh`).
- PyPI upload (`twine`), GitHub release (`gh release create`), tag push.
- Rollback procedures (PyPI yank, GitHub release delete, etc).
- **Calls out the broken paths in the existing heavyweight `.github/workflows/release.yml`** (references `v0/src/installer/build-pkg.sh` which doesn't exist — actual script is `v0/build/build-pkg.sh`) and recommends treating any failure from that workflow as expected this time around.

The "Followups" section at the bottom records the future-state aspirations: replace this runbook with a working `release-minimal.yml`, consolidate or delete the heavyweight `release.yml`, consider `python-semantic-release`.

## Test plan

- [x] Docs-only; no code changes.
- [x] `CHANGELOG.md` renders cleanly in GitHub preview.
- [x] All cross-doc links in `RELEASE_RUNBOOK.md` point at real files.

## Stack

This is independent of [PR #70](https://github.com/ZacharySBrown/stemforge/pull/70) (canonical_tempos fix). Both target `main` and can merge in any order.

Generated with [Claude Code](https://claude.com/claude-code)
