### PR TITLE
docs(configurator): commit Phase 3+ specs from new_specs/ into docs/configurator/

### DIFF
--- a/docs/configurator/PHASE_3_FRESH_SESSION_HANDOFF.md
+++ b/docs/configurator/PHASE_3_FRESH_SESSION_HANDOFF.md
@@ -1,0 +1,142 @@
+# Fresh Session Handoff — Configurator Phase 3
+
+Paste this verbatim at the start of a fresh Claude Code session.
+
+---
+
+````
+Picking up StemForge configurator work. Hardening complete; Phase 1 + 2 +
+2.5 complete (commits on `feat/hardening-hw3-hw4-finish`, then merged).
+Resuming with Phase 3.
+
+## Read first, in order
+
+1. `docs/configurator/STEMFORGE_CONFIGURATOR_SPEC_v4.md` — active spec. **v4 is current**;
+   v3 is superseded (archived under `docs/configurator/archive/`). The
+   "Changes since v3" block at the top calls out Decision 16 (per-group
+   sample format) which is NEW since the last session and is load-bearing
+   for the priority workflow.
+2. `docs/configurator/STEMFORGE_TOP3_WORKFLOWS.md` — the three target use cases the
+   configurator is being built to enable. Read carefully; the priority
+   workflow has shifted.
+3. `docs/STEMFORGE_HARDENING_SPEC.md` + `docs/HARDENING_VERIFICATION.md` —
+   foundation. Read R6 + R7 in the verification's §4 explicitly; both
+   apply during Phase 3 work.
+
+## What changed in the previous session
+
+- **Phase 2 complete:** abstract scene model in `stemforge/scene_model/`,
+  EP-133 projector refactored, byte-identity gate green, JS arrangement
+  reader emits `{schema_version: 2, songs: []}` shape.
+- **Phase 2.5 emerged:** COMMIT was walking session view only, so
+  arrangement-only edits were invisible. Fixed by walking both views,
+  dedup by file_path, slot-claim 0..19. Architectural insight:
+  `session_tracks` is a slot table, not a view dump.
+- **Spec went v3 → v4:** Decision 16 (per-group sample format) was added
+  to support the hip-hop verse-swap workflow. Without it, 24 verses
+  won't fit in EP-133's 64 MB memory at uniform stereo 48 kHz.
+
+## Priority shift — read this carefully
+
+The previous session had Workflow #1 (EP-133 + Chompi MIDI-synced)
+ranked highest. **The priority is now a fourth workflow not in the doc:**
+
+**Workflow #3a — hip-hop verse-swap deck.** EP-133 only. Single scene,
+four groups: A = primary verses (12 vocal pads), B = alt verses + hooks
+(12 pads), C = drum corpus (12 pads), D = texture/IDM (12 pads).
+Performance gesture: trigger a verse on Group A, swap drum breaks from
+Group C underneath the same vocal mid-verse.
+
+**Why this is the new priority:**
+- It's the closest "real workflow you can ship" given current hardware.
+- It's EP-133 only — skips the Chompi projector dependency.
+- It's single-scene Workflow B — skips splice editor and scene
+  structure work.
+- It's the workflow the user is most excited about.
+
+**What it specifically requires from configurator work** (per
+`STEMFORGE_TOP3_WORKFLOWS.md` and the v4 spec):
+- All of Phase 3 EXCEPT projectors 3.5–3.6 (Koala, Chompi). EP-133 only.
+- Phase 4.1–4.5 (scene strip, pad canvas, inspector, validation, audio
+  preview) plus 4.6 (slicer mini-UI).
+- SKIP Phase 4.7 (splice editor) and 4.8 (multi-target export).
+- **Decision 16 (per-group sample format)** must land — vocal verses at
+  mono 24 kHz are what makes the memory math work.
+
+That's roughly 60% of v1's full surface, ordered for fastest time-to-
+performance.
+
+## Phase 3 starting point
+
+Per the v4 spec §Plan, Phase 3 is:
+1. Local Python HTTP server (`tools/m4l_configurator_server.py`)
+2. New `m4l-devices` repo with strip device
+3. Popup shell via `[jweb]` pointing at `localhost:<port>`
+4. (Skipped for now) port Koala + Chompi exporters
+
+**Three design calls before code starts:**
+
+a. **Frontend stack.** SolidJS leading per spec; React acceptable.
+   Decide based on what you can iterate fast in. Not load-bearing for
+   the architecture — both work.
+
+b. **HTTP server API shape.** Per Decision 15, server is an
+   intent-receiver (not a thin file-writing proxy). Endpoints should be
+   intent-shaped (`POST /intent/commit`, `POST /intent/assign-pad`)
+   rather than CRUD. Worth ~30 min of design before code.
+
+c. **Where audio_hash population lives.** Per Phase 2 loose-end #1,
+   `audio_hash` is empty string at COMMIT time today. Phase 3 should
+   wire hash population somewhere — likely the Python server when it
+   ingests COMMIT output, but could also be JS-side. Affects
+   reconciliation logic (Decision 14 says implicit slot-claim is the
+   seed; explicit user assignment overrides). Worth deciding before
+   code touches the slot-table reconciliation path.
+
+## Forge work in parallel (does not block configurator)
+
+The user is forging 5 more hip-hop tracks to bring the verse-swap
+deck to 12 songs total. **This work is independent of Phase 3 and runs
+in parallel.** Configurator doesn't need to know about it; just be
+aware that the manifest pool will expand during Phase 3 and the popup
+should handle a project that references manifests added after project
+creation gracefully.
+
+## Discipline holds from prior phases
+
+- Per-PR scope, not big-bang commits.
+- §15 must-keep-green path-IDs from v4 stay green through all Phase 3
+  work. The Phase 1 byte-identity gate (`test_song_export_parity`)
+  stays green throughout.
+- R6 sentinel triple isolation: configurator work shouldn't touch
+  `cli.py`'s `refine_bpm` call sites. If it does, run the sentinels
+  explicitly per commit.
+- R7 verify-load layered coverage: any new LOM-binding JS in the strip
+  device needs Tier-3 mock tests; verify-load won't catch its bugs.
+- Honesty discipline from prior bundles: surface drift between spec
+  and reality rather than rationalizing.
+
+## What I do NOT want
+
+- Don't start Phase 4 work in parallel with Phase 3. Sequence them.
+- Don't port Koala or Chompi projectors yet — both are deferred until
+  after the verse-swap deck ships.
+- Don't add scene structure or splice editor UI to Phase 4 — single-
+  scene Workflow B is the priority surface.
+- Don't redesign the spec without flagging it. v4 is the active doc.
+
+## Immediate next step
+
+Make the three design calls (a–c above), document them as a short PR
+or `docs/phase3-decisions.md` note, then start Phase 3.1 (HTTP server
+skeleton). The user is around for design discussion if any of the
+three calls need a back-and-forth.
+````
+
+---
+
+After Phase 3 lands cleanly, the next prompt covers the Phase 4 minimum
+viable surface (pad canvas + inspector + slicer + audio preview +
+Decision 16 implementation). Phase 4.7 (splice editor) and 4.8 (multi-
+target export) get their own prompts later as separate workflows
+require them.

--- a/docs/configurator/README.md
+++ b/docs/configurator/README.md
@@ -1,0 +1,38 @@
+# StemForge Configurator
+
+Design docs and execution plans for the configurator subsystem — a target-agnostic abstract scene model + 2D editor UI for building hardware-sampler projects.
+
+## Status (as of v0.2.0)
+
+- **Phase 1** ✅ shipped — `stemforge/scene_model/`, `AbstractProjector`, EP-133 projector with byte-identity gate, `re-anchor --then-curate`.
+- **Phase 2** ✅ shipped — full `Project → Song → SceneSpec → GroupSpec → PadSpec` schema, `Ep133Projector.project_from_spec`, `export-song --write-spec`, `{schema_version: 2, songs: []}` reader.
+- **Phase 2.5** ✅ shipped — COMMIT walks arrangement view too (was session-only); `session_tracks` is a slot table, not a view dump.
+- **Phase 3** — not started. M4L device + HTTP server + popup shell.
+- **Phase 4** — not started. Editor UI (scene strip, pad canvas, inspector, slicer).
+- **Phase 5** — not started. Locator sync + skill bindings.
+
+The breaks-n-beats1 `.ppak` shipped in v0.2.0 hardware-validates the EP-133 pipeline end-to-end via the CLI path (`deck-from-manifest` + `build-deck`). The configurator adds a UI on top of this proven foundation.
+
+## Files in this directory
+
+| File | What it is |
+|---|---|
+| [`STEMFORGE_CONFIGURATOR_SPEC_v4.md`](STEMFORGE_CONFIGURATOR_SPEC_v4.md) | **Active spec.** Goal, scope, load-bearing decisions (1–16), 5-phase plan, risks. |
+| [`STEMFORGE_TOP3_WORKFLOWS.md`](STEMFORGE_TOP3_WORKFLOWS.md) | The three target use cases the configurator enables. **Priority has shifted to Workflow #3a (verse-swap deck)** — see the next file. |
+| [`VERSE_SWAP_DECK_PLAN.md`](VERSE_SWAP_DECK_PLAN.md) | Execution plan for the verse-swap workflow — the minimum surface that ships first. Decision 16 (per-group sample rate) is the key new capability. |
+| [`PHASE_3_FRESH_SESSION_HANDOFF.md`](PHASE_3_FRESH_SESSION_HANDOFF.md) | Paste-this-at-fresh-session brief. Required reading order, what changed in the last session, the 3 design calls that gate Phase 3 start. |
+| [`archive/`](archive/) | Superseded specs: v2, v3. |
+| [`research/`](research/) | Background research bundles (export configurator design + testability + prior art + UX inventory). |
+
+## Where to start
+
+If you're picking up configurator work for the first time:
+
+1. Read [`STEMFORGE_CONFIGURATOR_SPEC_v4.md`](STEMFORGE_CONFIGURATOR_SPEC_v4.md) §Goal and §Scope.
+2. Read [`STEMFORGE_TOP3_WORKFLOWS.md`](STEMFORGE_TOP3_WORKFLOWS.md) to ground the design in real use cases.
+3. Read [`PHASE_3_FRESH_SESSION_HANDOFF.md`](PHASE_3_FRESH_SESSION_HANDOFF.md) for the current entry point — it documents the 3 design calls that gate writing any code.
+4. If specifically working the verse-swap deck: also read [`VERSE_SWAP_DECK_PLAN.md`](VERSE_SWAP_DECK_PLAN.md) — it has the realistic memory budget math and the slice-by-slice execution plan.
+
+## Foundation
+
+The configurator builds on the [hardening spec](../STEMFORGE_HARDENING_SPEC.md) which closed 2026-05-08 (verification: [`../HARDENING_VERIFICATION.md`](../HARDENING_VERIFICATION.md)). Phase 1 was unblocked the moment hardening's acceptance gate met. Phases 1–2.5 are in main.

--- a/docs/configurator/STEMFORGE_CONFIGURATOR_SPEC_v4.md
+++ b/docs/configurator/STEMFORGE_CONFIGURATOR_SPEC_v4.md
@@ -1,0 +1,687 @@
+# StemForge Configurator Spec
+
+**Status:** active, **v4**. Hardening pass complete (2026-05-08
+`HARDENING_VERIFICATION.md`). Phase 1 + Phase 2 + Phase 2.5 complete.
+Configurator work is unblocked.
+**Companions:** `STEMFORGE_HARDENING_SPEC.md` (foundation),
+`HARDENING_VERIFICATION.md` (acceptance + lessons),
+`STEMFORGE_TOP3_WORKFLOWS.md` (target use cases),
+`EXPORT_CONFIGURATOR_PLAN_v4.md` (archived reasoning),
+four input bundles (design, testability, prior-art, UX inventory).
+
+## Changes since v3
+
+- **Decision 16 NEW** — per-group sample format settings (mono/stereo,
+  sample rate). Motivated by the hip-hop verse-swap workflow where 24
+  vocal pads at stereo 48 kHz won't fit in EP-133's 64 MB cap, but at
+  mono 24 kHz they do. Format is per-group (`vocal`, `drum`, `texture`,
+  `preserve_source` profiles), not per-pad. Memory-budget validation
+  surfaces overflow in popup before export.
+
+## Changes since v2 (v2 → v3, preserved here)
+
+- **Decision 9 clarified** — Live's native primitives (Consolidate Time
+  to New Scene, Capture and Insert Scene, Tab-drag, Cmd-J) are the
+  canonical arrangement↔session bridge.
+- **Decision 12 NEW** — Workflow A (time-based scenes) and Workflow B
+  (free clip-to-pad kit) are equally first-class.
+- **Decision 13 NEW** — clip identity by content (audio_hash); same
+  audio appearing in multiple places is one clip.
+- **Decision 14 NEW** — pad canvas is the slot table. Explicit user
+  assignment, not implicit slot-claim.
+- **Decision 15 NEW** — slot table has a single writer (HTTP server).
+- **Schema simplification** — `SceneSpec.source_song_id` and
+  `source_bar_range` become optional metadata.
+- **Risks updated** — R6/R7 retained; R8 added for slot-claim contract.
+
+## Goal
+
+Replace stemforge's EP-133-specific export pipeline with a **target-agnostic
+abstract scene model** that can be projected onto any compatible hardware
+sampler. Provide a 2D editor UI for configuring projects against this model.
+Connect arrangement view, session view, and curation through a unified
+workflow.
+
+## Why
+
+Today, stemforge has three feature areas — arrangement, curation, and EP-133
+export — that share concepts but don't share code. The export pipeline is
+entangled with EP-133's specific topology (4 groups, 12 pads, 99 scenes).
+Adding a new target (Koala, Chompi, MPC, SP-404) means duplicating the
+plumbing.
+
+The configurator does three things:
+
+1. **Lifts shared concepts** (scenes, groups, pads, tile/repeat math) out of
+   the EP-133 exporter into a target-agnostic layer.
+2. **Adds projectors** that map the abstract model onto specific hardware
+   topologies. EP-133 becomes one projector among several.
+3. **Provides a UI** for building and tweaking projects against the abstract
+   model, with multi-target export from one configuration.
+
+The deeper rationale: the user's actual workflow is "I have stems and clips,
+I want to perform/sample them on hardware." Today's pipeline is shaped by
+the export format. The configurator inverts this — the workflow shapes the
+data, and the export format is a projection.
+
+## Scope
+
+### v1 — what this spec covers
+
+**Core configurator:**
+- Abstract scene model with `Project → Song → Scene → Group → Pad` schema.
+- EP-133 projector with byte-identical parity to current
+  `stemforge export-song` output.
+- Koala projector (existing exporter ported to projector interface).
+- Chompi projector (existing exporter ported to projector interface).
+- Multi-target export from popup (select EP-133 / Koala / Chompi).
+- Configurator popup UI: scene strip, pad canvas with multi-axis selection,
+  inspector with bulk-apply, audio preview, validation warnings.
+- Slicer mini-UI: define named scenes by selecting bar ranges from
+  arrangement view (creative selection, not locator-driven).
+- Splice editor: cross-song scene splicing in the data model and UI.
+- Strip device with full operations surface: load, slice, recompute,
+  re-anchor, curate, export, open editor.
+
+**Multi-song support:**
+- Schema supports multiple songs from day one.
+- v1 UI forces n=1; multi-song UI surface deferred to v2.
+- Auto-grouping via pre-made template `.als` (default).
+- Auto-grouping via AppleScript keystroke (experimental flag, macOS
+  developer-only).
+
+**Workflow connections:**
+- `re-anchor --then-curate` flag: re-anchoring downbeat auto-triggers
+  curation re-run.
+- Read-only locator sync: locators in arrangement view drive scene
+  definitions in the model. The reverse direction (writing locators back
+  to arrangement view from the model) is v2.
+
+**Skills + harness:**
+- `skill.forge-pick` and `skill.forge-commit` unblocked by the
+  `[udpreceive]` + `sf_remote` infrastructure (which lands as part of
+  hardening).
+
+### v2 — explicitly deferred
+
+- Multi-song UI surface (song tabs, per-song scoping in popup).
+- Bidirectional locator sync (the *write-back* half — model → arrangement
+  view locators).
+- Recent-clip enumeration for `skill.bounce-to-clip-and-collect`.
+- `commit-with-bounce` skill (blocked on first-class post-processing
+  pipelines, which is a separate subsystem).
+
+### Indefinitely deferred
+
+- Programmatic group creation through LOM (`call group_tracks` confirmed
+  unavailable; AppleScript stays experimental).
+- Mouse-click automation for any operation.
+- Auto curation across multiple songs (manual splicing only).
+
+## Load-bearing decisions
+
+The calls that shape this spec. If any feels wrong, push back before the
+work starts.
+
+### Decision 1: abstract scene model is target-agnostic
+
+The data model knows nothing about EP-133, MPC, Koala, or any specific
+device. It's `Project → Song → Scene → Group → Pad` with arbitrary group
+counts, pad counts, and scene counts. Targets enter only at the projection
+step.
+
+Concretely: `_event_positions_bars`, `_scene_lengths_in_bars`, and
+`infer_bars` (currently in `song_synthesizer.py`) get lifted to
+`stemforge/scene_model/`. They're already pure; the lift is mechanical.
+
+### Decision 2: projectors are pluggable; EP-133, Koala, Chompi ship in v1
+
+`AbstractProjector` interface with three methods: `capabilities()`,
+`validate()`, `project()`. Adding a new target means subclassing this
+interface and supplying device specifics in a `DeviceProfile`-shaped
+data structure. No new test plumbing per device.
+
+EP-133 stays the byte-identical reference (Phase 1 acceptance gate).
+Koala and Chompi exist as exporters today and adapt cleanly. Three
+targets in v1 forces the abstraction to be real, not nominal.
+
+### Decision 3: clip identity is hash-based, not path-based
+
+Per the hardening spec's Decision 4: `audio_hash` (16-hex sha256 prefix
+of WAV bytes) is the identity. The configurator's clip refs use
+`audio_hash`; the file path is advisory. This survives `re-anchor`
+WAV regeneration without invalidating clip references.
+
+This is foundation work and lands as part of hardening — not the
+configurator itself. By the time configurator work starts, every chunk
+has a hash.
+
+### Decision 4: filesystem side-channel as primary I/O pattern
+
+Same convention as the M4L device today: write artifacts to disk, tail
+files, never poke back into Live or another running process for state
+reads. The configurator popup talks to a local Python HTTP server; the
+M4L device talks to the same server via `[shell]` + `[v8]`; everything
+that needs to be observable writes to disk.
+
+Rationale: this makes every layer testable via filesystem assertions
+(extending the hardening spec's tier model into the new code). LOM
+read-after-write is avoided everywhere.
+
+### Decision 5: M4L device strip is the operations surface, popup is the editor
+
+The M4L device strip (820×169) holds all controls for the workflow:
+manifest selection, configuration selection, song scope, group scope,
+track source, re-anchor, auto-curate, slice, export, open-editor. The
+popup is for fine inspection and bulk editing — the 2D pad grid, scene
+list, splice editor.
+
+Both strip and popup talk to the same local Python HTTP server, which
+holds the canonical `ProjectSpec` in memory and persists it to disk.
+
+### Decision 6: local Python HTTP server, not Node-for-Max
+
+Node-for-Max is broken on macOS 15.6+ with Live 12.2.7 / Max 9.0.8 (per
+testability bundle R5). The viable transport is `[shell]`-launched Python
+server + `[jweb]` pointing at `localhost:<port>` for the popup.
+
+This sidesteps the macOS hardened-runtime issue, gives real frontend
+tooling for the popup (SolidJS / React / etc.), and matches the bridge
+pattern stemforge already uses for `m4l_export_clips.py` and
+`m4l_locator_anchor.py`.
+
+### Decision 7: cross-song splicing is supported in v1; multi-song UI is v2
+
+Schema (`Project → Song → Scene`) supports cross-song splicing from day
+one. The splice editor UI ships in v1's Phase 4 work — this is the
+mashup workflow the user explicitly wants.
+
+Multi-song UI (song tabs, per-song scoped operations in the popup) is
+v2. Reason: the schema lift is foundational and cheap to do upfront;
+the UI surface for multi-song is genuinely additive and can land later
+without schema migration. Per Q5 of the design conversation.
+
+### Decision 8: locator sync is read-only in v1
+
+Locators in arrangement view drive scene boundaries in the abstract
+model. The reverse direction — writing locators back to arrangement
+view from the model — is v2.
+
+Rationale: LOM `cue_point` writes have known quirks (per testability
+bundle R8); building the read path first validates the data flow without
+taking on the LOM-write risk. Reverse direction lands once the model is
+proven.
+
+### Decision 9: scenes are first-class objects; Live's native primitives are the bridge
+
+Today, locators in arrangement view double as scene boundaries. The user
+flagged this as "gross." In the configurator:
+
+- Locators stay for downbeat anchoring (their original technical purpose).
+- Scenes are defined by the user via Live's native primitives — the
+  configurator observes them rather than reinventing them.
+- A scene's `provenance` field records whether it was auto-curated, manual,
+  or splice-defined.
+
+**Native Live primitives the configurator leans on (verified in Live 12 docs):**
+
+- **Consolidate Time to New Scene** (Create menu, or right-click on
+  arrangement selection) — selects a time range in arrangement view and
+  produces a new session scene with one consolidated clip per track.
+  This is the *canonical* arrangement→scene primitive. The configurator's
+  "slicer mini-UI" wraps this rather than reimplementing it.
+- **Capture and Insert Scene** (Create menu) — captures currently-running
+  session clips into a new scene. The canonical Workflow B primitive: jam
+  with clips, find a combination, capture as scene.
+- **Tab-drag** — held-clip + Tab during drag transfers between views.
+  Manual but precise. Used by users directly; configurator doesn't need
+  to script it.
+- **Cmd-J Consolidate** within arrangement — replaces a selection with one
+  new clip. Useful for tidying before a Consolidate to New Scene call.
+- **Arrangement Record** + scene launching — record session-view
+  performance into arrangement timeline. v2 territory but worth flagging.
+- **Remove Stop Button** on session-view clip slots — makes clip slots
+  transparent to scene launches. Critical for "linear backing track + per-
+  track triggering" workflows. Has implications for EP-133 projector's
+  pattern-launch semantics.
+
+**What this means for the configurator's slicer:**
+
+The "slicer mini-UI" in the popup is a thin wrapper that:
+1. Asks the user for a name and (optionally) instructs them to select
+   the relevant arrangement-time range and run Consolidate Time to New Scene.
+2. Reads the resulting session scene via the LOM.
+3. Builds the abstract `SceneSpec` from the scene's clips.
+
+OR, going the other direction:
+1. User triggers Capture and Insert Scene in Live directly.
+2. Configurator detects the new session scene.
+3. Same observation → SceneSpec build path.
+
+**Schema implication:** `SceneSpec.source_song_id` and
+`source_bar_range` become *optional metadata* (recorded if Consolidate
+Time to New Scene was the source), not required fields. The configurator
+doesn't track scenes by arrangement-time; it tracks them by the session-
+view scene Live created.
+
+The slicer is the manual-curation UX. Auto-curation is a separate path
+that produces ungrouped clip kits (Workflow B); manual curation produces
+named scenes with structure (Workflow A).
+
+### Decision 10: schema multi-song-ready in v1, even though UI is single-song
+
+Adding the `Song` layer between `Project` and `Scene` later is painful —
+every projector, fixture, and snapshot.json shape would need migration.
+Adding it now is free.
+
+v1 forces `len(songs) == 1` everywhere a song-loop would appear. The UI
+hides the song dimension. When v2 turns on multi-song UI, it's purely
+additive.
+
+### Decision 11: tempo-sensitive features require canonical real-audio regression fixtures
+
+Synth fixtures are necessary but not sufficient. This is a load-bearing
+lesson from the hardening pass (Stream E — see `HARDENING_VERIFICATION.md`
+§4.1).
+
+During hardening, live testing on Definition / Ooh La La / Believer
+revealed that the tempo reconciler had been silently biased high by
+~0.1–0.4% on every track for at least a week. Visible failure mode: clip
+drift of +128ms by bar 12 of `drums_chunk_012.wav`. The synth fixture
+didn't catch it — the bias only showed up against real audio with real
+beat-this output. The fix expanded into Stream E (~9 additional checkboxes)
+and produced the canonical fixtures at `tests/fixtures/known_tempos.py`
+gated by `@pytest.mark.has_phase3_inputs`.
+
+The lesson generalizes: cross-song splicing (a v1 configurator feature) is
+in the same class — tempo-sensitive across multiple sources, with failure
+modes that synth fixtures can't reproduce because the bug isn't in the
+math, it's in how the math interacts with real beat-detector output.
+
+**Concretely:**
+- Cross-song splicing tests use the Definition / Ooh La La / Believer
+  fixtures (or extensions thereof) as regression bar.
+- Any new tempo-sensitive feature in the configurator adds its own
+  canonical real-audio fixtures with `@pytest.mark.has_phase3_inputs`.
+- Synth fixtures still cover the unit-level math (per Decision 4 of the
+  hardening spec); they're not deprecated, just bounded.
+- The CI tier-split holds: real-audio fixtures run on developer Mac, not
+  in Linux CI, because the audio inputs aren't redistributable.
+
+**What this is NOT:** a requirement that every test use real audio.
+Per-pad mode editing, splice-editor UI, projector validation, etc. don't
+need it. The rule is specifically for tempo-sensitive code paths —
+anything that touches `refine_bpm`, `_bar_period_from_downbeats`, locator
+math, scene-bar inference, or the splice-source-tempo handoff in the
+projectors.
+
+### Decision 12: two equally first-class workflows — time-based scenes (A) and free clip-to-pad kits (B)
+
+The configurator supports two top-level user intents as primary, not as
+primary + degenerate-case:
+
+**Workflow A — time-based song structure.** User has arrangement-view
+content; uses Live primitives (Consolidate Time to New Scene, Capture and
+Insert Scene per Decision 9) to produce session scenes; configurator
+imports those as scenes; pads on each scene reflect the per-track clips;
+export produces a multi-scene preset on the target device. Scenes are
+launched in song order for performance.
+
+**Workflow B — free clip-to-pad kit.** User has a pile of clips (curated
+session view, dragged in from outside, whatever); assigns them to specific
+pads; export produces a single kit/preset. No scene structure; no song
+time; just a performance-ready pad bank.
+
+Both are expressible as `Project → Song → [Scene] → Group → Pad`:
+- Workflow A: `len(scenes) > 1`, scenes time-anchored
+- Workflow B: `len(scenes) == 1`, the single scene is just "the kit"
+
+**UI implications:**
+- Fresh project opens with **one default scene** (named "Default" or
+  "Kit" — TBD in Phase 4 design). User can ignore the scene entirely
+  and just work with the pad canvas (Workflow B) or define more scenes
+  (Workflow A, naturally graduates from B).
+- **Scene strip** is shown but collapsible/hideable when only one scene
+  exists. Doesn't dominate the popup when the user is doing Workflow B.
+- **Clip palette/pool sidebar** is essential and ships in v1 (per user
+  decision). Drag-from-palette-to-pad is the primary Workflow B
+  interaction. Also useful in Workflow A for "I want this clip from
+  scene 1 on a pad in scene 2."
+
+The schema cost of supporting both workflows is zero — same data model.
+The UX cost is real (clip palette, scene-strip-collapsibility), but worth
+it: Workflow B is a real performance use case for the EP-133, not just
+"someone using Workflow A wrong."
+
+### Decision 13: clip identity is by content (`audio_hash`), not by trim or processing
+
+The same audio file appearing in multiple places — session view,
+arrangement view, multiple pads, multiple scenes — is **one clip with
+one identity** keyed by `audio_hash`.
+
+**Different playback semantics are expressed at the pad/slot level, not
+by duplicating clips:**
+- Same clip on different pads with different trim points → one clip,
+  two slot configurations with different `start_marker`/`end_marker`.
+- Same clip on different pads with different post-processing → one clip,
+  the configuration's per-track post-processing chain handles the
+  difference.
+- Same clip in different scenes with different modes (one-shot vs. loop)
+  → one clip, two pad configs with different `mode`.
+
+This matches Phase 2.5's COMMIT dedup-by-file_path approach and extends
+it once Phase 3 wires `audio_hash` population at COMMIT time (today
+`audio_hash` is empty string per the Phase 2 loose-end #1).
+
+**The escape hatch when you genuinely need different *audio content*:**
+re-export from the configuration with different post-processing applied
+upstream, producing a new file with a different hash. That's a content
+change, not a duplicate-clip change.
+
+### Decision 14: pad canvas is the slot table; assignment is explicit
+
+Slot N on the target device corresponds to cell (N mod cols, N div cols)
+on the popup's pad canvas. **Clip-to-slot assignment is an explicit user
+action — drag a clip onto a cell.** No implicit ordering, no
+first-come-first-served, no surprises at export time.
+
+**Implicit slot-claim algorithms are seeds, not source-of-truth:**
+- Phase 2.5's COMMIT dedup-by-file_path + claim-next-free-slot (0..19)
+  produces an *initial* slot assignment when a project is first opened.
+- The popup displays this initial assignment in the pad canvas.
+- The user drags clips to rearrange — that becomes the new source of truth.
+- Re-running COMMIT does not silently overwrite user-arranged slots; the
+  user's explicit assignments are preserved unless they ask to reset.
+
+**This is the entire point of the 2D UI.** Today's COMMIT semantics
+(implicit dedup, session-first ordering, silent overflow when >20 clips
+exist) are correct as a *starting point* but become hostile when the user
+has opinions. The pad canvas is where opinions are expressed.
+
+This also clarifies what happens in Workflow 4 from the design discussion
+(both views populated): the COMMIT dedup runs as a seed; the user then
+explicitly arranges in the pad canvas; export reads the pad canvas, not
+the implicit COMMIT output.
+
+### Decision 15: slot table has a single writer (the configurator HTTP server)
+
+Per Phase 2.5's "single-writer-per-fact" architectural insight: the slot
+table on disk has **exactly one writer** in the configurator era — the
+local Python HTTP server (per Decision 6).
+
+**Today (pre-configurator):** COMMIT writes to two destinations — the
+in-memory Max `sf_manifest` dict + `<source_dir>/curated/manifest.json`
+on disk. This works because COMMIT is the only writer. Phase 3 introduces
+a third potential writer (the popup); without discipline, three writers
+to the same JSON would create drift.
+
+**The discipline:**
+- Configurator HTTP server holds the canonical `ProjectSpec` in memory.
+- Persists to disk on a debounce (e.g. 500ms after last edit).
+- All other surfaces — strip device, popup, COMMIT, future slicer —
+  send *intents* to the server (POST/PATCH endpoints) rather than
+  writing the slot table directly.
+- COMMIT becomes one of those intent senders: "here's what I observed
+  in session+arrangement view, please reconcile against your current
+  state."
+- The server reconciles, decides what changes apply, and broadcasts
+  via SSE so other surfaces update.
+
+**What this prevents:**
+- The popup writing slot N=clip_A while COMMIT simultaneously writes
+  slot N=clip_B. Last-write-wins races on shared state.
+- The strip device showing stale state because it read the disk before
+  the popup's debounced write.
+- Reconciliation logic scattered across three writers, each with its
+  own dedup and slot-claim quirks.
+
+**Consequence for Phase 3 design:** the HTTP server's API shape is
+load-bearing. Designing it as a clean intent-receiver (rather than a
+thin file-writing proxy) is what makes this discipline survive contact
+with reality.
+
+### Decision 16: per-group sample format settings (mono/stereo, sample rate)
+
+Hardware target memory budgets are tight. EP-133 has 64 MB total sample
+memory across all groups; Chompi TEMPO holds 12 slots × ~10s each in
+internal memory. Both formats benefit massively from format-aware export:
+mono vocals fit in half the space of stereo vocals; 24 kHz vocals fit in
+half the space of 48 kHz vocals.
+
+**Concrete motivating workflow** (the "hip-hop verse-swap deck"):
+- Group A (vocals): 12 pads × ~42s verses × mono × 24 kHz × 16-bit ≈ 24 MB
+- Group B (alt verses + hooks): mixed lengths × mono × 24 kHz ≈ 14 MB
+- Group C (drums): stereo × 48 kHz × 16-bit (full punch) ≈ 12 MB
+- Group D (texture/IDM): stereo × 48 kHz × 16-bit (preserve detail) ≈ 10 MB
+- Total: ~60 MB, fits in 64 MB cap with margin.
+
+If this exported at uniform stereo 48 kHz, the same 24 verses alone would
+hit ~94 MB — over the device's total memory.
+
+**The decision:** sample format is set **per group** as a `Configuration`
+property, not per pad. Groups have a `format_profile` field with values
+like `vocal` (mono, 24 kHz, 16-bit), `drum` (stereo, 48 kHz, 16-bit),
+`texture` (stereo, 48 kHz, 16-bit), or explicit `format` overrides.
+Defaults to source format if unset.
+
+**Why per-group, not per-pad:**
+- Per-pad knobs would be UI surface bloat for negligible flexibility —
+  in practice you almost never want two pads in the same group at
+  different formats.
+- The user's mental model is "Group A is the vocal group" not "pad 7 is
+  vocal." Per-group matches the model.
+- Maps cleanly onto the existing `Configuration` concept already in
+  the schema (per-group post-processing chains, curation modes — format
+  joins them).
+
+**Schema change:** add `format_profile: Literal["vocal", "drum",
+"texture", "preserve_source"]` and optional explicit `format` override
+(channels, sample_rate, bit_depth) to the per-group config in
+`Configuration.track_assignments`.
+
+**Projector implication:** EP-133, Koala, Chompi projectors must honor
+per-group format and downsample/downmix at export time. Currently the
+EP-133 exporter passes through source format. **This is a meaningful
+projector code change — small but real.** Acceptance criterion: byte-
+identity test for "same source, exported at preserve_source format"
+must remain green; new tests cover each format profile against expected
+output specs.
+
+**UI implication:** group settings in the popup show the format profile
+as a dropdown with the four named profiles; explicit overrides hidden
+behind a "custom format" advanced control. Validation in `validate()`
+projects target memory budget against actual format choices, lights up
+red in popup when over budget *before* export.
+
+**What this is NOT:**
+- Not per-pad. Per-pad format would be a v2 add if it's ever needed.
+- Not automatic format inference. The user picks the profile; they know
+  whether vocals or drums or texture is the goal.
+- Not a new audio pipeline. Downsampling and downmixing use standard
+  scipy/librosa primitives at projector time; no new DSP.
+
+## Plan
+
+The work breaks into five phases. Order matters (each builds on the
+previous), but specific deliverable ordering within a phase is determined
+when picking the phase up. Hardening's acceptance gate is met as of
+2026-05-08; Phase 1 is unblocked.
+
+### Phase 1 — lift and split
+
+**Outcome:** existing EP-133 export still works, but uses the new
+abstraction.
+
+Lift `tile`, `scene_lengths`, `infer_bars` to `stemforge/scene_model/`.
+Define `AbstractProjector`. Refactor EP-133 exporter to implement it.
+`stemforge export-song` produces byte-identical `.ppak` for hardened
+fixtures. Wire `re-anchor --then-curate`.
+
+**Acceptance:** byte-identical `.ppak` for every fixture; all hardening
+must-keep-green paths still pass.
+
+### Phase 2 — abstract scene model + multi-song schema
+
+**Outcome:** full data model exists; single-song UI is the only live
+surface.
+
+Define `Project`, `Song`, `SceneSpec`, `GroupSpec`, `PadSpec` per the
+schema in v4 §2. `Song` layer present from day one (forced n=1 in v1).
+Generalize `sf_arrangement_reader.js` to write `Song`-shaped data. CLI
+helper to build empty `ProjectSpec` from a manifest + config.
+
+**Acceptance:** `ProjectSpec` round-trips through disk; single-song flow
+works end-to-end (forge → curate → ProjectSpec → projector → `.ppak`)
+byte-identical to Phase 1.
+
+### Phase 3 — bridge, strip, popup shell, additional projectors
+
+**Outcome:** M4L device exists; popup opens; multi-target abstraction is
+real.
+
+Local Python HTTP server (`tools/m4l_configurator_server.py`) with state
+endpoints, SSE, projector triggers, audio preview. New `m4l-devices` repo
+with strip device. Popup shell (SolidJS or equivalent). Port Koala and
+Chompi exporters to projectors.
+
+**Acceptance:** strip controls fire actions; popup loads via `[jweb]`;
+each of the three projectors produces a valid bundle for a fixture project.
+
+### Phase 4 — editor
+
+**Outcome:** the configurator UI is real; users build and export
+configurations.
+
+Scene strip, pad canvas with multi-axis selection, inspector with
+bulk-apply, audio preview, target capacity warnings. Slicer mini-UI for
+manual scene definition. Splice editor for cross-song scenes.
+Multi-target export.
+
+**Acceptance:** user can build a multi-scene single-song project in the
+popup, mix auto + manual curation, export to all three targets.
+
+### Phase 5 — locator sync + skill bindings
+
+**Outcome:** arrangement-view locators drive scene boundaries; skills
+drive the device headlessly.
+
+Read-only locator sync: arrangement → ProjectSpec → session view (one-way
+write). Wire `skill.forge-pick` and `skill.forge-commit` against the
+`[udpreceive]` infrastructure (which lands as part of hardening).
+
+**Acceptance:** drop locators in arrangement, hit Sync, session view
+populates with tiled clips; `sf_remote fire <target>` triggers device
+actions on developer Mac.
+
+## What this spec deliberately doesn't say
+
+- **Wall-clock estimates per phase.** v4 had them; they were guesses
+  anyway. Each phase is bounded by its acceptance criteria, not its
+  duration.
+- **Specific UI design details.** The mockup in v4 §6 stands as the
+  current intent; final design happens in Phase 4. The load-bearing
+  interaction decisions (multi-axis selection, bulk-apply contextual
+  suggestions, color-encoded modes) are documented; pixel-level details
+  aren't.
+- **File-by-file refactor instructions.** v4 has them in §7; this spec
+  references the v4 phasing rather than repeating it.
+- **Frontend stack final choice.** SolidJS is the leading candidate (v4
+  §6); React is acceptable. Decided when Phase 3 starts.
+
+## Risks
+
+**R1 — *(retired 2026-05-08)* Hardening's acceptance gate is met.** Phase 1's
+"byte-identical" criterion is now verifiable against shipped tests. See
+`HARDENING_VERIFICATION.md`.
+
+**R2 — Three projectors in v1 (EP-133, Koala, Chompi) is real work.**
+Existing exporter parity is the floor; making them implement
+`AbstractProjector` cleanly without leaking device specifics into the
+abstract layer is the actual challenge. Plan for genuine refactor cost,
+not commodity adaptation.
+
+**R3 — Phase 4's UI surface absorbs time.** Pad canvas with multi-axis
+selection, inspector with bulk-apply, splice editor, target validation —
+these are individually small but collectively a real frontend project.
+Discipline: ship Phase 4 as a minimum viable killer UI (selection, mode,
+export, splice) and polish in v1.1.
+
+**R4 — Cross-song splicing has multi-tempo edge cases that synth fixtures
+won't catch.** Splicing song1 (120 BPM) into song2 (140 BPM) requires the
+projector to handle native tempo per splice source. EP-133's
+`time_mode: bpm` per pad supports this; needs validation. **Per Decision 11,
+splice tests use the canonical Definition / Ooh La La / Believer fixtures
+(or extensions thereof), not synth.** This is the hardening's Stream E
+lesson applied; ignoring it has a documented track record of letting
+sub-percent tempo bias hide for a week.
+
+**R5 — Multi-song UI deferred to v2 means v1 needs an awkward "single-song
+mode" mental model.** The configurator strip's "Song: ●1" tab with no
+ability to add a second song is a UX paper-cut. Accept it for v1; v2
+removes it.
+
+**R6 — Tempo-pipeline static sentinels (SE-3/4/5) catch call-site changes,
+not behavior changes.** The hardening pass shipped `test_split_path_invokes_refine_bpm`,
+`test_re_anchor_path_invokes_refine_bpm`, and
+`test_re_anchor_auto_reslices_curated` as static greps because the synth
+fixture's hi-hat density makes beat-this report half-time on the full
+pipeline. Combined with SE-2's direct `refine_bpm` correctness coverage,
+this is functionally equivalent — but only if both stay in sync. **If
+configurator work modifies `refine_bpm`'s signature or call sites, both
+the sentinels and SE-2 need parallel updates.** Per `HARDENING_VERIFICATION.md`
+§4.2.
+
+**R7 — `verify-load` doesn't catch LOM-binding errors.** The hardening pass
+wired `verify-load` against `v0/build/StemForge.amxd` via the
+`_extract_maxpat_from_amxd()` adaptation (GH issue #61, resolved). It
+catches patcher-graph errors (the actual target of pitfall #24) but
+LOM-touching JS modules throw at load time without the LiveAPI host —
+errors come back as `js_no_function`/`missing_object`. **Configurator's
+M4L device work is heavy on LOM bindings; don't expect verify-load to
+be the only safety net.** Layered coverage required: structural
+verifiers + verify-load + Tier-3 mock tests + Tier-4 live integration.
+Per `HARDENING_VERIFICATION.md` §4.3.
+
+**R8 — Slot-claim algorithm in COMMIT is now a load-bearing contract.**
+Phase 2.5's COMMIT dedup-by-file_path + claim-next-free-slot-in-0..19
+became the seed for the slot table (per Decision 14). Existing fixtures
+record specific slot assignments produced by this algorithm. **Any future
+change to slot-claim logic must be tested against existing fixtures'
+assignments to confirm it doesn't reorder slots silently.** Particular
+care needed when Phase 3 wires `audio_hash` population at COMMIT time —
+switching the dedup key from file_path to audio_hash *should* produce
+identical results in normal cases, but edge cases (same path but
+different content, or same content but different paths) need explicit
+testing. Add at least one fixture that exercises each edge case.
+
+## What success looks like
+
+After v1 ships, the user can:
+- Forge a song, open the configurator, slice scenes manually from
+  arrangement view, configure pad modes, and export to EP-133, Koala,
+  or Chompi from the same project.
+- Re-anchor a downbeat in arrangement view and have curation re-run
+  automatically.
+- Define cross-song splice scenes (mashups) in the data model and UI.
+- Drive the device headlessly via `sf_remote fire forge` /
+  `sf_remote fire commit` for skill-level automation.
+- Drop locators in arrangement view and have them sync into scene
+  definitions in the configurator.
+
+After v2 ships, the user can additionally:
+- Manage multi-song projects with per-song UI scoping.
+- Have the configurator write locators back into arrangement view.
+- Use recent-clip enumeration in `skill.bounce-to-clip-and-collect`.
+- Use `commit-with-bounce` for post-processing-pipeline-aware bouncing.
+
+## Out of scope, full stop
+
+These won't ship as part of the configurator regardless of timeline:
+
+- Modifying or replacing the existing forge pipeline (it works; leave it).
+- Curation algorithm changes (orthogonal subsystem).
+- DSP effect chains within the configurator (post-processing is a v2
+  concern; v1 configurator just records what mode each pad is in).
+- Plugin extraction (`vst-extraction` skill) — orthogonal cleanup.
+- Live performance features beyond hardware export (the configurator is
+  for *preparing* hardware projects, not for performing live).

--- a/docs/configurator/STEMFORGE_TOP3_WORKFLOWS.md
+++ b/docs/configurator/STEMFORGE_TOP3_WORKFLOWS.md
@@ -1,0 +1,503 @@
+# StemForge — Top 3 Use-Case Workflow Plans
+
+**Status:** active. Targets the configurator after Phase 4 ships
+(scenes + slicer + splice editor + multi-target export).
+**Companions:** [`STEMFORGE_CONFIGURATOR_SPEC_v4.md`](STEMFORGE_CONFIGURATOR_SPEC_v4.md)
+(active spec — v3 archived under `archive/`),
+[`../HARDENING_VERIFICATION.md`](../HARDENING_VERIFICATION.md).
+
+## Hardware notes (load-bearing)
+
+- **EP-133 K.O. II** — 4 groups × 12 pads × ≤99 scenes. MIDI clock in/out.
+  Per-pad time mode (`bpm`/`bar`/`off`).
+- **Chompi (TEMPO firmware)** — groovebox mode, MIDI clock sync (slave or
+  master), 10-second sample length cap (16-bit 48kHz stereo WAV), two
+  parallel sample engines, arpeggiator-meets-step-sequencer Pattern
+  Generator with note probability and rest patterns, Slice Engine (16
+  even slices across white keys), snapshot A/B for live recall, clock-
+  synced FX (dual delay + diffusion reverb + freeze + sidechain ducking).
+- **Chompi TAPE firmware does NOT support MIDI sync.** All cross-device
+  workflows below use TEMPO. TAPE is mentioned only where relevant for
+  sample-prep notes.
+- **Chompi role here:** primarily an arpeggiator with tonal samples /
+  single-cycle synthesis sources / drone fragments. Not a sample-loop
+  player. The 10-second cap and Pattern Generator together make this the
+  natural fit.
+
+## Workflow ranking → use-case mapping (recap)
+
+| Rank | Use case | Maps to user mode |
+|---|---|---|
+| 1 | EP-133 drum-break corpus + Chompi tonal arpeggiator (MIDI-synced) | super-creative |
+| 2 | Drum-break corpus standalone (EP-133 only) | creative |
+| 3 | Hip-hop × IDM blend set (EP-133 scenes, optional Chompi) | DJ-mode |
+
+Workflows are presented in implementation order (#2 first as fastest win,
+#1 next as the headline goal, #3 last as the most configurator-validating).
+
+---
+
+## Workflow #2 — Drum-break corpus (creative mode, EP-133 only)
+
+**Concept:** A coherent kit of 90s sampledelic hip-hop drums, performable
+as one set without song structure. Pure Workflow B (per Decision 12 of the
+configurator spec).
+
+### Source material
+
+From the corpus, the tracks with strong drum stems suitable for a
+sampledelic kit:
+
+- A Tribe Called Quest — Electric Relaxation
+- A Tribe Called Quest — Peace, Prosperity and Paper
+- Digable Planets — Rebirth of Slick (Cool Like Dat)
+- Outkast — Rosa Parks
+- Pharoahe Monch — Simon Says
+- Mos Def — Quiet Dog Bite Hard
+- Jay-Z — 99 Problems
+
+That's 7 tracks. Each has a `drums` stem from demucs.
+
+### Configurator setup
+
+**Project:** `creative_drum_corpus` (single Song, n=1)
+
+**Configuration:** create `drums_corpus` config.
+- All 4 EP-133 groups feed from the `drums` stem (same stem, different
+  source tracks per group).
+- Curation mode: `manual` for all groups (we'll hand-pick chunks; auto
+  curation across 7 tracks would homogenize the kit).
+- Post-processing: minimal. Maybe HPF on group A (kicks/snares) for
+  punch, otherwise leave the 90s grit alone.
+
+**Group → track mapping** (1:1 per Decision 14):
+- Group A: chunks pulled from Tribe + Digable (laid-back jazzy breaks)
+- Group B: chunks from Outkast + Pharoahe (driving, harder hits)
+- Group C: chunks from Mos Def + Jay-Z (modern hip-hop production)
+- Group D: chunks from Tribe (Peace, Prosperity) (a single track's
+  variations, for cohesion)
+
+This isn't strictly necessary — you could mix all 7 tracks into one group
+— but gives you a clear "what am I playing" mental model per group.
+
+**Scene:** one default scene, named `kit`. (Per Decision 12, single-scene
+default; the scene strip is collapsed in the UI.)
+
+### Pad layout (12 per group)
+
+Per group, pads cluster from "core hits" at the bottom (low pad numbers)
+to "fills/variations" at the top:
+
+```
+Group A — Tribe + Digable
+─────────────────────────
+Pad 7 (top-left)  : Digable break loop (2 bar)
+Pad 8             : Tribe break loop A (2 bar)
+Pad 9             : Tribe break loop B (2 bar)
+Pad 4             : Digable kick + hat fill
+Pad 5             : Tribe ghost-note pattern
+Pad 6             : Digable percussion roll
+Pad 1 (bottom-L)  : kick (one-shot)
+Pad 2             : snare (one-shot)
+Pad 3             : closed hat (one-shot)
+Pad . (bot-corner): open hat
+Pad 0             : clap
+Pad ENTER         : crash/cymbal (rare hit)
+```
+
+Bottom row = single hits (one-shot mode). Middle row = fills (one-shot
+mode). Top row = full breaks (loop mode, 2-bar `time_mode: bar`). Same
+shape per group, different source tracks.
+
+### Modes
+
+- Bottom + middle row pads: `mode: oneshot`, `time_mode: off`.
+- Top row pads: `mode: loop`, `time_mode: bar`, `bars: 2`.
+
+### Performance approach
+
+You're playing this as a drum machine, not a song. Bottom row for
+finger-drumming patterns; top-row breaks as bedding when you want to
+stop drumming and let the loop carry; middle row for fills between
+phrases. Group switching (A/B/C/D) on the fly changes the source-track
+character mid-set.
+
+### Configurator features exercised
+
+- Workflow B (single-scene kit) — Decision 12
+- Manual curation per group — Decision 9
+- Pad canvas as slot table — Decision 14
+- Multi-target capability via Koala/Chompi projectors not needed here
+  (EP-133 only) — but the validation surface is `validate()`-correct
+  capacity (12 pads × 4 groups = 48 slots, well under 999 sample limit)
+- Auto-curate skipped — confirms the configurator handles
+  `provenance: manual` correctly
+
+### Acceptance / "this works" check
+
+You can perform a 15-minute drum set on the EP-133 alone, switching
+groups, mixing one-shots and loops, without touching a laptop. The kit
+feels stylistically coherent — someone listening would recognize "90s
+hip-hop" as the unifying aesthetic.
+
+### Deferred / v2 nice-to-haves
+
+- Per-pad processing variations (one bank with HPF, one with bitcrush) —
+  needs first-class post-processing pipelines (v2).
+- Auto-curation pass that picks "12 most diverse drum chunks per source
+  track" as a starting palette before manual tweaking. Today's auto-
+  curation is per-stem, not per-source-track-grouped; could be useful
+  here if extended.
+
+---
+
+## Workflow #1 — EP-133 drums + Chompi tonal arpeggiator (super-creative mode)
+
+**Concept:** EP-133 plays the rhythm section using the Workflow #2 drum
+kit (or a derivative). Chompi runs TEMPO firmware as a melodic
+arpeggiator, MIDI-clock-synced to the EP-133, playing tonal samples
+extracted from the IDM corpus. Two devices, two roles, one tempo.
+
+### Source material
+
+**EP-133 side:** the drum-break corpus from Workflow #2, or a streamlined
+version (4 groups × 12 pads).
+
+**Chompi side:** **tonal fragments from the Aphex Twin melodic tracks.**
+
+Specifically:
+- `aphex_twin_avril_14th` — single-note piano fragments, root notes
+  in C-minor-ish territory
+- `aphex_twin_rhubarb` — sustained pad fragments, harmonic tones
+- `aphex_twin_xtal` — bell/synth fragments
+- `aphex_twin_bucephalus_bouncing_ball` — bouncing tonal hits
+
+Each ~1-2 seconds long, well within TEMPO's 10-second cap. All sourced
+from the `other` stem of demucs (tonal/harmonic content).
+
+Optional: drone samples in C from Chompi's official TEMPO sample pack as
+a textural underlay if your tonal extracts feel thin.
+
+### Stemforge setup (for Chompi sample export)
+
+This is the workflow that **most needs the Chompi projector** (Decision 2
+in the configurator spec — Chompi as v1 target).
+
+**Project:** `super_creative_chompi_aphex` (single Song, n=1)
+
+**Configuration:** `chompi_tonal_arp`
+- Single group (Chompi has 12 sample slots per "preset" in TEMPO; we
+  use one group = one preset)
+- Source stems: `other` (tonal content) from each Aphex track
+- Curation mode: `manual` — hand-pick the cleanest tonal fragments
+- Post-processing: minimal. Maybe gentle HPF to remove sub rumble; no
+  aggressive shaping (preserve Aphex character).
+
+**Pad layout (12 slots):**
+
+The **Slice Engine in TEMPO** is the key feature here. Two strategies:
+
+**Strategy A — one sample per slot, Pattern Generator as arpeggiator:**
+- 12 slots = 12 distinct tonal fragments (3 from each of 4 Aphex tracks)
+- All in compatible keys (transpose at extraction time if needed; pick
+  source phrases that center on C-minor or A-minor for cohesion)
+- Chompi's Pattern Generator arpeggiates across them, using the
+  white-key mapping
+- **You play chord shapes on Chompi keys; the arpeggiator distributes
+  hits across the underlying samples in tempo-synced patterns**
+
+**Strategy B — fewer samples, more Slice usage:**
+- 3-4 slots, each holding a longer Aphex phrase (~5s)
+- Chompi's Slice Engine chops each into 16 even slices across white keys
+- Pattern Generator sequences slice-triggers
+- **You're sequencing slices of Aphex phrases against EP-133 drums**
+
+**Recommendation: Strategy A for v1.** Slicing requires careful sample
+prep (the slice points are even divisions, so the source has to cooperate
+rhythmically). Single tonal fragments are forgiving.
+
+### MIDI sync setup
+
+EP-133 = MIDI clock master, Chompi = slave.
+
+```
+EP-133 [MIDI OUT] ──→ [MIDI IN] Chompi
+```
+
+Chompi TEMPO syncs to EP-133's clock, plays Pattern Generator at the
+shared tempo. EP-133 scene-launch tempo changes propagate.
+
+(Could also reverse — Chompi master, EP-133 slave — but EP-133 is the
+"foundation" instrument here, so it's natural for it to be master.)
+
+### Performance approach
+
+1. Set EP-133 tempo (90-100 BPM territory for hip-hop). Chompi follows.
+2. Launch a Workflow #2 scene on EP-133 (e.g., Group A drum loop on
+   Pad 7, kick/snare ones-shots on bottom row).
+3. On Chompi, dial up an arp pattern (note order, rest pattern, clock
+   division) appropriate to the energy.
+4. Hold a chord shape on Chompi keys. Pattern Generator arpeggiates the
+   tonal samples against the EP-133 drums.
+5. Live-modulate: chord changes on Chompi keys → Pattern Generator
+   re-arpeggiates immediately. EP-133 group switches change drum
+   character. Both stay in time.
+6. Use Chompi's snapshot A/B for "verse vibe" vs "chorus vibe" recall.
+
+### Stemforge → Chompi export pipeline
+
+**This is the load-bearing technical work.**
+
+The Chompi projector needs to:
+- Take the abstract `ProjectSpec` for this project
+- Validate against TEMPO's capabilities: 12 slots/preset, max 10s per
+  sample, 16-bit 48kHz stereo WAV format
+- Project the abstract pads onto Chompi's preset structure
+- Write to a directory layout matching Chompi's TEMPO firmware SD card
+  expectations (different from TAPE per the firmware docs)
+- Handle the per-engine asymmetry: Chompi has two parallel sample
+  engines; we likely use just one for v1 simplicity
+
+**This work hasn't started.** Today's `KoalaExporter` exists; today's
+Chompi exporter exists in some form (mentioned in the bundle), but it
+was written for TAPE firmware. **The TEMPO projector needs to be built
+from scratch as part of Phase 3** of the configurator plan, or Workflow
+#1 doesn't exist.
+
+### Configurator features exercised
+
+- **Multi-target export** (Decision 2) — same `ProjectSpec` projects to
+  EP-133 and Chompi simultaneously, or to one at a time
+- **Chompi TEMPO projector** — first non-EP-133 first-class target;
+  forces the abstraction to be real (not nominal)
+- **Per-target validation** (`validate()` per projector) — Chompi's
+  10-second sample cap is the test case for "validation lights up red
+  in popup before export"
+- **Workflow B kit** on Chompi side
+- **Workflow A or B** on EP-133 side (B for kit-style; A if you want
+  to map this to song scenes)
+
+### Acceptance / "this works" check
+
+You can perform a 20-minute set with EP-133 drums and Chompi arpeggiator,
+both clock-synced, both fed by stemforge-produced sample banks. Drum
+character (Group A vs B vs C vs D on EP-133) and harmonic character
+(chord shape on Chompi) change live. Tempo changes on EP-133 propagate
+correctly to Chompi. No laptop required during performance.
+
+### Deferred / v2
+
+- Multi-snapshot export (Chompi A/B snapshots populated by stemforge,
+  not just one preset)
+- Slice-Engine projector mode (export longer Aphex phrases for Strategy
+  B above)
+- Chompi-as-master mode (less likely needed but possible)
+- Auto-tonal-curation (algorithmic "find harmonically compatible
+  fragments across multiple sources") — orthogonal feature, not
+  configurator-blocking
+
+---
+
+## Workflow #3 — Hip-hop × IDM blend DJ set (DJ-mode)
+
+**Concept:** A continuous performance where scenes alternate between
+recognizable 90s hip-hop and chaotic Aphex/Squarepusher IDM. The
+juxtaposition is the artistic statement. Workflow A (per Decision 12) —
+scenes are time-anchored, launched in song order.
+
+### Source material
+
+**Hip-hop side:**
+- A Tribe Called Quest — Electric Relaxation
+- Digable Planets — Rebirth of Slick
+- Outkast — Rosa Parks
+- Mos Def — Quiet Dog Bite Hard
+- Jay-Z — 99 Problems
+
+**IDM side:**
+- Aphex Twin — vordhosbn
+- Aphex Twin — 54 cymru beats
+- Aphex Twin — cock_ver10
+- Squarepusher — Beep Street
+- Squarepusher — Vic Acid
+- Squarepusher — Ill Descent
+
+10 source tracks → ~12-16 scenes (some tracks contribute multiple
+scenes for verse/chorus structure; some IDM tracks are too short for
+multi-scene treatment).
+
+### Configurator setup
+
+**Project:** `dj_blend_hiphop_idm` (single Song, n=1 — but uses cross-
+song splicing per Decision 7)
+
+**Configuration:** `dj_blend`
+- 4 groups: A=drums, B=bass, C=vocals, D=other
+- Curation: `manual` per scene (use the slicer)
+- Post-processing: differs by scene type (hip-hop scenes = subtle EQ;
+  IDM scenes = bitcrusher / saturation as character)
+
+### Scenes (the meat of this workflow)
+
+This workflow uses **Live's Consolidate Time to New Scene** primitive
+(per Decision 9) heavily. Process per scene:
+
+1. Load source song into arrangement view via stemforge `forge`
+2. Identify the section you want (e.g., Tribe verse 1, bars 17-32)
+3. Select that time range in arrangement view
+4. Run Create → Consolidate Time to New Scene
+5. Live creates a new session-view scene with one consolidated clip per
+   stem track
+6. Configurator detects the new scene; you import it via slicer mini-UI
+7. Name it (e.g., `tribe_verse_1`) and configure pad mode/settings
+8. Repeat for the next source
+
+Suggested scene order (~16 scenes):
+
+```
+1.  intro_drone        (Brian Eno — An Ending) — ambient bed, pad-style
+2.  tribe_verse_1      (Electric Relaxation, bars 17-32)
+3.  digable_chorus     (Rebirth, bars 1-16)
+4.  squarepusher_drop  (Beep Street, the rhythm-violence section)
+5.  outkast_chorus     (Rosa Parks, "Hey ya"-ish hook)
+6.  aphex_glitch       (54 cymru beats, peak chaos)
+7.  mos_def_verse      (Quiet Dog, ~16 bars)
+8.  squarepusher_riff  (Vic Acid, melodic fragment)
+9.  jay_z_chorus       (99 Problems, "got 99 problems...")
+10. aphex_pad          (cock_ver10, slower section)
+11. tribe_outro        (Peace Prosperity — outro vibe)
+12. squarepusher_break (Ill Descent, breakdown)
+13. pharoahe_simon     (Simon Says, the whistle/horn hook)
+14. aphex_chaos_2      (vordhosbn, dense rhythmic section)
+15. digable_outro      (Rebirth, fade-out)
+16. ambient_close      (True Love Waits or Eno return) — soft landing
+```
+
+### Per-scene pad layout
+
+Within each scene, pads are pre-filled by the slicer based on what
+Consolidate produced (one consolidated clip per stem → ~4 pads).
+Post-Phase 2.5, dedup runs as a *seed* (Decision 14); you then drag
+pads to make explicit assignments.
+
+For hip-hop scenes:
+- Pad 1 (kick/drums consolidated)
+- Pad 2 (bass consolidated)
+- Pad 3 (vocals consolidated)
+- Pad 4 (other / harmonic content)
+- Mode: `loop` for the consolidated 4-bar (or 8-bar) sections,
+  `time_mode: bar` so they tempo-stretch on scene launch
+
+For IDM scenes (where stem separation is less clean):
+- All 4 stems probably go to one or two pads
+- Mode: `loop`, `time_mode: bar` if rhythmic; `time_mode: off` for
+  textural Aphex like cock_ver10
+- May benefit from `time_mode: bpm` if the IDM section locks to a
+  specific BPM that differs from the project tempo
+
+### Cross-tempo splicing — the R4 risk realized
+
+This workflow **is** R4 in the configurator spec. Hip-hop sits 90-100 BPM;
+Aphex/Squarepusher ranges 120-180 BPM. Some scenes will require
+cross-tempo splice handling.
+
+**Per Decision 11 + the hardening canonical fixtures:** test this
+workflow against the Definition / Ooh La La / Believer fixtures *before*
+trying it with real Aphex content. If a 120 BPM source spliced into a
+90 BPM project produces drift, that bug needs fixing in the projector,
+not worked around in performance.
+
+### Performance approach
+
+1. Set project tempo to ~92 BPM (hip-hop center of gravity).
+2. Pre-load all scenes onto EP-133 via export. Each scene = one
+   EP-133 scene.
+3. Launch scenes in order via EP-133's scene-launch interface. The
+   abrupt swap from hip-hop bars to IDM chaos *is* the artistic
+   statement.
+4. Within a scene, you can play pads to add/remove stems (mute the
+   vocal pad to leave just the instrumental, etc.).
+5. Cross-fade between scenes is via EP-133's transition handling
+   (which is rougher than a software DJ but works at scene
+   boundaries).
+
+### Optional: Chompi underlay
+
+If you have Chompi available + want the v3 ambient-glue feature
+(Workflow #14 from the brainstorm):
+- Chompi runs TEMPO with drone samples (Eno, Radiohead extracts) on
+  one engine
+- MIDI-synced to EP-133
+- Plays continuously underneath, providing harmonic glue across abrupt
+  scene transitions
+- Pattern Generator on Chompi's drone engine = arpeggiated drones
+  evolving across scenes
+
+This adds the v1 multi-target export validation to the workflow.
+
+### Configurator features exercised
+
+- **Workflow A** (multi-scene song structure) — Decision 12
+- **Slicer mini-UI wrapping Consolidate Time to New Scene** — Decision 9
+- **Cross-song splicing across many tracks** — Decision 7
+- **Cross-tempo handling** — Decision 11 + R4
+- **Scene-launch performance** with EP-133 clock-synced
+- **Multi-target export** if Chompi underlay added
+- **Validation warnings** — 16 scenes with various group counts will
+  exercise the projector's validate() output meaningfully
+
+### Acceptance / "this works" check
+
+You can perform a 30-minute DJ set live, launching scenes in order,
+playing pads to mute/add stems within scenes, with the hip-hop ↔ IDM
+juxtaposition feeling intentional rather than chaotic. Tempo handling
+across cross-genre scenes works without audible drift.
+
+### Deferred / v2
+
+- Bidirectional locator sync (write back to arrangement so the set is
+  scrubable in Live as well as performable on EP-133)
+- Multi-song UI surface (right now, this is "single-song with 10
+  splice sources" — could become "10 songs in one project" once v2
+  multi-song UI lands)
+- Auto-arrange suggestions ("here's a good scene order based on tempo
+  proximity") — orthogonal feature
+- Live performance recording back into Ableton via Arrangement Record
+  (Decision 9 mentions; v2)
+
+---
+
+## Implementation order recommendation
+
+**Build #2 first.** EP-133-only, no Chompi work, no cross-tempo splicing.
+Validates: configurator end-to-end (forge → curate → configure → export →
+play), Workflow B UX, drum-break corpus aesthetic. Fast win; you're
+performing with it while #1 and #3 are in progress.
+
+**Build #1 second.** Adds Chompi TEMPO projector (the load-bearing
+unblocked work for non-EP-133 targets), MIDI sync between devices,
+multi-target export. Validates Decision 2 (pluggable projectors) and
+super-creative mode.
+
+**Build #3 third.** Adds cross-tempo splicing exercise (R4 stress test),
+slicer mini-UI maturity (16 scenes is real exercise), scene-launch
+performance. Validates Workflow A, Decision 11, and the most ambitious
+configurator surface.
+
+The ordering also matches the configurator spec's phasing: Phase 4
+(editor proper) ships #2 trivially; Phase 4 + Chompi projector port
+ships #1; Phase 4 + heavy slicer use ships #3.
+
+## What NOT to plan for in v1
+
+- **DJ-mode crossfading between scenes** — EP-133 handles scene
+  transitions but not crossfades; hardware-limited. Workflow #3 accepts
+  this.
+- **Chompi-as-master MIDI clock** — possible but not the natural fit;
+  EP-133 master is cleaner.
+- **Single-song multi-target with different content per target** —
+  e.g., "EP-133 gets the drums-only version, Chompi gets the
+  tonal-only version." Schema supports it; UI and projector logic for
+  it is v2.
+- **Live arrangement recording** — Decision 9 mentions Arrangement
+  Record as a v2 path; not in any of these workflows.

--- a/docs/configurator/VERSE_SWAP_DECK_PLAN.md
+++ b/docs/configurator/VERSE_SWAP_DECK_PLAN.md
@@ -1,0 +1,311 @@
+# Verse-Swap Deck — Execution Plan
+
+**Goal.** A hip-hop mixtape deck on the EP-133 with **24 full verse vocal pads**
+(2 verses × 12 source songs) on Groups A + B, **drum breaks/oneshots** on
+Group C, and **bass/synth/texture samples** on Group D. Memory budget fits
+inside the 64 MB device cap.
+
+**Status.** Plan only; not yet implemented. Target the smallest path through
+v4 that lets the user perform from this deck.
+
+**Spec anchors.** v4 Decision 16 (per-group format), Decision 12 (Workflow B
+single-scene kit), Decision 13 (clip identity by `audio_hash`), Decision 14
+(pad canvas as slot table). Phase 3.5/3.6 (Koala/Chompi) and Phase 4.7/4.8
+(splice editor + multi-target export) are explicitly out of scope here.
+
+---
+
+## Reality check before we start (read this)
+
+The v4 Decision 16 motivating math is mildly misleading for EP-133
+specifically. EP-133 is **always** mono / 16-bit / 46875 Hz on disk —
+[stemforge/exporters/ep133/wav_format.py:26-28](stemforge/exporters/ep133/wav_format.py#L26-L28)
+hardcodes that, and `convert_wav_to_ep133` always downmixes + resamples
+inputs to that format. The "stereo 48 kHz → 94 MB" framing in v4 was
+inflated for narrative; the real-world math at EP-133's actual on-disk
+format is:
+
+| Profile | Per 42s verse | × 24 verses | Fits in 64 MB? |
+|---|---|---|---|
+| `preserve_source` (46875 Hz mono 16-bit) | 3.94 MB | 94.5 MB | **No** |
+| `vocal` (23437 Hz mono 16-bit, half rate) | 1.97 MB | 47.3 MB | Yes, with ~17 MB of headroom for groups C+D |
+| `vocal-tight` (16000 Hz mono 16-bit) | 1.34 MB | 32.3 MB | Yes, with ~32 MB of headroom |
+
+**Conclusion:** the *channel* and *bit-depth* axes of Decision 16 are no-ops
+on EP-133 (already locked). The lever that matters here is **sample rate
+downsampling**. Plan accordingly: ship sample-rate-per-group as the v1
+hardware-constrained surface, treat channels/bit-depth as forward-looking
+hooks for Koala / Chompi / future targets.
+
+---
+
+## What ships (two slices)
+
+> **Update 2026-05-08:** the user is hand-curating source material in Live
+> (one song broken into two verses + 2-3 chunks per other section,
+> scaled across the corpus). **Slice 3 (verse-extraction CLI) drops** —
+> the user produces curated WAVs upstream and the deck-builder doesn't
+> need a verse-trimmer.
+
+### Slice 1 — Per-group sample rate + memory budget (Decision 16, EP-133-only edition)
+
+**Outcome:** the projector can produce a `.ppak` where Group A and B
+samples are downsampled to 24 kHz while Group C and D stay at the device
+default. Memory budget is computed pre-export and surfaces as a warning
+when the project exceeds 64 MB.
+
+Concrete commits:
+
+1. **Schema add** — extend
+   [stemforge/scene_model/schema.py:57-62](stemforge/scene_model/schema.py#L57-L62)
+   so `GroupSpec` carries `format_profile: Literal["vocal", "drum",
+   "texture", "preserve_source"] = "preserve_source"`. Defaults preserve
+   today's behavior. No optional `format` override yet — keep the surface
+   tight; add it when a real workflow asks for it.
+
+2. **Profile resolver** — new `stemforge/scene_model/format_profiles.py`
+   mapping each profile to a concrete `(target_rate, channels, bit_depth)`.
+   For Slice 1 only `target_rate` differs (24 kHz / 23437 Hz for vocal,
+   46875 Hz for everything else). Pure function; trivial to test.
+
+3. **WAV writer parameterization** — add `target_sample_rate: int |
+   None = None` to
+   [convert_wav_to_ep133](stemforge/exporters/ep133/wav_format.py#L43);
+   when `None`, default to `EP133_SAMPLE_RATE` (today's behavior). The
+   `_build_ep133_wav` and `byte_rate` math need to use the actual rate,
+   not the constant — small, surgical edit. Existing byte-identity test
+   (`test_song_export_parity`) stays green because the default path is
+   unchanged.
+
+4. **Projector wiring** — `synthesize` / `build_ppak` need to thread the
+   per-group rate into
+   [ppak_writer.py:297](stemforge/exporters/ep133/ppak_writer.py#L297)'s
+   `convert_wav_to_ep133` call. Lookup by group letter. The `project_from_spec`
+   path already knows the `Project` and can read each `GroupSpec.format_profile`.
+
+5. **Memory budget calculator** — new function
+   `Ep133Projector.estimate_memory_bytes(project) -> int`. Sums each pad's
+   `(end - start) seconds × group_rate × 2 bytes`. Pure function over
+   `Project` + clip durations from `ClipRef` or manifest.
+
+6. **`validate_spec` extension** — append warning when `estimate_memory_bytes
+   > 64 * 1024 * 1024`. Hard threshold; no grace.
+
+7. **Tests:**
+   - `test_format_profile_preserve_source_byte_identity` — projecting a
+     known fixture with all-`preserve_source` groups produces bytes equal
+     to today's output. Locks the migration.
+   - `test_format_profile_vocal_downsamples_rate` — projecting one group
+     as `vocal` produces a `.ppak` whose extracted WAVs report
+     `framerate == 23437` (read with `wave.open`).
+   - `test_memory_budget_warns_over_cap` — synthetic 70 MB project surfaces
+     the warning; 60 MB project doesn't.
+   - `test_format_profile_round_trips_in_serialize` — schema field survives
+     JSON round-trip.
+
+**Acceptance:** byte-identity gate stays green; one new test demonstrates
+mixed-rate output; memory warning fires deterministically.
+
+**Out of scope for Slice 1:** no UI, no `format` override, no per-pad
+format, no Koala/Chompi rate handling.
+
+---
+
+### Slice 2 — Multi-source kit assembly (the deck-builder CLI)
+
+**Outcome:** a deck-shaped `Project` can be built by hand-picking clips
+across N forge runs, without going through Live's arrangement view. The
+CLI emits a `ProjectSpec` JSON; the projector turns it into a `.ppak`.
+
+This is the workflow piece that **doesn't exist anywhere today**. The
+existing `Ep133Projector.project_from_spec` requires a single
+`manifest` argument because `synthesize` walks `manifest.session_tracks`
+to look up sample slots
+([stemforge/exporters/ep133/song_synthesizer.py:1-17](stemforge/exporters/ep133/song_synthesizer.py#L1-L17)).
+The verse-swap deck has **12 manifests**; the kit projection path needs
+to resolve clips from a federated lookup.
+
+Concrete commits:
+
+1. **Federated clip resolver** — new `stemforge/exporters/ep133/clip_index.py`.
+   Given a list of forge directories, builds a
+   `dict[audio_hash, (path, manifest_entry)]`. Per Decision 13, this is the
+   identity layer; per Phase 2 loose-end #1, today's `audio_hash` is empty
+   string at COMMIT time, so this slice also wires hash population at
+   resolver build time (compute on demand from file bytes — trivial).
+
+2. **Kit-projection synthesizer path** — new
+   `stemforge/exporters/ep133/kit_synthesizer.py`. Mirrors `song_synthesizer.py`
+   but consumes `(Project, ClipIndex)` instead of `(snapshots, manifest)`.
+   Emits a one-scene `PpakSpec` where every pad is its own pattern (one
+   trigger at position 0). Re-uses
+   [global_sample_slot()](stemforge/exporters/ep133/song_synthesizer.py#L77)
+   for slot allocation — Group A → 700-719, B → 720-739, C → 740-759,
+   D → 760-779.
+
+3. **Projector method** — `Ep133Projector.project_kit(project, clip_index,
+   *, project_slot, reference_template)` — analogue of `project_from_spec`
+   but driven by `kit_synthesizer.synthesize_kit(...)`. Bytes path is
+   identical from `PpakSpec` onwards.
+
+4. **CLI: `stemforge build-deck`** — new subcommand. Takes a YAML/JSON
+   project plan and a list of forge directories; emits the `ProjectSpec`
+   plus the `.ppak`. Plan shape (concrete, simple):
+
+   ```yaml
+   project: "verse_swap_deck_v1"
+   project_slot: 8
+   groups:
+     A:
+       format_profile: vocal
+       pads:
+         - {pad: 1, source: "01_hey_mami/curated/manifest.json", clip: "vocals_v1"}
+         - {pad: 2, source: "02_benjamins/curated/manifest.json", clip: "vocals_v1"}
+         - ... (12 pads)
+     B:
+       format_profile: vocal
+       pads: [... 12 alt verses + hooks ...]
+     C:
+       format_profile: drum
+       pads: [... 12 drum picks ...]
+     D:
+       format_profile: texture
+       pads: [... 12 bass/synth/other ...]
+   ```
+
+   The `clip:` selector resolves against the manifest's `session_tracks`
+   entries. Naming convention: bar-loop chunks are addressable by stem
+   plus bar index (`drums_b3` = 3rd bar of drums stem), or by curated
+   slot name. Pick whichever's already canonical; that's a 30-min
+   research task before this commit.
+
+5. **Live test on the deck** — the user actually performs from it. This
+   is acceptance, not "tests passing."
+
+**Acceptance:** user runs `stemforge build-deck deck.yaml --output verse_swap.ppak`,
+loads to project slot 8, plays a 15-minute set without laptop, all 24
+vocal pads audible and in tempo, drum/synth pads functional.
+
+**Out of scope for Slice 2:** popup UI, drag-import, audio preview,
+HTTP server. The CLI YAML is the editor for now.
+
+---
+
+### (Slice 3 dropped — user-side curation handles verse production)
+
+User-side workflow assumed: hand-curate clips in Live (verses, hooks,
+drum picks, bass/synth fragments), COMMIT into a manifest per source
+song. The deck-builder operates on those manifests + optionally raw
+WAV paths for clips that bypass COMMIT.
+
+**deck.yaml supports two clip-resolution shapes** (both, not pick-one):
+
+```yaml
+groups:
+  A:
+    pads:
+      - {pad: 1, source: "01_hey_mami/curated/manifest.json", clip: "vocals_verse_1"}
+      - {pad: 2, path: "/Users/zak/Music/hand_curated/02_benjamins/verse_1.wav"}
+```
+
+`clip:` resolves through the federated `ClipIndex`; `path:` references
+a raw WAV directly (hash computed at build-deck time). Both produce a
+`ClipRef` with the same downstream behavior. Trivial to support both;
+saves the user from forcing every clip through COMMIT if they don't
+want to.
+
+---
+
+## Sequence + critical-path dependencies
+
+```
+Slice 1 ──→ Slice 2 ──→ Live performance verification on hardware
+```
+
+Slice 1 lands first (byte-identity gate, isolated, testable).
+Slice 2 builds on it (needs `format_profile` in the schema).
+
+---
+
+## What I'm explicitly NOT doing in this plan
+
+Per the Phase 3 fresh-session handoff:
+
+- No HTTP server (Phase 3.1) — the CLI is the editor for v0 of this deck.
+- No M4L strip device for configurator (Phase 3.2) — existing `forge`
+  device stays unchanged.
+- No popup UI / pad canvas / inspector (Phase 4) — the YAML deck plan
+  is the inspector.
+- No Koala/Chompi projectors (Phase 3.5/3.6) — EP-133 only.
+- No splice editor (Phase 4.7) — single-scene Workflow B.
+- No multi-target export (Phase 4.8) — EP-133 only.
+- No per-pad format profile — per-group is the whole surface.
+
+The configurator Phase 3 + 4 work in v4's plan is genuinely useful
+**after** this deck ships — at that point you have a real workflow to
+test the popup against. Building popup-first risks designing for an
+imagined workflow.
+
+---
+
+## Risks specific to this path
+
+**RV1 — `audio_hash` empty at COMMIT.** Phase 2 loose-end. Slice 2's
+clip resolver computes hash on demand from file bytes, so this isn't
+actually blocking — but it does mean two hashes are generated for the
+same content (one in resolver, one when COMMIT eventually wires it up)
+unless we standardize on the same helper. **Mitigation:** use
+[stemforge/manifest_schema.py:66](stemforge/manifest_schema.py#L66)'s
+`compute_audio_hash` everywhere. One place; no drift.
+
+**RV2 — verses' BPM may differ from project BPM.** A hip-hop deck
+spans 88-100 BPM across sources. EP-133's per-pad `time.mode: bpm` +
+`sound.bpm` handles this — it stretches playback to project tempo.
+Each `ClipRef` already carries `source_bpm`; `convert_wav_to_ep133`
+already takes `sound_bpm`. Slice 2 just needs to wire the bpm through
+from `ClipRef.source_bpm` for each pad. **No new code; just plumbing.**
+
+**RV3 — sample-rate downsampling breaks BPM stretching.**
+Conjecture: lower-rate vocal samples might stretch differently on
+device because the BPM-stretch math depends on the WAV's declared rate.
+Probability low but unverified. **Mitigation:** Slice 1 acceptance
+includes "load a 23437 Hz WAV with `time.mode: bpm` to a real device,
+play at scene tempo, confirm pitch + tempo are correct." Live test, not
+unit test.
+
+**RV4 — verse trim points + project-tempo-synced playback.** Decision
+14 says pad canvas is the slot table; trim points are in the pad
+config (`start_offset_sec` / `end_offset_sec` already on `ClipRef`).
+The 16-bar verse may not be a clean 16 bars on the source — pickup
+notes, post-verse breath, etc. **Mitigation:** Slice 3's verse
+extraction outputs the raw trim; Slice 2's YAML can refine via per-pad
+`start_offset_sec` / `end_offset_sec`. Both layers already supported by
+the schema.
+
+**RV5 — phasing pressure to skip Slice 1's byte-identity gate.** Easy
+trap: "format_profile defaults to preserve_source; nobody changes it;
+why do we need a parity test?" Because subtle bugs in the rate
+parameterization will only surface when the user actually flips a
+group to `vocal` in production, after the test is gone. Hold the
+gate.
+
+---
+
+## Definition of done
+
+User is able to:
+1. Author a `deck.yaml` listing 4 groups × 12 pads with `format_profile`
+   per group, referencing a mix of manifest entries (`clip:`) and raw
+   WAV paths (`path:`).
+2. Run `stemforge build-deck deck.yaml --output verse_swap.ppak`, see
+   the memory-budget validation report ~50 MB used / 64 MB cap, no
+   warnings.
+3. Load `verse_swap.ppak` to EP-133 project slot 8 via existing
+   `tools/ep133_load_project.py` plumbing (or a sysex transfer
+   helper if needed).
+4. Perform: trigger Group A pad 1 (a verse), swap Group C drum break
+   underneath mid-verse, swap to Group B pad 7 (alt hook from a
+   different song), Group D pad 4 sub-bass underlay. No laptop,
+   no audible drift, vocals stretched to scene tempo correctly.
+
+That's the ship bar.


### PR DESCRIPTION
## Summary

**Protects the configurator design work from a lost-laptop incident.** 4 active configurator spec files were sitting untracked in `new_specs/` at repo root — committing them as the canonical configurator design source.

## Files committed

| File | Lines | What it is |
|---|---|---|
| `docs/configurator/STEMFORGE_CONFIGURATOR_SPEC_v4.md` | 687 | **Active spec.** Goal, scope, load-bearing decisions 1–16, 5-phase plan, risks. |
| `docs/configurator/STEMFORGE_TOP3_WORKFLOWS.md` | 502 | Target use cases. Priority has shifted to Workflow #3a (verse-swap deck). |
| `docs/configurator/VERSE_SWAP_DECK_PLAN.md` | 311 | Execution plan for the hip-hop verse-swap workflow. Decision 16 (per-group sample rate) is load-bearing. |
| `docs/configurator/PHASE_3_FRESH_SESSION_HANDOFF.md` | 141 | Paste-at-fresh-session brief. Required reading order, the 3 design calls that gate Phase 3 start. |
| `docs/configurator/README.md` | new | Index of the dir + phase status (1/2/2.5 ✅ shipped, 3/4/5 not started) + reading order. |

## Cross-refs updated during the move

| File | Change |
|---|---|
| `PHASE_3_FRESH_SESSION_HANDOFF.md:14, 18` | `docs/STEMFORGE_*` → `docs/configurator/STEMFORGE_*` for in-dir companion docs |
| `PHASE_3_FRESH_SESSION_HANDOFF.md:21` | `HARDENING_VERIFICATION.md` qualified with `docs/` prefix (matches new location post-PR #88) |
| `STEMFORGE_TOP3_WORKFLOWS.md:5` | Companion ref `STEMFORGE_CONFIGURATOR_SPEC_v3.md` (archived) → v4 (active), with note about archive/ |

## Configurator status (also in the new README)

- **Phase 1** ✅ shipped — `stemforge/scene_model/`, `AbstractProjector`, EP-133 projector with byte-identity gate, `re-anchor --then-curate`
- **Phase 2** ✅ shipped — full `Project → Song → SceneSpec → GroupSpec → PadSpec` schema
- **Phase 2.5** ✅ shipped — COMMIT walks arrangement view too
- **Phase 3** — not started. M4L device + HTTP server + popup shell.
- **Phase 4** — not started. Editor UI.
- **Phase 5** — not started. Locator sync + skill bindings.

The breaks-n-beats1 `.ppak` shipped in v0.2.0 hardware-validates the EP-133 pipeline end-to-end via the CLI path. The configurator adds a UI on top of this proven foundation.

## Test plan

- [x] Docs-only; no code changes.
- [x] All 4 spec files moved verbatim except the 3 cross-ref updates listed above.
- [x] `new_specs/` removed (was untracked + empty after the moves).

## Mild ordering note

The `docs/HARDENING_VERIFICATION.md` reference in `PHASE_3_FRESH_SESSION_HANDOFF.md` assumes PR #88 (root cleanup) has merged. If this PR merges first, that link is broken for ~the duration before #88 lands. The pair were designed to merge in either order; this is the only inter-PR link.

Generated with [Claude Code](https://claude.com/claude-code)
