### PR TITLE
fix(m4l): defensive guard on _collapseToLoopRegion for 2nd-bounce safety

### DIFF
--- a/docs/issues/loop-region-collapse-second-bounce.md
+++ b/docs/issues/loop-region-collapse-second-bounce.md
@@ -1,6 +1,12 @@
 # Loop-region collapse: second-bounce behavior unverified
 
-**Status:** Open — captured 2026-05-12.
+**Status:** Mitigated by defensive guard (2026-05-12 — `fix/loop-region-second-bounce-guard`).
+`_collapseToLoopRegion` now refuses to write markers when loop bounds already match
+the play region (Mode 2 no-op) or fall outside the play region (Mode 3 stale
+coordinates); the latter case also emits a `post()` warning. The helper is
+safe-by-construction in all three failure modes; pending optional on-device
+confirmation of which mode Live actually exhibits, but code correctness no
+longer depends on the answer.
 
 ## Background
 
@@ -20,17 +26,27 @@ If Live preserves the loop region after crop (now relative to the new extent), a
 
 If Live preserves `loop_start`/`loop_end` at OLD coordinates (sample positions that no longer match the cropped audio), we could write garbage to the markers. **This is the failure mode to verify.**
 
-## How to test
+## How to confirm which mode Live exhibits
+
+The guard makes the code safe regardless of Live's actual behavior, but
+understanding which mode is in play is still useful context for future LOM
+work. To confirm on-device (requires `.pkg` rebuild + reinstall first):
 
 1. In Live, load a clip with a loop region inside the play region (e.g. play 0..8 bars, loop 2..6 bars).
 2. Bounce via `sf-remote fire forge bounceTracks <path>`. Verify the bounced WAV is the loop region.
 3. **Without reloading the original**, bounce again with the same command.
-4. Inspect the second-bounce output: same audio? Truncated? Errors in Max console?
+4. Inspect the Max console:
+   - No `[StemForge] _collapseToLoopRegion: loop bounds ... outside play region` warning → Mode 1 or Mode 2 (safe).
+   - That warning appears → Mode 3 (helper correctly refused to corrupt; bounce 2 falls through to a plain `crop` of the current play region).
+5. Inspect the second-bounce WAV: should match the first-bounce WAV in all modes.
 
 ## Done when
 
-Either:
-- We confirm Live resets loop bounds on crop (then the helper is safe on second bounce — no action needed).
-- We find a failure mode and add an early-return when post-crop loop bounds match play bounds.
+Mitigation has landed. Optional follow-up: confirm Mode on-device and record
+the answer in `memory/feedback_loop_region_canonical_for_materialize.md`.
 
-Also: add a JS mock test that exercises this case once we know what to assert.
+The JS mock tests added alongside the guard live in `tests/js_mocks/test_bounce.test.js`:
+
+- `_collapseToLoopRegion: skips when already collapsed (loop bounds == play bounds)`
+- `_collapseToLoopRegion: skips + warns when loop_end > end_marker (stale Mode 3)`
+- `_collapseToLoopRegion: skips when loop_start < 0 (defensive)`

--- a/tests/js_mocks/test_bounce.test.js
+++ b/tests/js_mocks/test_bounce.test.js
@@ -225,6 +225,138 @@ test('_collapseToLoopRegion: unit — looping=0 leaves markers alone', () => {
     assert.equal(props.end_marker, 9, 'untouched when looping=0');
 });
 
+// ── 6. 2nd-bounce defensive guards on _collapseToLoopRegion ─────────────────
+//
+// docs/issues/loop-region-collapse-second-bounce.md: when a clip is bounced a
+// 2nd time without reloading, Live's loop_start/loop_end behavior is unverified.
+// The guards in _collapseToLoopRegion make the helper safe-by-construction:
+//
+//   (a) skip when loop bounds == play bounds (Mode 2 no-op — avoids any LOM
+//       side effect from a same-value write).
+//   (b) skip when loop bounds fall outside the play region (Mode 3 stale-
+//       coordinate garbage), and emit a `post()` warning.
+//   (c) skip when loop_start < 0 (defensive — impossible in practice).
+//
+// These tests assert each guard fires by verifying the markers are not
+// rewritten when the guard should apply.
+//
+// Strategy: wrap LiveAPI.prototype.set to count set() calls against the clip
+// path, so we can assert "no write happened" rather than just "value
+// happened to equal the pre-state".
+
+function instrumentSetSpy(ctx) {
+    var spy = { calls: [] };
+    var origSet = ctx.LiveAPI.prototype.set;
+    ctx.LiveAPI.prototype.set = function (prop, value) {
+        spy.calls.push({ path: this._path, prop: prop, value: value });
+        return origSet.call(this, prop, value);
+    };
+    spy.restore = function () { ctx.LiveAPI.prototype.set = origSet; };
+    return spy;
+}
+
+test('_collapseToLoopRegion: skips when already collapsed (loop bounds == play bounds)', () => {
+    const { ctx, collapseToLoopRegion } = loadBounce();
+
+    // Non-trivial bounds — loop region exactly matches play region.
+    // Simulates Mode 1 after one crop (or Mode 2 reset).
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot({
+            warping: 1,
+            start_marker: 2, end_marker: 6,
+            looping: 1, loop_start: 2, loop_end: 6,
+        })])],
+    });
+
+    const spy = instrumentSetSpy(ctx);
+    const clipApi = new ctx.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    collapseToLoopRegion(clipApi);
+    spy.restore();
+
+    // The guard must skip ENTIRELY — no set() against start_marker or
+    // end_marker, not even a same-value no-op write.
+    const markerWrites = spy.calls.filter(c =>
+        c.prop === 'start_marker' || c.prop === 'end_marker'
+    );
+    assert.equal(markerWrites.length, 0,
+        'no marker writes when loop bounds already match play bounds; ' +
+        'got ' + JSON.stringify(markerWrites));
+
+    // And of course the seeded values stay put.
+    const props = getClipProps(0, 0);
+    assert.equal(props.start_marker, 2);
+    assert.equal(props.end_marker, 6);
+});
+
+test('_collapseToLoopRegion: skips + warns when loop_end > end_marker (stale Mode 3)', () => {
+    const { ctx, collapseToLoopRegion } = loadBounce();
+
+    // Simulates Mode 3: clip was cropped once (extent now 0..4) but Live
+    // preserved the pre-crop loop region at OLD coordinates (2..6). Writing
+    // loop_end=6 to end_marker would corrupt the 2nd bounce.
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot({
+            warping: 1,
+            start_marker: 0, end_marker: 4,
+            looping: 1, loop_start: 2, loop_end: 6,
+        })])],
+    });
+
+    const spy = instrumentSetSpy(ctx);
+    const clipApi = new ctx.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    collapseToLoopRegion(clipApi);
+    spy.restore();
+
+    const markerWrites = spy.calls.filter(c =>
+        c.prop === 'start_marker' || c.prop === 'end_marker'
+    );
+    assert.equal(markerWrites.length, 0,
+        'markers must NOT be touched when loop bounds exceed play region');
+
+    // Markers must still be at the seeded values.
+    const props = getClipProps(0, 0);
+    assert.equal(props.start_marker, 0);
+    assert.equal(props.end_marker, 4);
+
+    // Warning must appear on the Max console (state.logs is the post()
+    // capture buffer).
+    const warning = maxApi.state.logs.find(s =>
+        s.indexOf('outside play region') >= 0
+    );
+    assert.ok(warning,
+        'expected a post() warning about loop bounds outside play region; ' +
+        'logs were: ' + JSON.stringify(maxApi.state.logs));
+});
+
+test('_collapseToLoopRegion: skips when loop_start < 0 (defensive)', () => {
+    const { ctx, collapseToLoopRegion } = loadBounce();
+
+    // loop_start < 0 is impossible in real Live usage but the guard exists
+    // to make the function safe-by-construction against any corrupted state.
+    maxApi.seedLiveTree({
+        tracks: [makeTrack('A', [makeClipSlot({
+            warping: 1,
+            start_marker: 0, end_marker: 8,
+            looping: 1, loop_start: -1, loop_end: 4,
+        })])],
+    });
+
+    const spy = instrumentSetSpy(ctx);
+    const clipApi = new ctx.LiveAPI('live_set tracks 0 clip_slots 0 clip');
+    collapseToLoopRegion(clipApi);
+    spy.restore();
+
+    const markerWrites = spy.calls.filter(c =>
+        c.prop === 'start_marker' || c.prop === 'end_marker'
+    );
+    assert.equal(markerWrites.length, 0,
+        'markers must NOT be touched when loop_start is negative');
+
+    const props = getClipProps(0, 0);
+    assert.equal(props.start_marker, 0);
+    assert.equal(props.end_marker, 8);
+});
+
 // ── 7. Atomic-rename stub flow ──────────────────────────────────────────────
 // docs/issues/bounce-stub-race.md: _ensureDeckManifestStub writes to
 // ``<path>.tmp`` (NOT the final path), and commitOffsets renames .tmp →

--- a/v0/src/m4l-js/stemforge_loader.v0.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.js
@@ -1804,6 +1804,21 @@ function _warpBpmFromMarkers(clipApi) {
 // All four properties use the same unit (beats when warping=1, seconds
 // otherwise), so the swap is a 1:1 substitution. Loop bounds equal to play
 // bounds → no-op write but harmless.
+//
+// 2nd-bounce safety (see docs/issues/loop-region-collapse-second-bounce.md):
+// after a clip has been cropped once, Live's behavior for `loop_start`/
+// `loop_end` on a re-bounced clip is unverified. We can't drive Live from a
+// worktree to confirm which of three modes applies, so this helper is made
+// safe-by-construction:
+//
+//   Mode 1 — loop bounds preserved relative to new extent → re-collapse is
+//     idempotent. Safe (the guard below skips a no-op write).
+//   Mode 2 — loop bounds reset to match play bounds → guard skips entirely.
+//   Mode 3 — loop bounds preserved at OLD coordinates that no longer map to
+//     the cropped audio (e.g. loop_end past the new end_marker). DANGEROUS:
+//     writing those stale coordinates onto start_marker/end_marker would
+//     corrupt the 2nd bounce. Guard refuses to write and emits a `post()`
+//     warning so the operator sees what happened in the Max console.
 function _collapseToLoopRegion(clipApi) {
     var looping = 0;
     try { looping = _getLomNumber(clipApi, "looping") | 0; } catch (_) { return; }
@@ -1814,6 +1829,37 @@ function _collapseToLoopRegion(clipApi) {
         le = _getLomNumber(clipApi, "loop_end");
     } catch (_) { return; }
     if (!isFinite(ls) || !isFinite(le) || le <= ls) return;
+
+    // 2nd-bounce safety guards. Read the current play region so we can
+    // compare loop bounds against it.
+    var sm = 0, em = 0;
+    try {
+        sm = _getLomNumber(clipApi, "start_marker");
+        em = _getLomNumber(clipApi, "end_marker");
+    } catch (_) { return; }
+    if (!isFinite(sm) || !isFinite(em)) return;
+
+    // Guard 1: loop bounds already match play bounds. This is Mode 2 (or
+    // Mode 1 with bounds that happen to equal play bounds). Either way the
+    // write would be a no-op; skip to avoid emitting any LOM side effect.
+    if (ls === sm && le === em) return;
+
+    // Guard 2: loop bounds fall outside the current play region. This is
+    // either Mode 3 stale-coordinate garbage from a prior crop, or a
+    // negative loop_start (impossible in practice but defensive). Refuse
+    // to write — silently corrupting the 2nd-bounce WAV is the worst
+    // possible outcome.
+    var EPS = 1e-6;
+    if (ls < 0 || le > em + EPS) {
+        post(
+            "[StemForge] _collapseToLoopRegion: loop bounds (" +
+            ls + ".." + le + ") outside play region (" +
+            sm + ".." + em + "), skipping collapse — " +
+            "clip may be a re-bounce of an already-cropped clip.\n"
+        );
+        return;
+    }
+
     try { clipApi.set("start_marker", ls); } catch (_) {}
     try { clipApi.set("end_marker", le); } catch (_) {}
 }

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
@@ -1804,6 +1804,21 @@ function _warpBpmFromMarkers(clipApi) {
 // All four properties use the same unit (beats when warping=1, seconds
 // otherwise), so the swap is a 1:1 substitution. Loop bounds equal to play
 // bounds → no-op write but harmless.
+//
+// 2nd-bounce safety (see docs/issues/loop-region-collapse-second-bounce.md):
+// after a clip has been cropped once, Live's behavior for `loop_start`/
+// `loop_end` on a re-bounced clip is unverified. We can't drive Live from a
+// worktree to confirm which of three modes applies, so this helper is made
+// safe-by-construction:
+//
+//   Mode 1 — loop bounds preserved relative to new extent → re-collapse is
+//     idempotent. Safe (the guard below skips a no-op write).
+//   Mode 2 — loop bounds reset to match play bounds → guard skips entirely.
+//   Mode 3 — loop bounds preserved at OLD coordinates that no longer map to
+//     the cropped audio (e.g. loop_end past the new end_marker). DANGEROUS:
+//     writing those stale coordinates onto start_marker/end_marker would
+//     corrupt the 2nd bounce. Guard refuses to write and emits a `post()`
+//     warning so the operator sees what happened in the Max console.
 function _collapseToLoopRegion(clipApi) {
     var looping = 0;
     try { looping = _getLomNumber(clipApi, "looping") | 0; } catch (_) { return; }
@@ -1814,6 +1829,37 @@ function _collapseToLoopRegion(clipApi) {
         le = _getLomNumber(clipApi, "loop_end");
     } catch (_) { return; }
     if (!isFinite(ls) || !isFinite(le) || le <= ls) return;
+
+    // 2nd-bounce safety guards. Read the current play region so we can
+    // compare loop bounds against it.
+    var sm = 0, em = 0;
+    try {
+        sm = _getLomNumber(clipApi, "start_marker");
+        em = _getLomNumber(clipApi, "end_marker");
+    } catch (_) { return; }
+    if (!isFinite(sm) || !isFinite(em)) return;
+
+    // Guard 1: loop bounds already match play bounds. This is Mode 2 (or
+    // Mode 1 with bounds that happen to equal play bounds). Either way the
+    // write would be a no-op; skip to avoid emitting any LOM side effect.
+    if (ls === sm && le === em) return;
+
+    // Guard 2: loop bounds fall outside the current play region. This is
+    // either Mode 3 stale-coordinate garbage from a prior crop, or a
+    // negative loop_start (impossible in practice but defensive). Refuse
+    // to write — silently corrupting the 2nd-bounce WAV is the worst
+    // possible outcome.
+    var EPS = 1e-6;
+    if (ls < 0 || le > em + EPS) {
+        post(
+            "[StemForge] _collapseToLoopRegion: loop bounds (" +
+            ls + ".." + le + ") outside play region (" +
+            sm + ".." + em + "), skipping collapse — " +
+            "clip may be a re-bounce of an already-cropped clip.\n"
+        );
+        return;
+    }
+
     try { clipApi.set("start_marker", ls); } catch (_) {}
     try { clipApi.set("end_marker", le); } catch (_) {}
 }


### PR DESCRIPTION
## Summary
- `_collapseToLoopRegion` is now safe-by-construction against the unverified 2nd-bounce edge case documented in `docs/issues/loop-region-collapse-second-bounce.md`. Two new guards (skip when loop bounds already equal play bounds; skip + `post()` warning when loop bounds fall outside the play region) make all 3 hypothesized Live behaviors produce correct output.
- 3 new mock tests in `tests/js_mocks/test_bounce.test.js` use a `LiveAPI.prototype.set` spy to assert no marker writes happen on the guarded paths. All 13 tests pass; the 6 existing tests from PR #63 still hold.
- JS source-of-truth dual-sync verified: `v0/src/m4l-js/stemforge_loader.v0.js` and `v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js` are byte-identical (per `feedback_js_source_of_truth.md`).
- Issue file flipped from "Open" to "Mitigated by defensive guard"; the "How to test" section is reframed as "How to confirm which mode Live exhibits" — informational now, not gating.

## Background
PR #63 added `_collapseToLoopRegion` so that a looping clip's loop region (not its full play region) is materialized into the bounced WAV. Hardware-validated for first-bounce; second-bounce behavior was untested. The issue file identified 3 possible Live behaviors, one of which (Mode 3 — Live preserves stale `loop_start`/`loop_end` past the new `end_marker`) would silently corrupt the 2nd bounce. We can't drive Live from a worktree to confirm which mode applies, so this PR makes the code safe in all 3.

## Test plan
- [x] `node --test tests/js_mocks/test_bounce.test.js` — 13/13 pass (10 prior + 3 new)
- [x] `uv run pytest -q` — 856 pass / 11 skip. The single failure (`test_canonical_tempos.py::...[ooh_la_la]`) is the pre-existing reconciler-pick flake (see `memory/feedback_canonical_tempos_full_suite_env.md` and `memory/project_reconciler_drums_vs_mix.md`); passes in isolation, unrelated to JS loader changes.
- [x] `diff` of source vs deploy-copy of `stemforge_loader.v0.js` — identical
- [ ] On-device confirmation: requires `.pkg` rebuild + reinstall to take effect on-device. Not done from this worktree (per `feedback_test_deploy_discipline.md`). Deferred to whoever next runs an end-to-end bounce on hardware.

## Notes
- The guard cannot claim Live's actual 2nd-bounce behavior is known — only that the code is safe-by-construction. On-device run with Max console open should reveal whether the new `outside play region` warning ever fires.
- No callers of `_collapseToLoopRegion` were refactored; behavior unchanged for first-bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
