### PR TITLE
test(ep133): deck-from-manifest end-to-end + session-mode fixture

### DIFF
--- a/docs/issues/hardening-test-coverage-gaps.md
+++ b/docs/issues/hardening-test-coverage-gaps.md
@@ -1,6 +1,6 @@
 # Hardening: JS mock test coverage gaps + CLI integration gaps
 
-**Status:** Open — captured 2026-05-12.
+**Status:** Closed 2026-05-12 — all sub-tasks done. See per-section markers.
 
 ## JS mock suites NOT run by pytest
 
@@ -37,12 +37,13 @@ tests/js_mocks/
 `stemforge deck-from-manifest` and `stemforge build-deck` are covered by:
 - `tests/test_build_deck_cli.py` (8 cases) — argument parsing + smoke run.
 
-But NOT covered:
-- `deck-from-manifest` end-to-end CLI test against a fixture manifest. Currently the production-mode manifests from `curate-bars` produce empty `session_tracks`, so the only deck-from-manifest test inputs are hand-rolled fixtures. We need a session-mode fixture (the COMMIT-flow output shape).
-- The format_profile patch step (regex swap of vocal/texture/preserve_source → drum) we did inline at the CLI — that's not in code, it's an ad-hoc step in the breaks-n-beats1 build. Should be a flag on deck-from-manifest (`--all-drum`, `--profile <preset>`, etc).
+But NOT covered (status as of 2026-05-12):
+- ✅ DONE — `deck-from-manifest` end-to-end CLI test against a session-mode fixture manifest. Landed via `test/deck-from-manifest-e2e`: `tests/ep133/test_deck_from_manifest_e2e.py` (5 cases) + `tests/ep133/fixtures/session_mode_manifest.json` (mirrors `_commitSessionTracks` output). Uses subprocess pattern matching `tests/test_canonical_tempos.py::_run_split`.
+- ✅ DONE (prior commit, Phase 1) — The format_profile patch step is now a first-class flag (`--profile`, `--all-drum`, `--play-mode`) on `deck-from-manifest`. Library-level coverage in `tests/ep133/test_deck_autogen.py`; end-to-end CLI coverage in `tests/ep133/test_deck_from_manifest_e2e.py`. No more regex sed step needed.
 
 ## Done when
 
-- Every `js_mocks/*.test.js` is exercised by pytest.
-- `STACKED_PR_PENDING` is empty.
-- `deck-from-manifest --profile drum` (or equivalent) is a first-class option, not an inline sed.
+- ✅ Every `js_mocks/*.test.js` is exercised by pytest.
+- ✅ `STACKED_PR_PENDING` is empty.
+- ✅ `deck-from-manifest --profile drum` (or equivalent) is a first-class option, not an inline sed.
+- ✅ `deck-from-manifest` end-to-end CLI test landed against a session-mode fixture.

--- a/tests/ep133/fixtures/session_mode_manifest.json
+++ b/tests/ep133/fixtures/session_mode_manifest.json
@@ -1,0 +1,88 @@
+{
+  "_comment": "Session-mode manifest fixture: mirrors what _commitSessionTracks (v0/src/m4l-js/stemforge_loader.v0.js:1526) writes after the user clicks COMMIT in the forge device. Each session_tracks[L][i] entry matches the dict built by _sessionTrackEntryFromClip (slot/file/start_offset_sec/end_offset_sec/clip_length_sec/mode + optional source_bpm captured pre-crop from warp_markers slope). Used by tests/ep133/test_deck_from_manifest_e2e.py. File paths are intentionally fictional — deck-from-manifest is pure-Python dict transform and never reads the WAVs.",
+  "track": "breaks_n_beats_fixture",
+  "source_audio": "/tmp/nonexistent/breaks_n_beats/source.wav",
+  "bpm": 92.0,
+  "session_tracks": {
+    "A": [
+      {
+        "slot": 0,
+        "file": "/tmp/nonexistent/breaks_n_beats/A/clip_000.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 2.608695652173913,
+        "clip_length_sec": 2.608695652173913,
+        "mode": "rotate",
+        "source_bpm": 92.0
+      },
+      {
+        "slot": 1,
+        "file": "/tmp/nonexistent/breaks_n_beats/A/clip_001.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 5.217391304347826,
+        "clip_length_sec": 5.217391304347826,
+        "mode": "trim",
+        "source_bpm": 88.5
+      },
+      {
+        "slot": 2,
+        "file": "/tmp/nonexistent/breaks_n_beats/A/clip_002.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 2.608695652173913,
+        "clip_length_sec": 2.608695652173913,
+        "mode": "rotate",
+        "source_bpm": 141.27
+      }
+    ],
+    "B": [
+      {
+        "slot": 0,
+        "file": "/tmp/nonexistent/breaks_n_beats/B/clip_000.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 5.217391304347826,
+        "clip_length_sec": 5.217391304347826,
+        "mode": "trim",
+        "source_bpm": 92.0
+      },
+      {
+        "slot": 1,
+        "file": "/tmp/nonexistent/breaks_n_beats/B/clip_001.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 2.608695652173913,
+        "clip_length_sec": 2.608695652173913,
+        "mode": "rotate",
+        "source_bpm": 92.0
+      }
+    ],
+    "C": [
+      {
+        "slot": 0,
+        "file": "/tmp/nonexistent/breaks_n_beats/C/clip_000.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 2.608695652173913,
+        "clip_length_sec": 2.608695652173913,
+        "mode": "rotate",
+        "source_bpm": 92.0
+      },
+      {
+        "slot": 1,
+        "file": "/tmp/nonexistent/breaks_n_beats/C/clip_001.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 2.608695652173913,
+        "clip_length_sec": 2.608695652173913,
+        "mode": "rotate",
+        "source_bpm": 184.0
+      }
+    ],
+    "D": [
+      {
+        "slot": 0,
+        "file": "/tmp/nonexistent/breaks_n_beats/D/clip_000.wav",
+        "start_offset_sec": 0.0,
+        "end_offset_sec": 10.434782608695652,
+        "clip_length_sec": 10.434782608695652,
+        "mode": "trim",
+        "source_bpm": 92.0
+      }
+    ]
+  }
+}

--- a/tests/ep133/test_deck_from_manifest_e2e.py
+++ b/tests/ep133/test_deck_from_manifest_e2e.py
@@ -1,0 +1,262 @@
+"""End-to-end CLI tests for ``stemforge deck-from-manifest``.
+
+Library-level coverage lives in ``tests/ep133/test_deck_autogen.py`` (which
+uses Click's in-process ``CliRunner``). This file complements it with a
+full-subprocess pattern matching ``tests/test_canonical_tempos.py``'s
+``_run_split`` helper: ``python -m stemforge.cli deck-from-manifest ...``
+runs the CLI exactly as the user invokes it, including module-import side
+effects we'd miss with an in-process runner.
+
+The fixture (``tests/ep133/fixtures/session_mode_manifest.json``) mirrors
+the dict shape ``_commitSessionTracks`` writes in the COMMIT flow — see
+``v0/src/m4l-js/stemforge_loader.v0.js:1526`` for the canonical authoring
+side. File paths in the fixture are intentionally fictional because
+``deck-from-manifest`` does not read any WAVs (verified by inspecting
+``stemforge/exporters/ep133/deck_autogen.py``); if that changes, this
+test will need to materialize real WAVs alongside the fixture.
+
+Closes the last "CLI integration gaps" task from
+``docs/issues/hardening-test-coverage-gaps.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Canonical session-mode fixture committed alongside this test. Kept beside
+# the test so the input shape is reviewable in the same diff as the
+# assertions that consume it.
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "session_mode_manifest.json"
+
+
+@dataclass
+class _CLIResult:
+    exit_code: int
+    output: str
+
+
+def _run_deck_from_manifest(manifest: Path, *extra_args: str) -> _CLIResult:
+    """Invoke ``python -m stemforge.cli deck-from-manifest`` as a subprocess.
+
+    Mirrors ``tests/test_canonical_tempos.py::_run_split``'s pattern. The
+    deck-from-manifest CLI is dirt-cheap (pure dict transform) so subprocess
+    overhead is fine; the value is exercising the real entry point including
+    Click registration and the per-command imports done inside the function
+    body (``deck_from_manifest_cmd`` lazy-imports ``deck_autogen``).
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "stemforge.cli",
+            "deck-from-manifest",
+            str(manifest),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return _CLIResult(exit_code=proc.returncode, output=proc.stdout + proc.stderr)
+
+
+def _staged_manifest(tmp_path: Path) -> Path:
+    """Copy the canonical fixture into a per-test tmp dir.
+
+    deck-from-manifest writes ``deck.yaml`` next to the manifest by default,
+    so staging into tmp_path keeps the test hermetic and lets ``--project``
+    name derivation (which reads ``manifest_path.parent.name``) produce
+    something stable across runs.
+    """
+    assert FIXTURE_PATH.is_file(), f"missing fixture: {FIXTURE_PATH}"
+    staged_dir = tmp_path / "curated"
+    staged_dir.mkdir(parents=True)
+    dest = staged_dir / "manifest.json"
+    shutil.copyfile(FIXTURE_PATH, dest)
+    return dest
+
+
+def test_deck_from_manifest_session_mode_smoke(tmp_path: Path) -> None:
+    """Fixture → CLI → ``deck.yaml`` exists + valid + row counts match input.
+
+    The fixture's session_tracks block has 3/2/2/1 entries on A/B/C/D
+    respectively. After deck-from-manifest the deck.yaml's groups should
+    have the same per-group pad counts (no spillover; all under the 12-pad
+    cap).
+    """
+    manifest = _staged_manifest(tmp_path)
+    result = _run_deck_from_manifest(manifest, "--project", "smoke_test")
+    assert result.exit_code == 0, result.output
+
+    deck_path = manifest.parent / "deck.yaml"
+    assert deck_path.is_file(), result.output
+
+    parsed = yaml.safe_load(deck_path.read_text())
+    # Top-level keys we always emit.
+    assert parsed["project"] == "smoke_test"
+    assert parsed["project_slot"] == 8  # default --project-slot
+    assert parsed["project_bpm"] == 92.0  # echoed from manifest's bpm field
+    assert parsed["time_sig"] == [4, 4]
+
+    # Per-group pad counts mirror the fixture's session_tracks counts.
+    expected_counts = {"A": 3, "B": 2, "C": 2, "D": 1}
+    for group, expected in expected_counts.items():
+        assert group in parsed["groups"], f"group {group} missing from deck"
+        assert len(parsed["groups"][group]["pads"]) == expected, (
+            f"group {group}: expected {expected} pads, got {len(parsed['groups'][group]['pads'])}"
+        )
+
+    # Default format-profile layout is preserved (no --profile/--all-drum).
+    assert parsed["groups"]["A"]["format_profile"] == "vocal"
+    assert parsed["groups"]["B"]["format_profile"] == "vocal"
+    assert parsed["groups"]["C"]["format_profile"] == "drum"
+    assert parsed["groups"]["D"]["format_profile"] == "texture"
+
+
+def test_deck_from_manifest_profile_drum_overrides_format_profile(
+    tmp_path: Path,
+) -> None:
+    """``--profile drum`` rewrites every populated group's format_profile.
+
+    Encodes the breaks-n-beats workflow where every group is a drum kit
+    and the prior "patch with sed" step is replaced by the CLI flag.
+    """
+    manifest = _staged_manifest(tmp_path)
+    result = _run_deck_from_manifest(manifest, "--profile", "drum", "--project", "drum_test")
+    assert result.exit_code == 0, result.output
+
+    parsed = yaml.safe_load((manifest.parent / "deck.yaml").read_text())
+    for group in ("A", "B", "C", "D"):
+        assert parsed["groups"][group]["format_profile"] == "drum", (
+            f"group {group}: expected drum, got {parsed['groups'][group]['format_profile']}"
+        )
+        # Each pad inherits drum's default play_mode = "key" (see
+        # DEFAULT_PLAY_MODE in deck_autogen.py + feedback_drum_profile_defaults.md).
+        for pad in parsed["groups"][group]["pads"]:
+            assert pad["play_mode"] == "key", (
+                f"pad {pad}: expected play_mode=key (drum default), got {pad.get('play_mode')!r}"
+            )
+
+
+def _strip_source_paths(plan: dict) -> dict:
+    """Remove ``source:`` keys from every pad row.
+
+    Each pad's ``source`` field is the absolute path of the manifest the
+    deck was generated from. When comparing two runs that staged the
+    fixture in different tmp dirs, this field will legitimately differ
+    even if every other behavior-bearing field matches. Strip it so the
+    comparison focuses on layout/format/play_mode semantics.
+    """
+    out = json.loads(json.dumps(plan))  # cheap deep-copy
+    for gblock in out.get("groups", {}).values():
+        for pad in gblock.get("pads", []):
+            pad.pop("source", None)
+    return out
+
+
+def test_deck_from_manifest_all_drum_alias(tmp_path: Path) -> None:
+    """``--all-drum`` is a documented shortcut for ``--profile drum``.
+
+    Runs the CLI twice against staged copies of the same fixture and
+    asserts the resulting deck plans are equivalent (modulo each pad's
+    ``source:`` field, which is the absolute manifest path and therefore
+    differs by tmp dir). If the two flags ever diverge in any
+    behavior-bearing field, the "shortcut" framing in the CLI help is a lie.
+    """
+    # First run: --profile drum.
+    manifest_a = _staged_manifest(tmp_path / "a")
+    result_a = _run_deck_from_manifest(manifest_a, "--profile", "drum", "--project", "shared_name")
+    assert result_a.exit_code == 0, result_a.output
+    deck_a = yaml.safe_load((manifest_a.parent / "deck.yaml").read_text())
+
+    # Second run: --all-drum.
+    manifest_b = _staged_manifest(tmp_path / "b")
+    result_b = _run_deck_from_manifest(manifest_b, "--all-drum", "--project", "shared_name")
+    assert result_b.exit_code == 0, result_b.output
+    deck_b = yaml.safe_load((manifest_b.parent / "deck.yaml").read_text())
+
+    assert _strip_source_paths(deck_a) == _strip_source_paths(deck_b), (
+        "deck.yaml differs between --profile drum and --all-drum "
+        "(after stripping per-tmp-dir source paths)"
+    )
+
+
+def test_deck_from_manifest_play_mode_propagates(tmp_path: Path) -> None:
+    """``--play-mode oneshot`` overrides the per-profile default on every row.
+
+    Without the flag, group C (drum) would default to play_mode=key. With
+    the flag, every pad — including drum-group pads — must end up oneshot.
+    """
+    manifest = _staged_manifest(tmp_path)
+    result = _run_deck_from_manifest(
+        manifest, "--play-mode", "oneshot", "--project", "play_mode_test"
+    )
+    assert result.exit_code == 0, result.output
+
+    parsed = yaml.safe_load((manifest.parent / "deck.yaml").read_text())
+    seen_any = False
+    for group in ("A", "B", "C", "D"):
+        for pad in parsed["groups"][group]["pads"]:
+            assert pad["play_mode"] == "oneshot", (
+                f"group {group} pad {pad.get('pad')}: expected play_mode=oneshot, "
+                f"got {pad.get('play_mode')!r}"
+            )
+            seen_any = True
+    assert seen_any, "no pads to assert against — fixture/CLI regression"
+
+
+def test_deck_from_manifest_per_clip_bpm_preserved(tmp_path: Path) -> None:
+    """Per-clip ``source_bpm`` from the manifest threads into the deck row.
+
+    The COMMIT flow captures each clip's warp_bpm (via warp_markers slope)
+    pre-crop and writes it into ``session_tracks[L][i].source_bpm``. The
+    deck row must carry that value forward as ``source_bpm`` so kit
+    synthesis can skip duration-based inference. Per-clip BPM should NOT
+    be overwritten by the project-level BPM — they're independent fields.
+    """
+    manifest = _staged_manifest(tmp_path)
+    result = _run_deck_from_manifest(manifest, "--project", "bpm_test")
+    assert result.exit_code == 0, result.output
+
+    parsed = yaml.safe_load((manifest.parent / "deck.yaml").read_text())
+    project_bpm = parsed["project_bpm"]
+    assert project_bpm == 92.0
+
+    # The fixture has heterogeneous per-clip source_bpm values
+    # (88.5 / 141.27 / 184.0 etc.) — all are deliberately != project_bpm so
+    # a "copy project_bpm everywhere" bug would be visible.
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    expected_bpms_by_slot = {}
+    for group, entries in fixture["session_tracks"].items():
+        expected_bpms_by_slot[group] = {e["slot"]: e["source_bpm"] for e in entries}
+
+    # Walk every produced pad and assert source_bpm matches the fixture's
+    # entry for the pad's (group, slot:N) coordinates.
+    saw_non_project_bpm = False
+    for group, gblock in parsed["groups"].items():
+        for pad in gblock["pads"]:
+            origin = pad["group"]
+            slot = int(pad["clip"].removeprefix("slot:"))
+            expected = expected_bpms_by_slot[origin][slot]
+            assert "source_bpm" in pad, (
+                f"group {group} pad {pad.get('pad')}: missing source_bpm "
+                f"(fixture had {expected} for origin {origin} slot {slot})"
+            )
+            assert pad["source_bpm"] == pytest.approx(expected), (
+                f"group {group} pad {pad.get('pad')}: source_bpm={pad['source_bpm']} "
+                f"!= fixture {expected} (origin {origin} slot {slot})"
+            )
+            if pad["source_bpm"] != project_bpm:
+                saw_non_project_bpm = True
+    assert saw_non_project_bpm, (
+        "every per-clip source_bpm equaled project_bpm — fixture or pipeline "
+        "lost the per-clip BPM signal we're trying to assert here"
+    )


### PR DESCRIPTION
## Summary

- Adds an end-to-end CLI test for `stemforge deck-from-manifest` against a session-mode manifest fixture matching the COMMIT-flow output shape (`v0/src/m4l-js/stemforge_loader.v0.js::_commitSessionTracks`). Uses the same subprocess pattern as `tests/test_canonical_tempos.py::_run_split` so the real entry point is exercised end-to-end.
- Lands `tests/ep133/fixtures/session_mode_manifest.json` (3/2/2/1 entries across A/B/C/D with heterogeneous per-clip `source_bpm` values) and `tests/ep133/test_deck_from_manifest_e2e.py` (5 cases: smoke, `--profile drum`, `--all-drum` alias parity, `--play-mode oneshot` propagation, per-clip BPM preservation).
- Closes the last open task on `docs/issues/hardening-test-coverage-gaps.md` and marks the issue Closed.

Scope is purely additive — no production code touched (`stemforge/`, `m4l/`, JS, etc. all unchanged). Sibling agents on `stemforge/cli.py` / `v0/src/m4l-*` lanes are unaffected.

## Notes / findings

- `deck_autogen.py` is a pure dict transform — no WAV reads. Verified before relying on fictional fixture paths.
- One harmless test issue surfaced during authoring (NOT a product bug): comparing `--profile drum` and `--all-drum` deck outputs across two tmp dirs naturally diverges in the per-pad `source:` field (absolute manifest path). Test compares with that field stripped — every other behavior-bearing field is identical, so the "shortcut" framing in the CLI help holds.
- Full-suite `pytest -q` shows 844 passed / 1 failed / 11 skipped on this branch. The 1 failure is `test_canonical_tempos.py::test_canonical_track_first_downbeat_matches_truth[ooh_la_la]` — a known pre-existing environment flake (`canonical_tempos full-suite torch double-init`) documented in MEMORY (`feedback_canonical_tempos_full_suite_env.md`), reproducible on `main`, completely unrelated to this PR.

## Test plan

- [x] `uv run pytest tests/ep133/test_deck_from_manifest_e2e.py -v` → 5/5 pass
- [x] `uv run ruff check tests/ep133/test_deck_from_manifest_e2e.py` → clean
- [x] `uv run ruff format --check tests/ep133/test_deck_from_manifest_e2e.py` → clean
- [x] Full suite: 844 passed (1 pre-existing canonical_tempos flake unrelated to changes)

Generated with [Claude Code](https://claude.com/claude-code)
