### PR TITLE
chore(lint): ruff format tests/test_canonical_tempos.py

### DIFF
--- a/tests/test_canonical_tempos.py
+++ b/tests/test_canonical_tempos.py
@@ -39,6 +39,7 @@ from fixtures.known_tempos import CANONICAL_TRACKS, CanonicalTempo
 # imports torch a second time after earlier tests have already pulled it in.
 # Running each split as a fresh subprocess sidesteps the import state entirely.
 
+
 @dataclass
 class _SplitResult:
     exit_code: int
@@ -47,8 +48,17 @@ class _SplitResult:
 
 def _run_split(source: Path, out: Path) -> _SplitResult:
     proc = subprocess.run(
-        [sys.executable, "-m", "stemforge.cli", "split",
-         str(source), "--output", str(out), "--pipeline", "arrangement"],
+        [
+            sys.executable,
+            "-m",
+            "stemforge.cli",
+            "split",
+            str(source),
+            "--output",
+            str(out),
+            "--pipeline",
+            "arrangement",
+        ],
         capture_output=True,
         text=True,
         timeout=600,


### PR DESCRIPTION
Pure formatting fix. PR #70 landed a `subprocess.run([...])` call that wasn't formatted to ruff's default line-break style. The `Lint + format` CI job rejects it.

Three open downstream PRs (#74, #75, #76) inherit the failure since they all branch off main. Once this merges, their CI will go green on rebase.

## Test plan

- [x] `uv run ruff format --check tests/test_canonical_tempos.py` → clean.
- [x] `uv run pytest tests/test_canonical_tempos.py` (isolated) → still 6/6 pass (no logic change).

Generated with [Claude Code](https://claude.com/claude-code)
