### PR TITLE
feat(configurator): Phase 3 HTTP server — intent-receiver API + SSE + audio_hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,16 @@ ep133 = [
     "python-rtmidi>=1.5",
     "playwright>=1.45",
 ]
+# Configurator HTTP server (Phase 3): FastAPI + uvicorn + soundfile-backed
+# preview/hash helpers. Local-only bind; auth-free; the M4L strip + popup
+# both talk to this surface. Optional so headless-CI installs don't pull
+# the web stack.
+configurator = [
+    "fastapi>=0.110",
+    "uvicorn>=0.27",
+    "soundfile>=0.12",
+    "httpx>=0.27",
+]
 # ONNX Runtime + conversion tooling (required for native M4L binary per PIVOT).
 onnx = [
     "onnx>=1.16",
@@ -74,6 +84,7 @@ local = [
 [project.scripts]
 stemforge = "stemforge.cli:cli"
 sf-remote = "tools.sf_remote:main"
+stemforge-configurator = "stemforge.configurator.server:run"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/stemforge/configurator/__init__.py
+++ b/stemforge/configurator/__init__.py
@@ -1,0 +1,29 @@
+"""Configurator HTTP server (Phase 3, Lane A).
+
+Local-only FastAPI app that holds the canonical :class:`Project` spec in
+memory and exposes:
+
+- ``GET /state`` — current :class:`Project` JSON.
+- ``GET /state/stream`` — Server-Sent Events stream (``state``, ``log``,
+  ``progress``, ``error``).
+- ``GET /preview/<clip_id>`` — Range-aware WAV streaming for clip preview.
+- ``GET /healthz`` — liveness check used by the strip device.
+- ``POST /intent/*`` — single-writer mutation endpoints: ``load-manifest``,
+  ``commit``, ``assign-pad``, ``clear-pad``, ``set-group-format``,
+  ``recompute``, ``export``.
+
+The server is the **single writer** to the slot table (configurator spec
+v4 Decision 15). Every other surface — strip device, popup, COMMIT —
+sends intents and receives state via SSE.
+
+Entry points:
+
+- :func:`stemforge.configurator.server.run` (also exposed as the
+  ``stemforge-configurator`` console script).
+- :mod:`tools.m4l_configurator_server` (thin wrapper used by the
+  M4L ``[shell]`` launcher).
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/stemforge/configurator/audio_hash.py
+++ b/stemforge/configurator/audio_hash.py
@@ -1,0 +1,163 @@
+"""Channel-collapse-invariant audio hash with on-disk cache.
+
+The configurator's clip identity is hash-based (spec v4 Decision 3).
+StemForge already has ``compute_audio_hash`` in
+:mod:`stemforge.manifest_schema`, but that one hashes the raw WAV bytes —
+which means re-encoding the same audio (mono ↔ stereo, 48 kHz ↔ 24 kHz)
+produces a different hash. For the configurator we want a **content** hash
+that survives format conversion at projector time.
+
+:func:`audio_hash` reads the float32 PCM, averages channels to mono, and
+hashes the bytes of that float32 mono buffer. Two WAVs with identical
+musical content but different channel counts or bit depths produce the
+same hash.
+
+A disk cache at ``~/stemforge/.audio_hash_cache.json`` keyed by
+``(path, mtime, size)`` avoids re-reading on every state-rebuild. Cache
+entries that point at no-longer-existing files are trimmed lazily on
+read.
+
+This module is intentionally self-contained — no imports from
+``stemforge.configurator.*`` — so it can be reused by other surfaces
+(future bounce-to-clip, splice editor, etc.) without taking on the
+HTTP-server dependency tree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+import soundfile as sf
+
+HASH_LENGTH: Final[int] = 16
+DEFAULT_CACHE_PATH: Final[Path] = Path.home() / "stemforge" / ".audio_hash_cache.json"
+
+
+def _cache_key(path: Path) -> str:
+    """Build the cache key for a path: ``"abs|mtime_ns|size"``."""
+    stat = path.stat()
+    return f"{path.resolve()}|{stat.st_mtime_ns}|{stat.st_size}"
+
+
+def _load_cache(cache_path: Path) -> dict[str, str]:
+    if not cache_path.is_file():
+        return {}
+    try:
+        return json.loads(cache_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_cache(cache_path: Path, cache: dict[str, str]) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True))
+    except OSError:
+        # Cache write is best-effort; don't let it surface as an error.
+        pass
+
+
+def _hash_buffer(samples: np.ndarray) -> str:
+    """Hash a float32 mono buffer's bytes. ``HASH_LENGTH`` hex chars."""
+    # Force C-contiguous float32 so the byte layout is canonical regardless
+    # of the source dtype/strides.
+    mono = np.ascontiguousarray(samples, dtype=np.float32)
+    return hashlib.sha256(mono.tobytes()).hexdigest()[:HASH_LENGTH]
+
+
+def _read_mono(path: Path) -> np.ndarray:
+    """Read audio and average channels to mono float32. Raises if unreadable."""
+    data, _sr = sf.read(str(path), dtype="float32", always_2d=True)
+    # data shape: (frames, channels). Mean across channel axis.
+    mono = data.mean(axis=1)
+    return mono.astype(np.float32, copy=False)
+
+
+def audio_hash(
+    wav_path: Path | str,
+    *,
+    cache_path: Path | None = None,
+    use_cache: bool = True,
+) -> str:
+    """Return a 16-char hex hash of ``wav_path``'s mono-mixdown PCM.
+
+    Channel-collapse-invariant: stereo and mono renderings of the same
+    musical content produce the same hash. The hash is computed against
+    float32 samples so format conversion (bit depth, sample rate not
+    changed) doesn't perturb it.
+
+    .. note::
+
+       Sample-rate changes DO change the hash — different rates produce
+       different sample arrays. That's intentional: a 24 kHz vocal
+       export is a derived artifact, not the same clip as the 48 kHz
+       source.
+
+    Args:
+        wav_path: Path to the audio file. Anything ``soundfile`` can read.
+        cache_path: Override the cache location. Defaults to
+            :data:`DEFAULT_CACHE_PATH`.
+        use_cache: When ``False``, bypass the cache entirely (still
+            updates it on miss). Useful for testing.
+
+    Returns:
+        Lowercase hex string of length :data:`HASH_LENGTH`.
+
+    Raises:
+        FileNotFoundError: ``wav_path`` doesn't exist.
+        RuntimeError: ``soundfile`` couldn't decode the file.
+    """
+    path = Path(wav_path).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"audio file not found: {path}")
+
+    cache_p = cache_path or DEFAULT_CACHE_PATH
+    cache: dict[str, str] = _load_cache(cache_p) if use_cache else {}
+
+    key = _cache_key(path)
+    if use_cache and key in cache:
+        return cache[key]
+
+    # Cache miss — compute the hash. Wrap soundfile errors in a friendly
+    # RuntimeError so callers don't have to know about libsndfile error
+    # taxonomy.
+    try:
+        samples = _read_mono(path)
+    except (sf.LibsndfileError, RuntimeError) as exc:  # pragma: no cover
+        raise RuntimeError(f"could not read audio from {path}: {exc}") from exc
+
+    digest = _hash_buffer(samples)
+
+    if use_cache:
+        # Trim stale entries lazily — anything that points at a missing
+        # file or has a key whose path no longer exists.
+        cache = _prune_cache(cache)
+        cache[key] = digest
+        _save_cache(cache_p, cache)
+
+    return digest
+
+
+def _prune_cache(cache: dict[str, str]) -> dict[str, str]:
+    """Drop cache entries whose path component no longer exists on disk."""
+    pruned: dict[str, str] = {}
+    for key, value in cache.items():
+        try:
+            raw_path = key.split("|", 1)[0]
+        except (IndexError, AttributeError):
+            continue
+        if os.path.exists(raw_path):
+            pruned[key] = value
+    return pruned
+
+
+__all__ = [
+    "DEFAULT_CACHE_PATH",
+    "HASH_LENGTH",
+    "audio_hash",
+]

--- a/stemforge/configurator/intents.py
+++ b/stemforge/configurator/intents.py
@@ -1,0 +1,385 @@
+"""Intent handlers — one async function per ``/intent/*`` endpoint.
+
+Each handler:
+
+1. Acquires ``state.mutation_lock`` (single-writer discipline, spec v4
+   Decision 15).
+2. Mutates ``state.project`` in place — or constructs a fresh
+   :class:`Project` for ``load-manifest``.
+3. Returns an :class:`IntentResponse` with ``ok=True`` on success.
+4. Broadcasts a ``state`` SSE event so subscribers can re-render.
+5. On failure, **does not** mutate; returns ``ok=False`` with populated
+   ``errors``.
+
+Handlers never raise — every failure surfaces as a structured error in
+the response envelope. The FastAPI route is responsible for HTTP-status
+mapping (200 with ``ok=False`` is acceptable here because the request
+*shape* was valid; pydantic 422 covers shape errors).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from stemforge.scene_model import (
+    ClipRef,
+    GroupSpec,
+    PadSpec,
+    Project,
+    Song,
+    empty_project_from_manifest,
+)
+
+from .audio_hash import audio_hash
+from .schemas import (
+    AssignPadRequest,
+    ClearPadRequest,
+    CommitRequest,
+    ExportRequest,
+    IntentResponse,
+    LoadManifestRequest,
+    RecomputeRequest,
+    SetGroupFormatRequest,
+)
+from .state import AppState
+
+DEFAULT_GROUPS = ("A", "B", "C", "D")
+PADS_PER_GROUP = 12
+
+
+def _ensure_song(project: Project) -> Song:
+    """Return ``project.songs[0]``, creating an empty one if missing."""
+    if not project.songs:
+        project.songs.append(
+            Song(
+                song_id="song_001",
+                name="",
+                bpm=120.0,
+                groups=[GroupSpec(group_id=g) for g in DEFAULT_GROUPS],
+                scenes=[],
+            )
+        )
+    return project.songs[0]
+
+
+def _ensure_group(song: Song, group_id: str) -> GroupSpec:
+    for g in song.groups:
+        if g.group_id == group_id:
+            return g
+    new = GroupSpec(group_id=group_id)
+    song.groups.append(new)
+    return new
+
+
+def _ensure_pad(group: GroupSpec, pad_idx: int) -> PadSpec:
+    """Return the pad whose ``pad_id`` matches ``str(pad_idx)``; create on demand."""
+    target = str(pad_idx)
+    for pad in group.pads:
+        if pad.pad_id == target:
+            return pad
+    new = PadSpec(pad_id=target)
+    group.pads.append(new)
+    return new
+
+
+# ── Handlers ─────────────────────────────────────────────────────────────────
+
+
+async def handle_load_manifest(state: AppState, req: LoadManifestRequest) -> IntentResponse:
+    """Replace state with a fresh project built from a stems manifest.
+
+    Wraps :func:`empty_project_from_manifest`. The manifest's
+    ``session_tracks`` block is the source of truth for the seed slot
+    table; audio hashes are NOT populated here — that's
+    ``/intent/commit``'s job (so the load step stays fast).
+    """
+    path = Path(req.manifest_path).expanduser()
+    if not path.is_file():
+        await state.error("manifest_not_found", f"manifest not found: {path}")
+        return IntentResponse(
+            ok=False,
+            errors=[f"manifest not found: {path}"],
+        )
+
+    try:
+        manifest = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        await state.error("manifest_unreadable", f"could not read manifest: {exc}")
+        return IntentResponse(
+            ok=False,
+            errors=[f"could not read manifest at {path}: {exc}"],
+        )
+
+    bpm = float(manifest.get("bpm") or req.bpm)
+
+    async with state.mutation_lock:
+        state.project = empty_project_from_manifest(
+            manifest,
+            bpm=bpm,
+            time_sig=req.time_sig,
+            project_name=req.project_name or path.stem,
+        )
+        state.last_manifest_path = str(path.resolve())
+
+    await state.log(f"loaded manifest from {path}", "info")
+    await state.broadcast_state()
+    return IntentResponse(ok=True, state=state.project, warnings=state.project.validate_v1())
+
+
+async def handle_commit(state: AppState, req: CommitRequest) -> IntentResponse:
+    """Reconcile observed session/arrangement tracks into the slot table.
+
+    Two driving modes (in priority order):
+
+    1. ``req.session_tracks`` populated — apply that block directly. The
+       M4L COMMIT path uses this.
+    2. ``req.manifest_path`` populated — re-read ``curated/manifest.json``
+       from disk.
+
+    Audio hashes are populated when ``populate_audio_hash=True`` (default)
+    using the channel-collapse-invariant :func:`audio_hash` helper. Pads
+    whose clip file can't be found are recorded with an empty
+    ``audio_hash`` and a warning.
+    """
+    warnings: list[str] = []
+
+    if req.session_tracks is not None:
+        session_tracks = req.session_tracks
+    elif req.manifest_path is not None:
+        path = Path(req.manifest_path).expanduser()
+        if not path.is_file():
+            return IntentResponse(ok=False, errors=[f"manifest not found: {path}"])
+        try:
+            manifest = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            return IntentResponse(ok=False, errors=[f"could not read manifest at {path}: {exc}"])
+        session_tracks = manifest.get("session_tracks") or {}
+    else:
+        return IntentResponse(
+            ok=False,
+            errors=[
+                "commit requires either session_tracks or manifest_path; neither was provided."
+            ],
+        )
+
+    async with state.mutation_lock:
+        song = _ensure_song(state.project)
+        for group_letter in DEFAULT_GROUPS:
+            entries = (
+                session_tracks.get(group_letter) or session_tracks.get(group_letter.lower()) or []
+            )
+            group = _ensure_group(song, group_letter)
+            # Reset the group's pads to mirror the observed entries.
+            # COMMIT is authoritative for *this* reconciliation; user-driven
+            # assign-pad calls after this will layer on top.
+            new_pads: list[PadSpec] = []
+            for entry in entries:
+                slot = int(entry.get("slot", len(new_pads)))
+                pad_id = str(slot + 1)
+                file_path = entry.get("file_path") or entry.get("file")
+                hash_val = str(entry.get("audio_hash") or "")
+                if req.populate_audio_hash and not hash_val and file_path:
+                    try:
+                        hash_val = audio_hash(file_path)
+                    except (FileNotFoundError, RuntimeError) as exc:
+                        warnings.append(f"could not hash {file_path}: {exc}")
+                clip = ClipRef(
+                    audio_hash=hash_val,
+                    path=str(file_path) if file_path else None,
+                    name=entry.get("name"),
+                    source_bpm=(float(entry["source_bpm"]) if entry.get("source_bpm") else None),
+                    end_offset_sec=(
+                        float(entry["clip_length_sec"])
+                        if entry.get("clip_length_sec") is not None
+                        else None
+                    ),
+                )
+                new_pads.append(
+                    PadSpec(
+                        pad_id=pad_id,
+                        clip=clip,
+                        play_mode="oneshot",
+                        stretch_mode="bpm",
+                    )
+                )
+            group.pads = new_pads
+
+    await state.log("committed session_tracks", "info")
+    await state.broadcast_state()
+    return IntentResponse(ok=True, state=state.project, warnings=warnings)
+
+
+async def handle_assign_pad(state: AppState, req: AssignPadRequest) -> IntentResponse:
+    """Set the clip on ``(group, pad)``.
+
+    ``clip_id`` is the ``audio_hash`` of an existing clip in the project,
+    OR (when ``clip_path`` is also provided) a fresh hash for a new clip.
+    Either way, the pad's ``ClipRef.audio_hash`` becomes the canonical
+    identity.
+    """
+    if req.clip_id is None and req.clip_path is None:
+        return IntentResponse(
+            ok=False,
+            errors=["assign-pad requires clip_id or clip_path"],
+        )
+
+    warnings: list[str] = []
+    async with state.mutation_lock:
+        song = _ensure_song(state.project)
+        group = _ensure_group(song, req.group)
+        pad = _ensure_pad(group, req.pad)
+
+        hash_val = req.clip_id or ""
+        if req.clip_path and not hash_val:
+            try:
+                hash_val = audio_hash(req.clip_path)
+            except (FileNotFoundError, RuntimeError) as exc:
+                warnings.append(f"could not hash {req.clip_path}: {exc}")
+
+        pad.clip = ClipRef(
+            audio_hash=hash_val,
+            path=req.clip_path,
+            name=req.name,
+        )
+
+    await state.log(f"assigned pad {req.group}{req.pad}", "info")
+    await state.broadcast_state()
+    return IntentResponse(ok=True, state=state.project, warnings=warnings)
+
+
+async def handle_clear_pad(state: AppState, req: ClearPadRequest) -> IntentResponse:
+    """Drop the clip on ``(group, pad)``. Pad row stays in the model."""
+    async with state.mutation_lock:
+        song = _ensure_song(state.project)
+        group = _ensure_group(song, req.group)
+        pad = _ensure_pad(group, req.pad)
+        pad.clip = None
+
+    await state.log(f"cleared pad {req.group}{req.pad}", "info")
+    await state.broadcast_state()
+    return IntentResponse(ok=True, state=state.project)
+
+
+async def handle_set_group_format(
+    state: AppState,
+    req: SetGroupFormatRequest,
+) -> IntentResponse:
+    """Update a group's ``format_profile`` (spec v4 Decision 16)."""
+    async with state.mutation_lock:
+        song = _ensure_song(state.project)
+        group = _ensure_group(song, req.group)
+        group.format_profile = req.format
+
+    await state.log(f"set group {req.group} format to {req.format}", "info")
+    await state.broadcast_state()
+    return IntentResponse(ok=True, state=state.project)
+
+
+async def handle_recompute(state: AppState, req: RecomputeRequest) -> IntentResponse:
+    """Re-broadcast state; future work derives bars + memory budget here."""
+    async with state.mutation_lock:
+        # No-op for now — derived state is computed on read. The intent
+        # exists so Lane B's UI can force a refresh without mutating.
+        pass
+
+    await state.log("recompute triggered", "info")
+    await state.broadcast_state()
+    return IntentResponse(
+        ok=True,
+        state=state.project,
+        warnings=state.project.validate_v1(),
+    )
+
+
+async def handle_export(state: AppState, req: ExportRequest) -> IntentResponse:
+    """Export the current project to a hardware target's bundle format.
+
+    Today only ``target="ep133"`` is wired; the projector's
+    ``project_from_spec`` or ``project_kit`` path is selected based on
+    whether the project has scenes (``project_from_spec``) or is a
+    single-scene kit (``project_kit``). Writes the resulting bytes to
+    ``out_path`` and emits start/finish progress SSE events.
+    """
+    # Heavy import deferred so module-load doesn't pull mido / EP-133 deps
+    # for routes that never touch them.
+    from stemforge.exporters.ep133.clip_index import ClipIndex
+    from stemforge.exporters.ep133.projector import Ep133Projector
+
+    warnings: list[str] = []
+    out_path = Path(req.out_path).expanduser()
+
+    await state.progress("export", 0.0, f"Exporting to {req.target} → {out_path.name}")
+
+    async with state.mutation_lock:
+        snapshot = state.project.model_copy(deep=True)
+
+    projector = Ep133Projector()
+    warnings.extend(projector.validate_spec(snapshot))
+    if not snapshot.songs:
+        await state.progress("export", 1.0, "Aborted: no songs.")
+        return IntentResponse(
+            ok=False,
+            errors=["project has no songs; nothing to export"],
+        )
+
+    song = snapshot.songs[0]
+    has_scenes = bool(song.scenes)
+
+    try:
+        await state.progress("export", 0.25, "Synthesizing bytes...")
+        if has_scenes:
+            # Song-mode path needs a manifest to resolve scene-aligned
+            # snapshots. For now require the manifest was loaded via
+            # /intent/load-manifest and is on disk.
+            if not state.last_manifest_path:
+                return IntentResponse(
+                    ok=False,
+                    errors=[
+                        "scene-mode export requires a loaded manifest; "
+                        "call /intent/load-manifest first."
+                    ],
+                )
+            manifest = json.loads(Path(state.last_manifest_path).read_text())
+            payload = projector.project_from_spec(
+                snapshot,
+                manifest,
+                project_slot=req.project_slot,
+                reference_template=req.reference_template,
+            )
+        else:
+            # Workflow B (single-scene kit). Build a federated clip index
+            # rooted at ``last_manifest_path`` when present; otherwise the
+            # ClipRef.path fallbacks are used by the kit synthesizer.
+            clip_index = ClipIndex()
+            if state.last_manifest_path:
+                clip_index.add_manifest(Path(state.last_manifest_path))
+            payload = projector.project_kit(
+                snapshot,
+                clip_index,
+                project_slot=req.project_slot,
+                reference_template=req.reference_template,
+            )
+    except Exception as exc:  # noqa: BLE001
+        await state.error("export_failed", str(exc))
+        return IntentResponse(
+            ok=False,
+            errors=[f"{type(exc).__name__}: {exc}"],
+        )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(payload)
+    await state.progress("export", 1.0, f"Wrote {len(payload)} bytes to {out_path}")
+    await state.log(f"exported {len(payload)} bytes to {out_path}", "info")
+    return IntentResponse(ok=True, state=snapshot, warnings=warnings)
+
+
+__all__ = [
+    "handle_assign_pad",
+    "handle_clear_pad",
+    "handle_commit",
+    "handle_export",
+    "handle_load_manifest",
+    "handle_recompute",
+    "handle_set_group_format",
+]

--- a/stemforge/configurator/preview.py
+++ b/stemforge/configurator/preview.py
@@ -1,0 +1,128 @@
+"""Range-aware WAV serving for the configurator's clip preview surface.
+
+The popup's ``<audio>`` tag (or future waveform viewer) issues ``Range``
+requests to scrub through a clip without downloading the whole file.
+:func:`build_audio_response` parses an HTTP ``Range`` header against a
+file's byte length and returns a FastAPI :class:`Response` with the
+correct slice and ``Content-Range`` / ``Accept-Ranges`` headers.
+
+This is intentionally a pure-bytes path — no decoding, no resampling.
+The browser handles WAV decoding; the server just serves the slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import Response
+
+WAV_MIME = "audio/wav"
+
+
+@dataclass(frozen=True)
+class ByteRange:
+    """Resolved byte range for a single ``Range: bytes=START-END`` request."""
+
+    start: int
+    end: int  # inclusive
+    total: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start + 1
+
+
+def parse_range(header_value: str | None, total: int) -> ByteRange | None:
+    """Parse an HTTP ``Range`` header against a file's byte length.
+
+    Returns ``None`` when the header is absent or malformed. Returns a
+    :class:`ByteRange` clamped to ``0..total-1`` otherwise.
+
+    Supports only the single-range ``bytes=START-END`` form. Multi-range
+    requests are rare; for the configurator's purposes we 200-fallback
+    via the caller's ``None`` branch when this returns ``None``.
+    """
+    if not header_value or total <= 0:
+        return None
+    header = header_value.strip().lower()
+    if not header.startswith("bytes="):
+        return None
+    spec = header[len("bytes=") :].split(",", 1)[0].strip()
+    if "-" not in spec:
+        return None
+    start_s, end_s = spec.split("-", 1)
+    start_s, end_s = start_s.strip(), end_s.strip()
+    try:
+        if start_s == "":
+            # Suffix range: bytes=-N → last N bytes.
+            if end_s == "":
+                return None
+            length = int(end_s)
+            if length <= 0:
+                return None
+            start = max(0, total - length)
+            end = total - 1
+        else:
+            start = int(start_s)
+            end = int(end_s) if end_s else total - 1
+    except ValueError:
+        return None
+    if start < 0 or start >= total:
+        return None
+    if end < start:
+        return None
+    end = min(end, total - 1)
+    return ByteRange(start=start, end=end, total=total)
+
+
+def build_audio_response(
+    path: Path,
+    *,
+    range_header: str | None,
+    mime: str = WAV_MIME,
+) -> Response:
+    """Build a FastAPI response for ``path``, honoring an optional ``Range``.
+
+    - Without a ``Range`` header → 200 with the full body and
+      ``Accept-Ranges: bytes`` (so the browser knows it can request slices).
+    - With a parseable ``Range`` header → 206 with the slice +
+      ``Content-Range: bytes START-END/TOTAL``.
+    - With a malformed range → 200 fallback (lenient; matches most CDN
+      behavior).
+    """
+    if not path.is_file():
+        return Response(status_code=404, content=f"clip not found: {path.name}")
+
+    total = path.stat().st_size
+    rng = parse_range(range_header, total)
+    headers = {
+        "Accept-Ranges": "bytes",
+        "Content-Type": mime,
+    }
+    if rng is None:
+        return Response(
+            content=path.read_bytes(),
+            status_code=200,
+            headers={**headers, "Content-Length": str(total)},
+        )
+    with path.open("rb") as fh:
+        fh.seek(rng.start)
+        chunk = fh.read(rng.length)
+    return Response(
+        content=chunk,
+        status_code=206,
+        headers={
+            **headers,
+            "Content-Range": f"bytes {rng.start}-{rng.end}/{total}",
+            "Content-Length": str(len(chunk)),
+        },
+    )
+
+
+__all__ = [
+    "ByteRange",
+    "WAV_MIME",
+    "build_audio_response",
+    "parse_range",
+]

--- a/stemforge/configurator/schemas.py
+++ b/stemforge/configurator/schemas.py
@@ -1,0 +1,174 @@
+"""Pydantic request/response schemas for the configurator HTTP API.
+
+These models describe the **wire format** of the ``/intent/*`` endpoints
+and the ``IntentResponse`` envelope every mutation handler returns. They
+intentionally do **not** redefine the underlying scene model — that lives
+in :mod:`stemforge.scene_model` and stays the single source of truth.
+
+Each request model maps 1:1 to a handler in :mod:`.intents`. The
+``Literal`` constraints (group letters, pad indices, format profiles)
+exist so pydantic returns ``422`` with a structured error before the
+handler runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from stemforge.scene_model import FormatProfile, Project
+
+GroupLetter = Literal["A", "B", "C", "D"]
+ExportTarget = Literal["ep133"]
+
+
+# ── Intent requests ──────────────────────────────────────────────────────────
+
+
+class LoadManifestRequest(BaseModel):
+    """Replace current state with a project built from a stems manifest."""
+
+    manifest_path: Path
+    project_name: str | None = None
+    bpm: float = 120.0
+    time_sig: tuple[int, int] = (4, 4)
+
+    model_config = {"extra": "forbid"}
+
+
+class CommitRequest(BaseModel):
+    """Reconcile observed session/arrangement tracks into the slot table.
+
+    The M4L device may POST a fresh ``session_tracks`` block directly
+    (Phase 2.5 COMMIT flow), or trigger a re-read from
+    ``manifest_path``'s ``curated/manifest.json``. Audio hashes are
+    populated as part of this intent (closes Phase 2 loose-end #1).
+    """
+
+    session_tracks: dict[str, list[dict[str, Any]]] | None = None
+    manifest_path: Path | None = None
+    populate_audio_hash: bool = True
+
+    model_config = {"extra": "forbid"}
+
+
+class AssignPadRequest(BaseModel):
+    group: GroupLetter
+    pad: int = Field(..., ge=1, le=12)
+    clip_id: str | None = None  # ``audio_hash`` of the clip to assign
+    clip_path: str | None = None  # advisory; recorded on the ClipRef
+    name: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+
+class ClearPadRequest(BaseModel):
+    group: GroupLetter
+    pad: int = Field(..., ge=1, le=12)
+
+    model_config = {"extra": "forbid"}
+
+
+class SetGroupFormatRequest(BaseModel):
+    group: GroupLetter
+    format: FormatProfile  # mirrors stemforge.scene_model.FormatProfile
+
+    model_config = {"extra": "forbid"}
+
+
+class RecomputeRequest(BaseModel):
+    """No-op-bodied trigger; recomputes derived state (bars, memory budget)."""
+
+    # Intentionally empty: the body's presence is the signal. Reserving
+    # for future "scope" flags (e.g. ``bars=True, memory=False``).
+    model_config = {"extra": "forbid"}
+
+
+class ExportRequest(BaseModel):
+    target: ExportTarget
+    out_path: Path
+    project_slot: int = Field(default=1, ge=1, le=9)
+    reference_template: Path | None = None
+
+    model_config = {"extra": "forbid"}
+
+
+# ── Response envelope ────────────────────────────────────────────────────────
+
+
+class IntentResponse(BaseModel):
+    """Uniform response shape for every ``/intent/*`` POST.
+
+    ``ok=True`` ⇒ ``state`` is the new ``Project``; mutations were applied.
+    ``ok=False`` ⇒ ``state`` is ``None``; ``errors`` populated; no
+    mutation occurred (handlers must roll back on partial failure).
+    """
+
+    ok: bool
+    state: Project | None = None
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "forbid"}
+
+
+# ── SSE event payloads (documented; not strictly required by FastAPI) ────────
+
+
+class StateEvent(BaseModel):
+    """``event: state`` payload — the full Project JSON."""
+
+    project: Project
+
+    model_config = {"extra": "forbid"}
+
+
+class LogEvent(BaseModel):
+    """``event: log`` payload — human-readable line for the strip device."""
+
+    level: Literal["debug", "info", "warning", "error"] = "info"
+    message: str
+    ts: float
+
+    model_config = {"extra": "forbid"}
+
+
+class ProgressEvent(BaseModel):
+    """``event: progress`` payload — long-running operation status."""
+
+    op: str
+    progress: float = Field(..., ge=0.0, le=1.0)
+    message: str = ""
+    ts: float
+
+    model_config = {"extra": "forbid"}
+
+
+class ErrorEvent(BaseModel):
+    """``event: error`` payload — non-fatal error surfaced to subscribers."""
+
+    code: str
+    message: str
+    ts: float
+
+    model_config = {"extra": "forbid"}
+
+
+__all__ = [
+    "AssignPadRequest",
+    "ClearPadRequest",
+    "CommitRequest",
+    "ErrorEvent",
+    "ExportRequest",
+    "ExportTarget",
+    "GroupLetter",
+    "IntentResponse",
+    "LoadManifestRequest",
+    "LogEvent",
+    "ProgressEvent",
+    "RecomputeRequest",
+    "SetGroupFormatRequest",
+    "StateEvent",
+]

--- a/stemforge/configurator/server.py
+++ b/stemforge/configurator/server.py
@@ -1,0 +1,292 @@
+"""FastAPI app + uvicorn entry point for the configurator HTTP server.
+
+The single :data:`app` object is built by :func:`create_app` so tests
+can construct fresh instances. :func:`run` is the console-script /
+``tools.m4l_configurator_server`` entry point — picks a port, writes
+``~/stemforge/.configurator_port`` for the strip device to discover, and
+boots uvicorn on ``127.0.0.1``.
+
+Routes:
+
+- ``GET  /healthz``
+- ``GET  /state``
+- ``GET  /state/stream``
+- ``GET  /preview/{clip_id}``
+- ``POST /intent/load-manifest``
+- ``POST /intent/commit``
+- ``POST /intent/assign-pad``
+- ``POST /intent/clear-pad``
+- ``POST /intent/set-group-format``
+- ``POST /intent/recompute``
+- ``POST /intent/export``
+
+Plus a static-files mount on ``/`` (configurable static dir; defaults to
+the package's ``static/`` directory). Lane B's frontend build output
+lands there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+from stemforge.scene_model import Project
+
+from . import intents
+from .preview import build_audio_response
+from .schemas import (
+    AssignPadRequest,
+    ClearPadRequest,
+    CommitRequest,
+    ExportRequest,
+    IntentResponse,
+    LoadManifestRequest,
+    RecomputeRequest,
+    SetGroupFormatRequest,
+)
+from .state import AppState, SseEvent
+
+DEFAULT_HOST = "127.0.0.1"
+PORT_ENV = "STEMFORGE_CONFIGURATOR_PORT"
+PORT_RANGE = range(7430, 7441)  # inclusive on 7440
+PORT_FILE = Path.home() / "stemforge" / ".configurator_port"
+STATIC_DIR_ENV = "STEMFORGE_CONFIGURATOR_STATIC"
+DEFAULT_STATIC_DIR = Path(__file__).parent / "static"
+PLACEHOLDER_HTML = (
+    '<!doctype html><html><head><meta charset="utf-8">'
+    "<title>StemForge Configurator</title></head><body>"
+    "<h1>Configurator static files not built yet</h1>"
+    "<p>Run <code>cd web/configurator && npm run build</code>.</p>"
+    "</body></html>"
+)
+
+
+# ── App factory ──────────────────────────────────────────────────────────────
+
+
+def create_app(*, static_dir: Path | None = None) -> FastAPI:
+    """Construct a fresh :class:`FastAPI` app and bind an :class:`AppState`.
+
+    Each call returns an independent app — tests use this to avoid
+    state leakage between cases. Production callers should use the
+    module-level :data:`app` built lazily by :func:`run`.
+    """
+    state = AppState()
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        yield
+        # No teardown to do — the lock + subscriber list are GC'd when
+        # the app dies.
+
+    app = FastAPI(
+        title="StemForge Configurator",
+        version="0.2.0",
+        lifespan=lifespan,
+    )
+    app.state.configurator = state
+
+    _register_routes(app, state)
+
+    # Static mount: serve the popup's build output (or the placeholder)
+    # at ``/``. Done last so explicit routes take precedence.
+    resolved_static = _resolve_static_dir(static_dir)
+    if not (resolved_static / "index.html").is_file():
+        resolved_static.mkdir(parents=True, exist_ok=True)
+        (resolved_static / "index.html").write_text(PLACEHOLDER_HTML)
+    app.mount("/", StaticFiles(directory=str(resolved_static), html=True), name="static")
+
+    return app
+
+
+def _resolve_static_dir(override: Path | None) -> Path:
+    if override is not None:
+        return Path(override).expanduser().resolve()
+    env = os.environ.get(STATIC_DIR_ENV)
+    if env:
+        return Path(env).expanduser().resolve()
+    return DEFAULT_STATIC_DIR.resolve()
+
+
+# ── Routes ───────────────────────────────────────────────────────────────────
+
+
+def _register_routes(app: FastAPI, state: AppState) -> None:
+    @app.get("/healthz")
+    async def healthz() -> JSONResponse:
+        return JSONResponse({"ok": True, "version": "0.2.0"})
+
+    @app.get("/state")
+    async def get_state() -> Project:
+        return state.project
+
+    @app.get("/state/stream")
+    async def stream_state(request: Request) -> StreamingResponse:
+        q = state.subscribe()
+
+        async def event_source() -> AsyncIterator[bytes]:
+            try:
+                # Send the current state immediately so a fresh subscriber
+                # has a baseline without waiting for the next mutation.
+                snapshot = SseEvent(
+                    event="state",
+                    data=json.loads(state.project.model_dump_json(exclude_none=True)),
+                )
+                yield snapshot.to_wire().encode("utf-8")
+                while True:
+                    if await request.is_disconnected():
+                        break
+                    try:
+                        event = await asyncio.wait_for(q.get(), timeout=15.0)
+                    except asyncio.TimeoutError:
+                        # Keep-alive comment frame so intermediaries don't
+                        # idle-kill the stream.
+                        yield b": keepalive\n\n"
+                        continue
+                    yield event.to_wire().encode("utf-8")
+            finally:
+                state.unsubscribe(q)
+
+        return StreamingResponse(event_source(), media_type="text/event-stream")
+
+    @app.get("/preview/{clip_id}")
+    async def preview(
+        clip_id: str,
+        range: str | None = Header(default=None),  # noqa: A002
+    ) -> Response:
+        clip_path = _resolve_clip_path(state.project, clip_id)
+        if clip_path is None:
+            raise HTTPException(status_code=404, detail=f"clip not found: {clip_id}")
+        return build_audio_response(clip_path, range_header=range)
+
+    # ── Intent routes ────────────────────────────────────────────────────────
+
+    @app.post("/intent/load-manifest", response_model=IntentResponse)
+    async def post_load_manifest(req: LoadManifestRequest) -> IntentResponse:
+        return await intents.handle_load_manifest(state, req)
+
+    @app.post("/intent/commit", response_model=IntentResponse)
+    async def post_commit(req: CommitRequest) -> IntentResponse:
+        return await intents.handle_commit(state, req)
+
+    @app.post("/intent/assign-pad", response_model=IntentResponse)
+    async def post_assign_pad(req: AssignPadRequest) -> IntentResponse:
+        return await intents.handle_assign_pad(state, req)
+
+    @app.post("/intent/clear-pad", response_model=IntentResponse)
+    async def post_clear_pad(req: ClearPadRequest) -> IntentResponse:
+        return await intents.handle_clear_pad(state, req)
+
+    @app.post("/intent/set-group-format", response_model=IntentResponse)
+    async def post_set_group_format(req: SetGroupFormatRequest) -> IntentResponse:
+        return await intents.handle_set_group_format(state, req)
+
+    @app.post("/intent/recompute", response_model=IntentResponse)
+    async def post_recompute(req: RecomputeRequest) -> IntentResponse:
+        return await intents.handle_recompute(state, req)
+
+    @app.post("/intent/export", response_model=IntentResponse)
+    async def post_export(req: ExportRequest) -> IntentResponse:
+        return await intents.handle_export(state, req)
+
+
+def _resolve_clip_path(project: Project, clip_id: str) -> Path | None:
+    """Find a clip with ``audio_hash == clip_id`` in the project; return its path."""
+    for song in project.songs:
+        for group in song.groups:
+            for pad in group.pads:
+                if pad.clip is None:
+                    continue
+                if pad.clip.audio_hash == clip_id and pad.clip.path:
+                    p = Path(pad.clip.path).expanduser()
+                    if p.is_file():
+                        return p
+    return None
+
+
+# ── Port discovery ───────────────────────────────────────────────────────────
+
+
+def discover_port() -> int:
+    """Pick a port: env var → first free in :data:`PORT_RANGE`.
+
+    Writes the resolved port to :data:`PORT_FILE` so the M4L strip device
+    can discover it. Raises :class:`RuntimeError` when no free port is
+    found in the configured range.
+    """
+    env = os.environ.get(PORT_ENV)
+    if env:
+        try:
+            return int(env)
+        except ValueError:
+            pass  # fall through to scan
+
+    for candidate in PORT_RANGE:
+        if _port_free(candidate):
+            return candidate
+    raise RuntimeError(
+        f"no free port in {PORT_RANGE.start}-{PORT_RANGE.stop - 1}; set {PORT_ENV} to override."
+    )
+
+
+def _port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((DEFAULT_HOST, port))
+        except OSError:
+            return False
+    return True
+
+
+def write_port_file(port: int, path: Path | None = None) -> Path:
+    """Persist the resolved port for the strip device to discover."""
+    target = path or PORT_FILE
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(str(port))
+    return target
+
+
+# ── Module-level app (for uvicorn import-string startup) ─────────────────────
+
+
+def _build_default_app() -> FastAPI:
+    return create_app()
+
+
+app: FastAPI = _build_default_app()
+
+
+def run() -> None:
+    """Console-script entry: pick port, write port file, run uvicorn."""
+    import uvicorn
+
+    port = discover_port()
+    write_port_file(port)
+    uvicorn.run(
+        "stemforge.configurator.server:app",
+        host=DEFAULT_HOST,
+        port=port,
+        log_level="info",
+    )
+
+
+__all__ = [
+    "DEFAULT_HOST",
+    "PORT_ENV",
+    "PORT_FILE",
+    "PORT_RANGE",
+    "app",
+    "create_app",
+    "discover_port",
+    "run",
+    "write_port_file",
+]

--- a/stemforge/configurator/state.py
+++ b/stemforge/configurator/state.py
@@ -1,0 +1,129 @@
+"""In-memory ProjectSpec + mutation lock + SSE broker.
+
+The configurator is **single-writer**: every mutation goes through one of
+the ``/intent/*`` handlers, which acquire :attr:`AppState.mutation_lock`
+before touching :attr:`AppState.project`. After a successful mutation the
+handler calls :meth:`AppState.broadcast_state` to push the new project to
+every SSE subscriber.
+
+The broker is an in-process fan-out — each subscriber owns one
+``asyncio.Queue``; the broker holds a list of those queues guarded by the
+same mutation lock. On disconnect the subscriber removes itself; nothing
+is persisted between server restarts.
+
+There's intentionally **no** persistence layer in this file. Disk
+debouncing (spec v4 Decision 15) is a follow-up; Phase 3.1 (this lane)
+ships the in-memory contract first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from stemforge.scene_model import Project, project_to_json
+
+EventName = Literal["state", "log", "progress", "error"]
+
+
+@dataclass
+class SseEvent:
+    """A single SSE frame to push to subscribers."""
+
+    event: EventName
+    data: dict[str, Any]
+
+    def to_wire(self) -> str:
+        """Serialize to the ``event: NAME\\ndata: JSON\\n\\n`` form."""
+        return f"event: {self.event}\ndata: {json.dumps(self.data, default=str)}\n\n"
+
+
+@dataclass
+class AppState:
+    """The mutable world the HTTP app runs against.
+
+    Held as a single attribute on ``app.state.configurator`` — there is
+    exactly one per server process. Initialization happens in
+    :func:`stemforge.configurator.server.create_app`.
+    """
+
+    project: Project = field(default_factory=Project)
+    mutation_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    subscribers: list[asyncio.Queue[SseEvent]] = field(default_factory=list)
+    # The Project's source manifest path (when loaded via load-manifest).
+    # Tracked so /intent/commit can re-read from disk without a body.
+    last_manifest_path: str | None = None
+
+    # ── Subscribers / broker ─────────────────────────────────────────────────
+
+    def subscribe(self) -> asyncio.Queue[SseEvent]:
+        """Register a new SSE subscriber. Caller MUST call :meth:`unsubscribe`."""
+        q: asyncio.Queue[SseEvent] = asyncio.Queue(maxsize=128)
+        self.subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[SseEvent]) -> None:
+        """Drop a subscriber's queue. Idempotent."""
+        try:
+            self.subscribers.remove(q)
+        except ValueError:
+            pass
+
+    async def broadcast(self, event: SseEvent) -> None:
+        """Push ``event`` to every subscriber. Drops on full queue."""
+        for q in list(self.subscribers):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                # Slow consumer — drop this event for them; don't block
+                # the broadcaster. Live UIs receive coalesced state via
+                # the next event.
+                pass
+
+    async def broadcast_state(self) -> None:
+        """Convenience: emit a ``state`` event with the current project."""
+        await self.broadcast(
+            SseEvent(event="state", data=json.loads(project_to_json(self.project)))
+        )
+
+    async def log(self, message: str, level: str = "info") -> None:
+        """Emit a ``log`` SSE event."""
+        await self.broadcast(
+            SseEvent(
+                event="log",
+                data={"level": level, "message": message, "ts": time.time()},
+            )
+        )
+
+    async def progress(self, op: str, progress: float, message: str = "") -> None:
+        """Emit a ``progress`` SSE event (0.0 → 1.0)."""
+        await self.broadcast(
+            SseEvent(
+                event="progress",
+                data={
+                    "op": op,
+                    "progress": max(0.0, min(1.0, float(progress))),
+                    "message": message,
+                    "ts": time.time(),
+                },
+            )
+        )
+
+    async def error(self, code: str, message: str) -> None:
+        """Emit an ``error`` SSE event."""
+        await self.broadcast(
+            SseEvent(
+                event="error",
+                data={"code": code, "message": message, "ts": time.time()},
+            )
+        )
+
+
+__all__ = [
+    "AppState",
+    "EventName",
+    "SseEvent",
+]

--- a/tests/configurator/conftest.py
+++ b/tests/configurator/conftest.py
@@ -1,0 +1,62 @@
+"""Test fixtures for configurator tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+
+@pytest.fixture
+def make_wav(tmp_path: Path):
+    """Return a callable that writes a deterministic WAV and returns its path.
+
+    Default: 0.5 s of mono 1 kHz sine at 22050 Hz. Override via kwargs.
+    """
+
+    def _make(
+        name: str = "test.wav",
+        *,
+        duration_sec: float = 0.5,
+        sample_rate: int = 22050,
+        channels: int = 1,
+        freq_hz: float = 1000.0,
+    ) -> Path:
+        path = tmp_path / name
+        n = int(duration_sec * sample_rate)
+        t = np.arange(n) / sample_rate
+        tone = (0.5 * np.sin(2 * np.pi * freq_hz * t)).astype("float32")
+        if channels == 1:
+            data = tone
+        else:
+            data = np.stack([tone] * channels, axis=1)
+        sf.write(str(path), data, sample_rate, subtype="PCM_16")
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def small_manifest(tmp_path: Path, make_wav):
+    """A 4-group manifest with one entry per group."""
+    groups = {}
+    for letter in ("A", "B", "C", "D"):
+        wav = make_wav(f"{letter}.wav")
+        groups[letter] = [
+            {
+                "slot": 0,
+                "file_path": str(wav),
+                "clip_length_sec": 0.5,
+                "name": f"clip_{letter}",
+            }
+        ]
+    manifest = {
+        "version": 1,
+        "bpm": 100.0,
+        "session_tracks": groups,
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(__import__("json").dumps(manifest))
+    return path

--- a/tests/configurator/test_audio_hash.py
+++ b/tests/configurator/test_audio_hash.py
@@ -1,0 +1,115 @@
+"""Tests for the channel-collapse-invariant audio hash."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from stemforge.configurator.audio_hash import HASH_LENGTH, audio_hash
+
+
+def test_hash_is_deterministic(make_wav, tmp_path: Path):
+    wav = make_wav("a.wav", duration_sec=0.25, freq_hz=440.0)
+    cache = tmp_path / "cache.json"
+    h1 = audio_hash(wav, cache_path=cache)
+    h2 = audio_hash(wav, cache_path=cache)
+    assert h1 == h2
+    assert len(h1) == HASH_LENGTH
+    assert all(c in "0123456789abcdef" for c in h1)
+
+
+def test_mono_vs_identical_stereo_hash_equal(tmp_path: Path):
+    """Stereo with L == R must hash the same as the mono version."""
+    sr = 22050
+    t = np.arange(int(sr * 0.25)) / sr
+    tone = (0.5 * np.sin(2 * np.pi * 440 * t)).astype("float32")
+
+    mono = tmp_path / "mono.wav"
+    sf.write(str(mono), tone, sr, subtype="PCM_16")
+
+    stereo = tmp_path / "stereo.wav"
+    sf.write(str(stereo), np.stack([tone, tone], axis=1), sr, subtype="PCM_16")
+
+    cache = tmp_path / "cache.json"
+    h_mono = audio_hash(mono, cache_path=cache)
+    h_stereo = audio_hash(stereo, cache_path=cache)
+    assert h_mono == h_stereo
+
+
+def test_different_content_hashes_differ(make_wav, tmp_path: Path):
+    a = make_wav("a.wav", freq_hz=440.0)
+    b = make_wav("b.wav", freq_hz=880.0)
+    cache = tmp_path / "cache.json"
+    assert audio_hash(a, cache_path=cache) != audio_hash(b, cache_path=cache)
+
+
+def test_cache_hit_avoids_re_reading_file(make_wav, tmp_path: Path, monkeypatch):
+    wav = make_wav("a.wav")
+    cache = tmp_path / "cache.json"
+
+    # Prime the cache.
+    expected = audio_hash(wav, cache_path=cache)
+    assert cache.is_file()
+
+    # Now monkeypatch soundfile.read to explode if invoked again.
+    import stemforge.configurator.audio_hash as ah
+
+    def boom(*args, **kwargs):
+        raise AssertionError("soundfile.read should not be called on cache hit")
+
+    monkeypatch.setattr(ah.sf, "read", boom)
+    second = audio_hash(wav, cache_path=cache)
+    assert second == expected
+
+
+def test_cache_miss_when_mtime_changes(make_wav, tmp_path: Path):
+    wav = make_wav("a.wav")
+    cache = tmp_path / "cache.json"
+    first = audio_hash(wav, cache_path=cache)
+
+    # Rewrite the file with different content; mtime / size will change.
+    import soundfile as _sf
+
+    t = np.arange(int(22050 * 0.25)) / 22050
+    different = (0.5 * np.sin(2 * np.pi * 1500 * t)).astype("float32")
+    _sf.write(str(wav), different, 22050, subtype="PCM_16")
+
+    second = audio_hash(wav, cache_path=cache)
+    assert second != first
+
+
+def test_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        audio_hash(tmp_path / "does_not_exist.wav", cache_path=tmp_path / "c.json")
+
+
+def test_use_cache_false_bypasses(make_wav, tmp_path: Path):
+    wav = make_wav("a.wav")
+    cache = tmp_path / "cache.json"
+    h = audio_hash(wav, cache_path=cache, use_cache=False)
+    assert len(h) == HASH_LENGTH
+    # No write should happen when use_cache is False.
+    assert not cache.exists()
+
+
+def test_cache_prunes_stale_paths(make_wav, tmp_path: Path):
+    """Cache entries that point at missing files should be trimmed."""
+    wav = make_wav("a.wav")
+    cache = tmp_path / "cache.json"
+    audio_hash(wav, cache_path=cache)
+
+    # Seed the cache with a bogus entry pointing at a non-existent path.
+    raw = json.loads(cache.read_text())
+    raw[f"{tmp_path}/missing.wav|0|0"] = "deadbeef" * 2
+    cache.write_text(json.dumps(raw))
+    assert "missing.wav" in cache.read_text()
+
+    # Trigger a recompute (different file → cache miss → prune).
+    other = make_wav("b.wav", freq_hz=550.0)
+    audio_hash(other, cache_path=cache)
+    final = json.loads(cache.read_text())
+    assert not any("missing.wav" in k for k in final)

--- a/tests/configurator/test_intents.py
+++ b/tests/configurator/test_intents.py
@@ -1,0 +1,210 @@
+"""Async handler tests — exercise each intent against a fresh AppState."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from stemforge.configurator import intents
+from stemforge.configurator.schemas import (
+    AssignPadRequest,
+    ClearPadRequest,
+    CommitRequest,
+    LoadManifestRequest,
+    RecomputeRequest,
+    SetGroupFormatRequest,
+)
+from stemforge.configurator.state import AppState
+
+
+def _run(coro):
+    # Pytest doesn't bind a default event loop on Python 3.10+; create one
+    # per call so handlers' asyncio.Lock() init binds to the loop they'll
+    # run on. We can't use asyncio.run() because the AppState's Lock is
+    # constructed in the fixture (outside the coroutine) and would bind to
+    # a different loop. Solution: use the same event loop for all _run
+    # calls within a test.
+    loop = _ensure_loop()
+    return loop.run_until_complete(coro)
+
+
+_LOOP_CACHE: dict[str, asyncio.AbstractEventLoop] = {}
+
+
+def _ensure_loop():
+    loop = _LOOP_CACHE.get("loop")
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        _LOOP_CACHE["loop"] = loop
+    return loop
+
+
+@pytest.fixture
+def state() -> AppState:
+    # Make sure the AppState's asyncio.Lock binds to the same loop the
+    # _run helper uses. Initializing the loop here primes the policy.
+    _ensure_loop()
+    return AppState()
+
+
+@pytest.fixture
+def collected_events(state: AppState):
+    """Subscribe to the broker and collect events into a list."""
+    queue = state.subscribe()
+    events: list = []
+
+    async def drain():
+        while not queue.empty():
+            events.append(await queue.get())
+
+    yield events, drain
+    state.unsubscribe(queue)
+
+
+def test_load_manifest_populates_state(state: AppState, small_manifest: Path):
+    resp = _run(
+        intents.handle_load_manifest(state, LoadManifestRequest(manifest_path=small_manifest))
+    )
+    assert resp.ok
+    assert resp.state is not None
+    song = resp.state.songs[0]
+    # All four groups present, each with one pad.
+    group_ids = {g.group_id for g in song.groups}
+    assert group_ids == {"A", "B", "C", "D"}
+    assert all(len(g.pads) == 1 for g in song.groups)
+    # last_manifest_path tracked so /intent/commit can re-read.
+    assert state.last_manifest_path == str(small_manifest.resolve())
+
+
+def test_load_manifest_missing_file_returns_error(state: AppState, tmp_path: Path):
+    resp = _run(
+        intents.handle_load_manifest(
+            state, LoadManifestRequest(manifest_path=tmp_path / "nope.json")
+        )
+    )
+    assert not resp.ok
+    assert resp.state is None
+    assert any("not found" in e for e in resp.errors)
+
+
+def test_load_manifest_broadcasts_state(state: AppState, small_manifest: Path, collected_events):
+    events, drain = collected_events
+    _run(intents.handle_load_manifest(state, LoadManifestRequest(manifest_path=small_manifest)))
+    _run(drain())
+    event_names = [e.event for e in events]
+    assert "state" in event_names
+    assert "log" in event_names
+
+
+def test_commit_with_session_tracks_populates_audio_hash(
+    state: AppState, small_manifest: Path, make_wav
+):
+    # Load first so we have a baseline.
+    _run(intents.handle_load_manifest(state, LoadManifestRequest(manifest_path=small_manifest)))
+    wav = make_wav("commit.wav")
+    req = CommitRequest(
+        session_tracks={
+            "A": [{"slot": 0, "file_path": str(wav), "clip_length_sec": 0.5, "name": "v1"}]
+        }
+    )
+    resp = _run(intents.handle_commit(state, req))
+    assert resp.ok
+    pad = resp.state.songs[0].groups[0].pads[0]
+    assert pad.clip is not None
+    assert pad.clip.audio_hash != ""
+    assert len(pad.clip.audio_hash) == 16
+
+
+def test_commit_requires_payload_source(state: AppState):
+    resp = _run(intents.handle_commit(state, CommitRequest()))
+    assert not resp.ok
+    assert any("session_tracks or manifest_path" in e for e in resp.errors)
+
+
+def test_commit_with_manifest_path_reads_from_disk(state: AppState, small_manifest: Path):
+    resp = _run(intents.handle_commit(state, CommitRequest(manifest_path=small_manifest)))
+    assert resp.ok
+    # Manifest's session_tracks were applied.
+    groups = {g.group_id: g for g in resp.state.songs[0].groups}
+    assert len(groups["A"].pads) == 1
+
+
+def test_assign_pad_creates_clip(state: AppState, make_wav):
+    wav = make_wav("a.wav")
+    resp = _run(
+        intents.handle_assign_pad(
+            state,
+            AssignPadRequest(group="A", pad=3, clip_path=str(wav), name="hook"),
+        )
+    )
+    assert resp.ok
+    pads = {p.pad_id: p for p in resp.state.songs[0].groups[0].pads}
+    assert "3" in pads
+    assert pads["3"].clip is not None
+    assert pads["3"].clip.name == "hook"
+    assert pads["3"].clip.audio_hash != ""
+
+
+def test_assign_pad_requires_clip_id_or_path(state: AppState):
+    resp = _run(intents.handle_assign_pad(state, AssignPadRequest(group="A", pad=1)))
+    assert not resp.ok
+
+
+def test_clear_pad_drops_clip(state: AppState, make_wav):
+    wav = make_wav("a.wav")
+    _run(
+        intents.handle_assign_pad(
+            state,
+            AssignPadRequest(group="A", pad=3, clip_path=str(wav)),
+        )
+    )
+    resp = _run(intents.handle_clear_pad(state, ClearPadRequest(group="A", pad=3)))
+    assert resp.ok
+    pads = {p.pad_id: p for p in resp.state.songs[0].groups[0].pads}
+    assert pads["3"].clip is None
+
+
+def test_set_group_format_updates_profile(state: AppState):
+    resp = _run(
+        intents.handle_set_group_format(state, SetGroupFormatRequest(group="A", format="vocal"))
+    )
+    assert resp.ok
+    g = {g.group_id: g for g in resp.state.songs[0].groups}["A"]
+    assert g.format_profile == "vocal"
+
+
+def test_recompute_broadcasts_without_mutation(state: AppState, collected_events):
+    events, drain = collected_events
+    resp = _run(intents.handle_recompute(state, RecomputeRequest()))
+    _run(drain())
+    assert resp.ok
+    assert any(e.event == "state" for e in events)
+
+
+def test_mutation_lock_prevents_concurrent_writes(state: AppState, small_manifest: Path):
+    """Two concurrent commits must serialize; both succeed without partial state."""
+
+    async def run_both():
+        return await asyncio.gather(
+            intents.handle_commit(
+                state,
+                CommitRequest(session_tracks={"A": [{"slot": 0, "name": "v1"}]}),
+            ),
+            intents.handle_commit(
+                state,
+                CommitRequest(session_tracks={"B": [{"slot": 0, "name": "v2"}]}),
+            ),
+        )
+
+    a, b = _run(run_both())
+    assert a.ok and b.ok
+    # Final state: last writer wins for the group it wrote, but the other
+    # group's pads are also persisted because each commit writes
+    # one-group's worth of data.
+    groups = {g.group_id: g for g in state.project.songs[0].groups}
+    # The exact final state depends on serialization order, but both
+    # groups must exist in the model.
+    assert "A" in groups and "B" in groups

--- a/tests/configurator/test_preview.py
+++ b/tests/configurator/test_preview.py
@@ -1,0 +1,62 @@
+"""Range-aware WAV serving."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from stemforge.configurator.preview import (
+    build_audio_response,
+    parse_range,
+)
+
+
+def test_parse_range_basic():
+    r = parse_range("bytes=0-99", total=1000)
+    assert r is not None and r.start == 0 and r.end == 99
+
+
+def test_parse_range_open_ended():
+    r = parse_range("bytes=500-", total=1000)
+    assert r is not None and r.start == 500 and r.end == 999
+
+
+def test_parse_range_suffix():
+    r = parse_range("bytes=-100", total=1000)
+    assert r is not None and r.start == 900 and r.end == 999
+
+
+def test_parse_range_malformed_returns_none():
+    assert parse_range("blah", total=1000) is None
+    assert parse_range("bytes=abc-def", total=1000) is None
+    assert parse_range("bytes=", total=1000) is None
+    assert parse_range(None, total=1000) is None
+
+
+def test_parse_range_out_of_bounds():
+    assert parse_range("bytes=2000-3000", total=1000) is None
+    # End past total clamped down.
+    r = parse_range("bytes=0-5000", total=1000)
+    assert r is not None and r.end == 999
+
+
+def test_build_audio_response_full_body(make_wav, tmp_path: Path):
+    wav = make_wav("a.wav")
+    resp = build_audio_response(wav, range_header=None)
+    assert resp.status_code == 200
+    assert resp.headers["Accept-Ranges"] == "bytes"
+    assert int(resp.headers["Content-Length"]) == wav.stat().st_size
+
+
+def test_build_audio_response_range_returns_206(make_wav, tmp_path: Path):
+    wav = make_wav("a.wav")
+    total = wav.stat().st_size
+    resp = build_audio_response(wav, range_header=f"bytes=0-{min(99, total - 1)}")
+    assert resp.status_code == 206
+    assert "Content-Range" in resp.headers
+    assert resp.headers["Content-Range"].startswith("bytes 0-")
+    assert resp.headers["Content-Range"].endswith(f"/{total}")
+
+
+def test_build_audio_response_missing_file(tmp_path: Path):
+    resp = build_audio_response(tmp_path / "nope.wav", range_header=None)
+    assert resp.status_code == 404

--- a/tests/configurator/test_schemas.py
+++ b/tests/configurator/test_schemas.py
@@ -1,0 +1,91 @@
+"""Pydantic round-trips and negative-control cases for configurator schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from stemforge.configurator.schemas import (
+    AssignPadRequest,
+    ClearPadRequest,
+    CommitRequest,
+    ExportRequest,
+    IntentResponse,
+    LoadManifestRequest,
+    RecomputeRequest,
+    SetGroupFormatRequest,
+)
+from stemforge.scene_model import Project
+
+
+def test_load_manifest_request_roundtrip():
+    req = LoadManifestRequest(manifest_path="/tmp/x.json", bpm=100.0)
+    again = LoadManifestRequest.model_validate_json(req.model_dump_json())
+    assert again.manifest_path == req.manifest_path
+    assert again.bpm == 100.0
+
+
+def test_load_manifest_request_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        LoadManifestRequest.model_validate({"manifest_path": "/tmp/x.json", "bogus": 1})
+
+
+def test_commit_request_accepts_either_payload_source():
+    a = CommitRequest(session_tracks={"A": []})
+    b = CommitRequest(manifest_path="/tmp/x.json")
+    c = CommitRequest()  # both None — handler enforces, not schema
+    assert a.session_tracks == {"A": []}
+    assert b.manifest_path is not None
+    assert c.session_tracks is None and c.manifest_path is None
+
+
+def test_assign_pad_request_validates_pad_range():
+    AssignPadRequest(group="A", pad=1, clip_id="abc")
+    AssignPadRequest(group="D", pad=12, clip_id="abc")
+    with pytest.raises(ValidationError):
+        AssignPadRequest(group="A", pad=0, clip_id="abc")
+    with pytest.raises(ValidationError):
+        AssignPadRequest(group="A", pad=13, clip_id="abc")
+    with pytest.raises(ValidationError):
+        AssignPadRequest(group="E", pad=1, clip_id="abc")  # type: ignore[arg-type]
+
+
+def test_clear_pad_request_roundtrip():
+    req = ClearPadRequest(group="B", pad=4)
+    assert ClearPadRequest.model_validate_json(req.model_dump_json()) == req
+
+
+def test_set_group_format_request_constraints():
+    SetGroupFormatRequest(group="A", format="vocal")
+    SetGroupFormatRequest(group="D", format="preserve_source")
+    with pytest.raises(ValidationError):
+        SetGroupFormatRequest(group="A", format="bogus")  # type: ignore[arg-type]
+
+
+def test_recompute_request_rejects_unknown_fields():
+    RecomputeRequest()
+    with pytest.raises(ValidationError):
+        RecomputeRequest.model_validate({"scope": "all"})
+
+
+def test_export_request_validates_target_and_slot():
+    req = ExportRequest(target="ep133", out_path="/tmp/out.ppak", project_slot=8)
+    assert req.project_slot == 8
+    with pytest.raises(ValidationError):
+        ExportRequest(target="koala", out_path="/tmp/x")  # type: ignore[arg-type]
+    with pytest.raises(ValidationError):
+        ExportRequest(target="ep133", out_path="/tmp/x", project_slot=10)
+
+
+def test_intent_response_default_shape():
+    r = IntentResponse(ok=True, state=Project())
+    assert r.warnings == [] and r.errors == []
+    j = r.model_dump_json()
+    assert '"ok":true' in j
+
+
+def test_intent_response_error_path():
+    r = IntentResponse(ok=False, state=None, errors=["bad"])
+    assert r.ok is False
+    assert r.state is None
+    assert r.errors == ["bad"]

--- a/tests/configurator/test_server_smoke.py
+++ b/tests/configurator/test_server_smoke.py
@@ -1,0 +1,102 @@
+"""End-to-end smoke test for the configurator HTTP server.
+
+Spawns uvicorn in a subprocess (similar to ``tests/test_canonical_tempos.py``'s
+``_run_split`` pattern), waits for ``/healthz`` to respond, and exercises the
+core surfaces (state, healthz, 422 on bad input). The subprocess pattern keeps
+asyncio loops + uvicorn state out of the test runner's process.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(port: int, *, timeout_sec: float = 15.0) -> None:
+    deadline = time.time() + timeout_sec
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            r = httpx.get(f"http://127.0.0.1:{port}/healthz", timeout=1.0)
+            if r.status_code == 200:
+                return
+        except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout) as exc:
+            last_err = exc
+        time.sleep(0.2)
+    raise AssertionError(f"server never came up on :{port}: {last_err!r}")
+
+
+@pytest.fixture
+def running_server(tmp_path: Path):
+    port = _free_port()
+    env = {
+        **os.environ,
+        "STEMFORGE_CONFIGURATOR_PORT": str(port),
+        "STEMFORGE_CONFIGURATOR_STATIC": str(tmp_path / "static"),
+    }
+    # Invoke the console-entry helper via -c so we don't need a __main__
+    # guard on the module. ``run()`` reads STEMFORGE_CONFIGURATOR_PORT
+    # from env, writes the port file, and boots uvicorn.
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "from stemforge.configurator.server import run; run()",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _wait_for_health(port)
+        yield port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_healthz_responds(running_server: int):
+    r = httpx.get(f"http://127.0.0.1:{running_server}/healthz", timeout=2.0)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert "version" in body
+
+
+def test_state_returns_empty_project(running_server: int):
+    r = httpx.get(f"http://127.0.0.1:{running_server}/state", timeout=2.0)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["schema_version"] == 2
+    assert body["songs"] == []
+
+
+def test_invalid_intent_returns_422(running_server: int):
+    r = httpx.post(
+        f"http://127.0.0.1:{running_server}/intent/assign-pad",
+        json={"group": "Z", "pad": 99},  # both invalid
+        timeout=2.0,
+    )
+    assert r.status_code == 422
+
+
+def test_static_placeholder_served(running_server: int):
+    r = httpx.get(f"http://127.0.0.1:{running_server}/", timeout=2.0)
+    assert r.status_code == 200
+    assert "Configurator" in r.text

--- a/tools/m4l_configurator_server.py
+++ b/tools/m4l_configurator_server.py
@@ -1,0 +1,16 @@
+"""Thin entry point for the configurator HTTP server.
+
+Wraps :func:`stemforge.configurator.server.run` so the M4L ``[shell]``
+launcher can invoke ``uv run python tools/m4l_configurator_server.py``
+without depending on the console-script install hook.
+
+Same module also pairs with the ``stemforge-configurator`` console
+script declared in ``pyproject.toml`` — both end up calling ``run()``.
+"""
+
+from __future__ import annotations
+
+from stemforge.configurator.server import run
+
+if __name__ == "__main__":
+    run()

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -918,6 +934,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "h2"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1020,6 +1045,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -3240,6 +3293,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "stemforge"
 version = "0.2.0"
 source = { editable = "." }
@@ -3262,6 +3328,12 @@ analyzer = [
 beat = [
     { name = "beat-this" },
     { name = "torch" },
+]
+configurator = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "soundfile" },
+    { name = "uvicorn" },
 ]
 dev = [
     { name = "mypy" },
@@ -3302,6 +3374,8 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "demucs", marker = "extra == 'local'", specifier = ">=4.0.1" },
     { name = "demucs", marker = "extra == 'native'", specifier = ">=4.0.1" },
+    { name = "fastapi", marker = "extra == 'configurator'", specifier = ">=0.110" },
+    { name = "httpx", marker = "extra == 'configurator'", specifier = ">=0.27" },
     { name = "laion-clap", marker = "extra == 'analyzer'", specifier = ">=1.1" },
     { name = "librosa", specifier = ">=0.10.2" },
     { name = "mido", marker = "extra == 'ep133'", specifier = ">=1.3" },
@@ -3324,14 +3398,16 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "soundfile", specifier = ">=0.12.1" },
+    { name = "soundfile", marker = "extra == 'configurator'", specifier = ">=0.12" },
     { name = "torch", marker = "extra == 'beat'", specifier = ">=2.1.0" },
     { name = "torch", marker = "extra == 'local'", specifier = ">=2.1.0" },
     { name = "torch", marker = "extra == 'native'", specifier = ">=2.1.0" },
     { name = "torchaudio", marker = "extra == 'local'", specifier = ">=2.1.0" },
     { name = "torchaudio", marker = "extra == 'native'", specifier = ">=2.1.0" },
     { name = "transformers", marker = "extra == 'analyzer'", specifier = ">=4.40" },
+    { name = "uvicorn", marker = "extra == 'configurator'", specifier = ">=0.27" },
 ]
-provides-extras = ["native", "beat", "analyzer", "modal", "ep133", "onnx", "dev", "local"]
+provides-extras = ["native", "beat", "analyzer", "modal", "ep133", "configurator", "onnx", "dev", "local"]
 
 [[package]]
 name = "submitit"
@@ -3636,6 +3712,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 3 Lane A — the Python HTTP server that holds the canonical Project spec in memory and exposes it to the M4L strip device (Lane C) and the popup frontend (Lane B). Single-writer-of-truth per configurator spec v4 Decision 15.

- New package stemforge/configurator/ with server.py, state.py, schemas.py, intents.py, audio_hash.py, preview.py. Eleven HTTP routes: /healthz, /state, /state/stream (SSE), /preview/{clip_id} (Range-aware), and seven /intent/* POSTs (load-manifest, commit, assign-pad, clear-pad, set-group-format, recompute, export).
- Channel-collapse-invariant audio_hash with disk cache at ~/stemforge/.audio_hash_cache.json. Stereo with L==R hashes equal to mono of the same content; closes Phase 2 loose-end #1 (empty audio_hash at COMMIT).
- FastAPI app factory + module-level app for uvicorn import-string startup. Static-files mount on / (defaults to stemforge/configurator/static/) holds Lane B's build output; falls back to a placeholder until Lane B lands. Port discovery: env-var override then first free in 7430-7440; resolved port written to ~/stemforge/.configurator_port so the strip device can discover it.
- tools/m4l_configurator_server.py thin entry script + stemforge-configurator console script ([project.scripts] in pyproject).
- 42 new tests under tests/configurator/: schemas (round-trips + negative controls), audio_hash (determinism, channel collapse, cache hit/miss, stale-path pruning), intents (every handler against a fresh AppState, mutation lock under concurrent commits, SSE broadcast verification), preview (Range parsing + 206 with Content-Range), and a subprocess-isolated server smoke test (same pattern as test_canonical_tempos._run_split).

Out of scope for this lane (per the brief): no frontend (Lane B), no M4L strip device (Lane C), no scene_model/ refactor (extend only, don't redefine), no persistence (in-memory only - disk debounce is a follow-up).

## Module layout

- stemforge/configurator/__init__.py
- stemforge/configurator/audio_hash.py - channel-collapse-invariant hash + on-disk cache
- stemforge/configurator/intents.py - 7 async handlers, single-writer under mutation_lock
- stemforge/configurator/preview.py - Range-aware WAV serving
- stemforge/configurator/schemas.py - pydantic request/response models
- stemforge/configurator/server.py - FastAPI app factory + uvicorn run() entry
- stemforge/configurator/state.py - AppState, SSE broker, asyncio.Lock
- stemforge/configurator/static/ - Lane B's build output lands here (placeholder until then)
- tools/m4l_configurator_server.py - entry script for the M4L [shell] launcher
- tests/configurator/ - 42 tests across 5 files

## Endpoints

- GET  /healthz - {ok: true, version}
- GET  /state - current Project JSON
- GET  /state/stream - SSE: events state | log | progress | error
- GET  /preview/{clip_id} - Range-aware WAV (206 on partial)
- POST /intent/load-manifest
- POST /intent/commit (populates audio_hash per slot)
- POST /intent/assign-pad
- POST /intent/clear-pad
- POST /intent/set-group-format
- POST /intent/recompute
- POST /intent/export (wraps Ep133Projector.project_from_spec / project_kit)

## Test plan

- [x] uv run pytest tests/configurator/ -q: 42/42 pass
- [x] Full suite (excluding test_canonical_tempos which needs phase3 inputs): 893 passed, 10 skipped, no regressions
- [x] uv run ruff check clean on new files
- [x] uv run ruff format --check clean on new files
- [x] Smoke test confirms uvicorn boots in a subprocess, /healthz responds, /state returns an empty Project, invalid intent returns 422, static placeholder served at /
- [ ] Lane C wires [shell] -> tools/m4l_configurator_server.py and [jweb] -> http://127.0.0.1:port/ once the strip device exists
- [ ] Lane B drops build artifacts into stemforge/configurator/static/ and verifies the popup loads

Co-Authored-By: Claude Opus 4.7 (1M context)
