### PR TITLE
release: align installer version refs to 0.2.0

### DIFF
--- a/v0/build/build-pkg.sh
+++ b/v0/build/build-pkg.sh
@@ -10,7 +10,7 @@
 # bundle the template.
 set -euo pipefail
 
-VERSION="${STEMFORGE_VERSION:-0.0.1}"
+VERSION="${STEMFORGE_VERSION:-0.2.0}"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 

--- a/v0/src/installer/distribution.xml
+++ b/v0/src/installer/distribution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="2">
-    <title>StemForge 0.0.1</title>
+    <title>StemForge 0.2.0</title>
     <organization>com.stemforge</organization>
     <options allow-external-scripts="no" hostArchitectures="x86_64,arm64" customize="never" require-scripts="false" rootVolumeOnly="true"/>
     <domains enable_localSystem="true" enable_currentUserHome="true"/>
@@ -22,6 +22,6 @@
     <choice id="com.stemforge.user" title="Ableton Integration" description="Installs the Max for Live device, Max Package, and template into your Ableton User Library. After file installation, the Neural Engine cache is pre-warmed (2-3 minutes on first install) so your first stem split is fast." enabled="false" selected="true">
         <pkg-ref id="com.stemforge.user"/>
     </choice>
-    <pkg-ref id="com.stemforge.system" version="0.0.1" onConclusion="none">system.pkg</pkg-ref>
-    <pkg-ref id="com.stemforge.user" version="0.0.1" onConclusion="none">user.pkg</pkg-ref>
+    <pkg-ref id="com.stemforge.system" version="0.2.0" onConclusion="none">system.pkg</pkg-ref>
+    <pkg-ref id="com.stemforge.user" version="0.2.0" onConclusion="none">user.pkg</pkg-ref>
 </installer-gui-script>


### PR DESCRIPTION
## Summary

Cuts **v0.2.0** as the first real StemForge release. `pyproject.toml` has been at `0.2.0` since the initial commit but was never published; this PR aligns the .pkg installer XML title + pkg-ref versions + `build-pkg.sh` default fallback to match, so a built `.pkg` consistently says "StemForge 0.2.0" everywhere.

After this merges, I'll tag `v0.2.0`, build the wheel + sdist + .pkg, and cut the GitHub release.

## Why 0.2.0 and not 0.1.0

`pyproject.toml` already says `0.2.0`. Downgrading to `0.1.0` is also safe (since `0.2.0` was never published anywhere), but `0.2.0` is the path of least churn for this first real cut. Future versions can roll forward normally from here.

## What this PR does NOT do

- **PyPI publish wiring** — still missing from CI. Manual upload for this release; followups captured in [PR #71](https://github.com/ZacharySBrown/stemforge/pull/71)'s `RELEASE_RUNBOOK.md`.
- **CHANGELOG.md** — drafted on [PR #71](https://github.com/ZacharySBrown/stemforge/pull/71). The GitHub release notes will summarize inline.
- **Notarization** — the `.pkg` we ship from this tag will be unsigned. Notarize as a followup if you want to distribute outside your machine.

## Test plan

- [x] No code changes; pure version-string alignment.
- [x] `pyproject.toml` (`0.2.0`), `v0/src/installer/distribution.xml` (`0.2.0` × 3 refs), `v0/build/build-pkg.sh` default (`0.2.0`) all match.
- [x] `STEMFORGE_VERSION` env var still overrides `build-pkg.sh`'s default.

Generated with [Claude Code](https://claude.com/claude-code)
