### PR TITLE
feat(configurator): Phase 3 strip device — fresh M4L device with HTTP intents

### DIFF
--- a/tests/js_mocks/_yaml_lite.js
+++ b/tests/js_mocks/_yaml_lite.js
@@ -1,0 +1,79 @@
+// _yaml_lite.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal YAML extractor used only by tests that need to read a couple of
+// fields out of `v0/src/m4l-devices/configurator-strip/device.yaml`. Avoids
+// pulling in a real YAML dep just for tests.
+//
+// Scope: extract the list of button items under
+//   ui:
+//     buttons:
+//       items:
+//         - id: btn_foo
+//           verb: load-manifest
+//
+// Anything more complex than that is out of scope for this helper — the
+// Python builder uses pyyaml for the full parse.
+// ─────────────────────────────────────────────────────────────────────────────
+
+'use strict';
+
+function extractButtonItems(yamlText) {
+    const lines = String(yamlText).split(/\r?\n/);
+    let inItems = false;
+    let itemsIndent = -1;
+    const items = [];
+    let cur = null;
+
+    for (const raw of lines) {
+        if (!inItems) {
+            if (/^\s*items:\s*$/.test(raw)) {
+                // Only honor this `items:` if it's nested under `buttons:`
+                // — we can't track that cheaply without a real parser, but
+                // device.yaml has only one `items:` block (the buttons),
+                // so it's safe in practice.
+                inItems = true;
+                itemsIndent = raw.length - raw.replace(/^\s+/, '').length;
+            }
+            continue;
+        }
+
+        // Stop when we hit a less-indented non-blank line.
+        if (raw.trim() === '') continue;
+        const indent = raw.length - raw.replace(/^\s+/, '').length;
+        if (indent <= itemsIndent) {
+            inItems = false;
+            if (cur) items.push(cur);
+            cur = null;
+            continue;
+        }
+
+        const lineNoIndent = raw.trim();
+        if (lineNoIndent.startsWith('- ')) {
+            if (cur) items.push(cur);
+            cur = {};
+            const rest = lineNoIndent.substring(2).trim();
+            const m = rest.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+            if (m) cur[m[1]] = unquote(m[2]);
+            continue;
+        }
+        const m = lineNoIndent.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+        if (m && cur) cur[m[1]] = unquote(m[2]);
+    }
+    if (cur) items.push(cur);
+    return items;
+}
+
+function unquote(s) {
+    if (s == null) return s;
+    const t = String(s).trim();
+    if ((t.startsWith('"') && t.endsWith('"')) ||
+        (t.startsWith("'") && t.endsWith("'"))) {
+        return t.substring(1, t.length - 1);
+    }
+    // Strip trailing comments.
+    const hashIdx = t.indexOf('#');
+    if (hashIdx > 0) return t.substring(0, hashIdx).trim();
+    return t;
+}
+
+module.exports = { extractButtonItems };

--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -1,0 +1,344 @@
+// test_sf_configurator.test.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Tier-3 tests for the Configurator Strip's JS operations dispatcher
+// (Phase 3). Module under test: v0/src/m4l-devices/configurator-strip/js/
+// sf_configurator.js.
+//
+// The script:
+//   - On loadbang, reads ~/stemforge/.configurator_port and caches the port.
+//   - When the port file is present, sets the status dot to green (DOT_OK)
+//     and emits the server URL into the footer.
+//   - When the port file is missing, sets DOT_ERROR and a "click Start
+//     Server" footer.
+//   - Each operation handler emits a curl POST to /intent/<verb> via
+//     outlet 4 (which the patcher pipes through [shell]).
+//   - openEditor emits `openurl <serverBase>/` on outlet 3 (the [jweb]).
+//   - startServer emits `exec stemforge-configurator &` on outlet 4.
+//   - commit walks session + arrangement view (mirrors
+//     _commitSessionTracks) and POSTs the result.
+// ─────────────────────────────────────────────────────────────────────────────
+
+'use strict';
+
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createSandbox, loadModule, maxApi } = require('./sandbox');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SF_CONF = path.join(
+    REPO_ROOT, 'v0', 'src', 'm4l-devices', 'configurator-strip',
+    'js', 'sf_configurator.js',
+);
+
+// Path the script will read at boot — the script expands `~` to `$HOME`
+// literally, so we seed that key. The real Max [js] File object resolves ~
+// against the running user's home; the mock has no such logic, so we seed
+// the literal post-expansion path.
+const PORT_FILE_KEY = '$HOME/stemforge/.configurator_port';
+
+function loadConf() {
+    maxApi.resetState();
+    const ctx = createSandbox();
+    loadModule(ctx, SF_CONF);
+    return ctx;
+}
+
+function outlets() {
+    return maxApi.state.outlets;
+}
+
+function outletOn(n) {
+    return outlets()[n] || [];
+}
+
+function normalize(x) {
+    return JSON.parse(JSON.stringify(x));
+}
+
+// ── Port discovery ───────────────────────────────────────────────────────────
+
+test('discoverPort: missing port file → DOT_ERROR + server-down status', () => {
+    const ctx = loadConf();
+    // No seed for the port file at all.
+    const port = ctx._discoverPort();
+    assert.equal(port, null);
+
+    // outlet 0 = status text. Last emission should be "server down".
+    const statusEmits = outletOn(0).map(a => a[0]);
+    assert.ok(statusEmits.includes('server down'),
+              `expected "server down" in ${JSON.stringify(statusEmits)}`);
+
+    // outlet 2 = dot color. Look for the error rgba (red).
+    const dotEmits = outletOn(2);
+    const lastDot = dotEmits[dotEmits.length - 1];
+    assert.equal(lastDot[0], 'bgcolor');
+    // DOT_ERROR red ~ 0.871.
+    assert.ok(lastDot[1] > 0.8, `expected red dot, got ${JSON.stringify(lastDot)}`);
+});
+
+test('discoverPort: present port file → DOT_OK + serverBase resolved', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421\n');
+
+    const port = ctx._discoverPort();
+    assert.equal(port, 7421);
+
+    const statusEmits = outletOn(0).map(a => a[0]);
+    assert.ok(statusEmits.includes('connected'),
+              `expected "connected" in ${JSON.stringify(statusEmits)}`);
+
+    // Footer last emission should be the serverBase URL.
+    const footerEmits = outletOn(1).map(a => a[0]);
+    const lastFooter = footerEmits[footerEmits.length - 1];
+    assert.equal(lastFooter, 'http://127.0.0.1:7421');
+
+    // Dot is green (DOT_OK ~ 0.220, 0.780, 0.376).
+    const dotEmits = outletOn(2);
+    const lastDot = dotEmits[dotEmits.length - 1];
+    assert.equal(lastDot[0], 'bgcolor');
+    assert.ok(Math.abs(lastDot[2] - 0.780) < 0.01,
+              `expected green-channel ~0.78, got ${lastDot[2]}`);
+});
+
+// ── HTTP intent emission ─────────────────────────────────────────────────────
+
+test('loadManifest: POSTs /intent/load-manifest via curl on outlet 4', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+
+    ctx.loadManifest('/Users/zak/song/stems.json');
+
+    const shellEmits = outletOn(4);
+    // Find the curl call.
+    const curl = shellEmits.find(a => a[0] === 'exec' && /curl/.test(a[1]));
+    assert.ok(curl, 'expected a curl exec emission');
+    const cmd = curl[1];
+    assert.match(cmd, /POST/);
+    assert.match(cmd, /http:\/\/127\.0\.0\.1:7421\/intent\/load-manifest/);
+    assert.match(cmd, /stems\.json/, `body should include manifest path; got: ${cmd}`);
+});
+
+test('exportPpak: POSTs /intent/export with target=ep133', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+
+    ctx.exportPpak('/tmp/out.ppak');
+
+    const shellEmits = outletOn(4);
+    const curl = shellEmits.find(a => a[0] === 'exec' && /intent\/export/.test(a[1]));
+    assert.ok(curl, 'expected export curl emission');
+    assert.match(curl[1], /target.*ep133/);
+    assert.match(curl[1], /out\.ppak/);
+});
+
+test('recompute / slice / curate / reAnchor each fire their verb', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+
+    ctx.recompute();
+    ctx.slice();
+    ctx.curate();
+    ctx.reAnchor();
+
+    const shellEmits = outletOn(4);
+    const cmds = shellEmits.filter(a => a[0] === 'exec').map(a => a[1]);
+    assert.ok(cmds.some(c => /intent\/recompute/.test(c)), 'recompute missing');
+    assert.ok(cmds.some(c => /intent\/slice/.test(c)),     'slice missing');
+    assert.ok(cmds.some(c => /intent\/curate/.test(c)),    'curate missing');
+    assert.ok(cmds.some(c => /intent\/re-anchor/.test(c)), 're-anchor missing');
+});
+
+// ── openEditor → jweb openurl ────────────────────────────────────────────────
+
+test('openEditor: emits openurl onto outlet 3 with serverBase', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+
+    ctx.openEditor();
+
+    const j = outletOn(3);
+    const last = j[j.length - 1];
+    assert.deepEqual(last, ['openurl', 'http://127.0.0.1:7421/']);
+});
+
+test('openEditor: with no server, refuses to emit openurl', () => {
+    const ctx = loadConf();
+    // no seed
+
+    ctx.openEditor();
+
+    const j = outletOn(3);
+    // Should not have emitted any openurl.
+    const urls = j.filter(a => a[0] === 'openurl');
+    assert.equal(urls.length, 0, 'openurl should not fire without a server');
+});
+
+// ── startServer → shell exec ─────────────────────────────────────────────────
+
+test('startServer: emits exec stemforge-configurator on outlet 4', () => {
+    const ctx = loadConf();
+    ctx.startServer();
+
+    const shellEmits = outletOn(4);
+    const start = shellEmits.find(a => a[0] === 'exec' && /stemforge-configurator/.test(a[1]));
+    assert.ok(start, 'expected stemforge-configurator start command');
+});
+
+// ── COMMIT walker — exact mirror of _commitSessionTracks contract ────────────
+
+function makeTrack(name, clipSlots, arrClips) {
+    const t = { _properties: { name }, clip_slots: clipSlots || [] };
+    if (arrClips) t.arrangement_clips = arrClips;
+    return t;
+}
+
+function makeClipSlot(clipProps) {
+    if (clipProps == null) return { _properties: {} };
+    return { _properties: {}, clip: { _properties: clipProps } };
+}
+
+function makeArrClip(clipProps) {
+    return { _properties: clipProps };
+}
+
+test('commit walker: empty live set → all four letters empty', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    maxApi.seedLiveTree({ _properties: { tempo: 120 }, tracks: [] });
+
+    const result = ctx._walkSessionAndArrangement();
+    assert.deepEqual(normalize(result), { A: [], B: [], C: [], D: [] });
+});
+
+test('commit walker: session-view clip on track A registers at clip-slot index', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    maxApi.seedLiveTree({
+        _properties: { tempo: 120 },
+        tracks: [
+            makeTrack('A', [
+                makeClipSlot(null),  // slot 0 empty
+                makeClipSlot({
+                    file_path: 'Macintosh HD:/abs/a.wav',
+                    start_marker: 0, end_marker: 4, length: 4, warping: 1,
+                }),
+            ]),
+        ],
+    });
+
+    const result = ctx._walkSessionAndArrangement();
+    assert.equal(result.A.length, 1);
+    assert.equal(result.A[0].slot, 1);   // claim by clip-slot index
+    assert.equal(result.A[0].file, '/abs/a.wav');  // HFS prefix stripped
+    // 4 beats @ 120 bpm = 2 sec.
+    assert.ok(Math.abs(result.A[0].end_sec - 2.0) < 0.001);
+});
+
+test('commit walker: arrangement-only file claims next free slot in 0..19', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    maxApi.seedLiveTree({
+        _properties: { tempo: 120 },
+        tracks: [
+            makeTrack('B',
+                [makeClipSlot({
+                    file_path: 'Macintosh HD:/abs/session.wav',
+                    start_marker: 0, end_marker: 4, length: 4, warping: 1,
+                })],
+                [makeArrClip({
+                    file_path: 'Macintosh HD:/abs/arr_only.wav',
+                    start_marker: 0, end_marker: 4, length: 4, warping: 1,
+                })],
+            ),
+        ],
+    });
+
+    const result = ctx._walkSessionAndArrangement();
+    assert.equal(result.B.length, 2);
+    // Session entry first (claimed slot 0 by clip-slot index).
+    assert.equal(result.B[0].slot, 0);
+    assert.equal(result.B[0].file, '/abs/session.wav');
+    // Arrangement entry claims the next free slot (1, since 0 is taken).
+    assert.equal(result.B[1].slot, 1);
+    assert.equal(result.B[1].file, '/abs/arr_only.wav');
+});
+
+test('commit walker: dedup by file_path — same path in both views = one entry', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    maxApi.seedLiveTree({
+        _properties: { tempo: 120 },
+        tracks: [
+            makeTrack('C',
+                [makeClipSlot({
+                    file_path: 'Macintosh HD:/abs/shared.wav',
+                    start_marker: 0, end_marker: 4, length: 4, warping: 1,
+                })],
+                [makeArrClip({
+                    file_path: 'Macintosh HD:/abs/shared.wav',
+                    start_marker: 0, end_marker: 4, length: 4, warping: 1,
+                })],
+            ),
+        ],
+    });
+
+    const result = ctx._walkSessionAndArrangement();
+    assert.equal(result.C.length, 1, 'duplicate path should dedup');
+    assert.equal(result.C[0].file, '/abs/shared.wav');
+});
+
+test('commit: full path — walk + POST /intent/commit with session_tracks body', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    maxApi.seedLiveTree({
+        _properties: { tempo: 120 },
+        tracks: [
+            makeTrack('A', [makeClipSlot({
+                file_path: 'Macintosh HD:/abs/a.wav',
+                start_marker: 0, end_marker: 4, length: 4, warping: 1,
+            })]),
+        ],
+    });
+
+    ctx.commit();
+
+    const shellEmits = outletOn(4);
+    const curl = shellEmits.find(a => a[0] === 'exec' && /intent\/commit/.test(a[1]));
+    assert.ok(curl, 'expected commit curl emission');
+    assert.match(curl[1], /session_tracks/);
+    assert.match(curl[1], /\/abs\/a\.wav/);
+});
+
+// ── Verb→handler integrity: every device.yaml verb has a JS handler ─────────
+
+test('every device.yaml verb has a callable handler on the sandbox', () => {
+    const fs = require('fs');
+    const yaml = require('./_yaml_lite');   // no jsdep — use a tiny parser
+    const DEVICE_YAML = path.join(
+        REPO_ROOT, 'v0', 'src', 'm4l-devices', 'configurator-strip', 'device.yaml',
+    );
+    const items = yaml.extractButtonItems(fs.readFileSync(DEVICE_YAML, 'utf8'));
+
+    const ctx = loadConf();
+    const verbToHandler = {
+        'load-manifest': 'loadManifest',
+        'slice':         'slice',
+        'recompute':     'recompute',
+        're-anchor':     'reAnchor',
+        'curate':        'curate',
+        'export':        'exportPpak',
+        'open-editor':   'openEditor',
+    };
+    for (const it of items) {
+        const h = verbToHandler[it.verb];
+        assert.ok(h, `device.yaml verb missing in test map: ${it.verb}`);
+        assert.equal(typeof ctx[h], 'function',
+                     `handler ${h} (verb ${it.verb}) not exposed on sandbox`);
+    }
+});

--- a/v0/src/m4l-devices/configurator-strip/README.md
+++ b/v0/src/m4l-devices/configurator-strip/README.md
@@ -1,0 +1,177 @@
+# Configurator Strip — Phase 3 M4L device
+
+A thin, fresh-build M4L audio-effect device that fires the seven canonical
+Configurator operations (load, slice, recompute, re-anchor, curate, export,
+open editor) at the local HTTP server.
+
+Status: builder + JS + tests landed. `.amxd` packaging and on-device verify
+are manual (per `feedback_test_deploy_discipline.md` — never bake .amxd
+artefacts in a worktree, the user packs + installs to verify).
+
+## What this is
+
+A SEPARATE device from `StemForge.amxd`. It runs alongside the big device,
+on its own M4L track or after the big device on the same track. The strip
+has no LOM/forge logic of its own — it's an intent-emitter that:
+
+1. Discovers the local HTTP server's port via `~/stemforge/.configurator_port`.
+2. Renders seven labelled buttons (`live.text` widgets, orange-accent).
+3. POSTs to `http://127.0.0.1:<port>/intent/<verb>` via curl + `[shell]`.
+4. Opens the popup editor via `[jweb]` (float window).
+5. Walks session + arrangement view for `commit`, mirroring the algorithm
+   in `stemforge_loader.v0.js`'s `_commitSessionTracks`.
+
+## Files
+
+```
+v0/src/m4l-devices/configurator-strip/
+  device.yaml          # operation table, palette, geometry, server config
+  builder.py           # generates the .maxpat (programmatic)
+  js/
+    sf_configurator.js # operations dispatcher (classic [js])
+  tests/
+    test_strip_builder.py  # 17 Python tests (static .maxpat asserts)
+    conftest.py
+    __init__.py
+  README.md            # this file
+```
+
+The JS-side test is at `tests/js_mocks/test_sf_configurator.test.js` so the
+project's existing `tests/test_js_bridge.py` autodiscovers it. The bridge
+runs every `tests/js_mocks/*.test.js` as a parametrized pytest case (10
+prior + 1 new = 11 cases as of this PR).
+
+## Local development loop
+
+```bash
+# Python tests (fast, no Max).
+uv run pytest v0/src/m4l-devices/configurator-strip/tests/ -q
+
+# JS tests (also fast, no Max).
+node tests/js_mocks/test_sf_configurator.test.js
+
+# Both, via the pytest bridge.
+uv run pytest v0/src/m4l-devices/configurator-strip/tests/ tests/test_js_bridge.py -q
+
+# Generate a .maxpat for visual inspection in standalone Max (no Ableton).
+python v0/src/m4l-devices/configurator-strip/builder.py \
+    --out v0/build/ConfiguratorStrip.maxpat
+open v0/build/ConfiguratorStrip.maxpat
+```
+
+## Packing the .amxd + installing (deferred to on-device verify)
+
+The strip is NOT packed in CI. Per
+`memory/feedback_test_deploy_discipline.md`, the .amxd is built and
+installed manually by the user to verify on real hardware. Suggested
+recipe once the design is locked:
+
+```bash
+# 1. Build the maxpat.
+python v0/src/m4l-devices/configurator-strip/builder.py \
+    --out v0/build/ConfiguratorStrip.maxpat
+
+# 2. Pack into .amxd using the existing amxd_pack helper.
+python - <<'PY'
+import sys, json, pathlib
+sys.path.insert(0, "v0/src/maxpat-builder")
+from amxd_pack import pack_amxd
+patcher = json.loads(pathlib.Path("v0/build/ConfiguratorStrip.maxpat").read_text())
+pack_amxd(patcher, "v0/build/ConfiguratorStrip.amxd",
+          device_type=1, device_class="audio")
+PY
+
+# 3. Sync sf_configurator.js into StemForge's Max Package (so [js] finds it).
+cp v0/src/m4l-devices/configurator-strip/js/sf_configurator.js \
+   "$HOME/Documents/Max 9/Packages/StemForge/javascript/"
+
+# 4. Install the .amxd alongside StemForge.amxd.
+cp v0/build/ConfiguratorStrip.amxd \
+   "$HOME/Music/Ableton/User Library/Presets/Audio Effects/Max Audio Effect/"
+```
+
+A future installer wrapper (`tools/install_configurator_strip.sh`, similar
+to `tools/sf_deploy.py`) is the right place to land step 3+4 once the
+device design is verified on hardware.
+
+## JS source of truth
+
+`v0/src/m4l-devices/configurator-strip/js/sf_configurator.js` is the
+canonical source.
+
+Per `memory/feedback_js_source_of_truth.md`, the big device duplicates JS
+across `v0/src/m4l-js/` and `v0/src/m4l-package/StemForge/javascript/`.
+The strip device avoids that duplication by:
+
+- Keeping JS only in `v0/src/m4l-devices/configurator-strip/js/`.
+- Having the install step (recipe above) copy it into the existing
+  `StemForge/javascript/` package directory at install time.
+
+This means the strip and the big device share one Max Package — both end
+up looking in `~/Documents/Max 9/Packages/StemForge/javascript/` for any
+classic `[js]` filename.
+
+## HTTP transport choice
+
+Max's classic `[js]` (SpiderMonkey) doesn't ship a reliable
+`XMLHttpRequest` binding. Per
+`memory/m4l_device_development_guide.md` §3 the working pattern for
+external I/O is `[shell]` + the JS emitting commands out an outlet. We
+follow that: JS builds a `curl --silent --max-time 5 -X POST -d <json>
+<url>` command string and emits `exec <cmd>` on outlet 4. The `[shell]`
+external (already a project dependency for the big device) runs it.
+
+Trade-offs:
+
+- Pro: works today, no Max 9.x quirks, easy to debug (the curl command is
+  copy-pasteable to a terminal).
+- Pro: timeouts are explicit (`--max-time 5`) so a missing server doesn't
+  hang the M4L thread.
+- Con: stdout from curl isn't surfaced — POSTs are fire-and-forget from
+  the strip's POV. Lane A's server is expected to use SSE/websocket for
+  progress reporting, which the popup (not the strip) listens to.
+- Con: no header-level introspection in the strip (HTTP status codes are
+  hidden in `[shell]` stdout). Phase 3.1 may parse `curl --write-out` and
+  surface non-200s on the footer line.
+
+## [jweb] embedding choice
+
+Phase 3 uses a **float-window** `[jweb]` (separate window, openurl-driven),
+not an embedded view inside the M4L strip rect. Rationale:
+
+- The strip's rect is ~820×100 — way too small to embed a 1200×800 popup
+  meaningfully.
+- Live's M4L device-area rect doesn't grow dynamically; embedding would
+  force the strip to claim 800px tall.
+- A float window is movable and the user can drag it to a second monitor,
+  which is the common workflow for hardware-export prep.
+
+Phase 4 may revisit if a richer in-device popup makes sense (e.g. a
+mini-inspector for the currently-selected scene).
+
+## COMMIT walker
+
+The strip implements `_walkSessionAndArrangement()` inline, mirroring
+`_commitSessionTracks` in `v0/src/m4l-js/stemforge_loader.v0.js`. The
+walker:
+
+- Iterates tracks named A / B / C / D.
+- Session view: clip_slots 0..30, claim slot = clip-slot index, dedup by
+  posix file_path.
+- Arrangement view: walk `arrangement_clips`, dedup against session
+  paths, claim next free slot in 0..19.
+- Converts markers to seconds via session bpm when warping=1.
+
+TODO: factor a shared walker into `v0/src/m4l-js/sf_commit_walker.js` so
+both devices share one implementation. The duplicate is acceptable for
+Phase 3 because it keeps the strip independent of the big device's JS
+bundle; a follow-up PR can deduplicate.
+
+## References
+
+- `docs/configurator/STEMFORGE_CONFIGURATOR_SPEC_v4.md` — Phase 3 scope.
+- `memory/m4l_device_development_guide.md` — 20 pitfalls observed.
+- `memory/feedback_test_deploy_discipline.md` — never auto-build .amxd.
+- `memory/feedback_js_source_of_truth.md` — JS duplication trap.
+- `memory/project_configurator_device_decision.md` — fresh build, not v2
+  refactor.

--- a/v0/src/m4l-devices/configurator-strip/builder.py
+++ b/v0/src/m4l-devices/configurator-strip/builder.py
@@ -1,0 +1,586 @@
+"""
+builder — generate the Configurator Strip (.maxpat) from device.yaml.
+
+Phase 3 strip device: a thin operations strip with seven labelled buttons
+that fires HTTP intents at Lane A's local server. The strip is a SEPARATE
+device from StemForge.amxd — both live in the user's M4L track stack and
+share no patcher state.
+
+See `device.yaml` for the operations table and layout numbers. See
+`memory/m4l_device_development_guide.md` for the 20 pitfalls this builder
+honors (audio passthrough, project field, classic [js] vs node.script,
+[textbutton] needing [t b]→message, presentation rects, etc.).
+
+Output: a Max patcher dict, JSON-serialisable, ready for amxd_pack.
+
+Usage (as a library):
+
+    from builder import build_patcher
+    patcher = build_patcher("v0/src/m4l-devices/configurator-strip/device.yaml")
+
+Usage (CLI — writes a .maxpat for visual debugging):
+
+    python builder.py --out v0/build/ConfiguratorStrip.maxpat
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ── Stable object IDs ────────────────────────────────────────────────────────
+# Keep these stable so test assertions don't shift when the layout changes.
+
+OBJ_PLUGIN_IN = "obj-plugin-in"
+OBJ_PLUGOUT = "obj-plugout"
+
+OBJ_JS = "obj-sf-configurator-js"
+OBJ_JWEB = "obj-sf-configurator-jweb"
+OBJ_SHELL = "obj-sf-configurator-shell"
+
+OBJ_LOADBANG = "obj-loadbang"
+
+OBJ_STATUS_DOT = "obj-status-dot"
+OBJ_STATUS_TEXT = "obj-status-text"
+OBJ_FOOTER_TEXT = "obj-footer-text"
+OBJ_VERSION_TEXT = "obj-version-text"
+
+OBJ_ROUTE_DOT = "obj-route-dot"
+
+
+# Per-button id template (filled with button id from device.yaml).
+def _btn_box_id(btn_id: str) -> str:
+    return f"obj-btn-{btn_id}"
+
+
+def _btn_tb_id(btn_id: str) -> str:
+    """[t b] trigger object between textbutton and message box.
+
+    Per m4l_device_development_guide.md pitfall #17: [textbutton] outlet 0
+    emits its label text, not a bang — we need [t b] to convert.
+    """
+    return f"obj-tb-{btn_id}"
+
+
+def _btn_msg_id(btn_id: str) -> str:
+    """Message box that names the verb fed into the JS dispatcher."""
+    return f"obj-msg-{btn_id}"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _box(
+    obj_id: str,
+    maxclass: str,
+    patching_rect: tuple[float, float, float, float],
+    *,
+    presentation: bool = False,
+    presentation_rect: tuple[float, float, float, float] | None = None,
+    numinlets: int = 1,
+    numoutlets: int = 0,
+    outlettype: list[str] | None = None,
+    extras: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "id": obj_id,
+        "maxclass": maxclass,
+        "numinlets": numinlets,
+        "numoutlets": numoutlets,
+        "patching_rect": list(patching_rect),
+    }
+    if outlettype is not None:
+        body["outlettype"] = outlettype
+    if presentation:
+        body["presentation"] = 1
+        body["presentation_rect"] = list(presentation_rect or patching_rect)
+    if extras:
+        body.update(extras)
+    return {"box": body}
+
+
+def _line(src_id: str, src_outlet: int, dst_id: str, dst_inlet: int) -> dict[str, Any]:
+    return {
+        "patchline": {
+            "source": [src_id, src_outlet],
+            "destination": [dst_id, dst_inlet],
+        }
+    }
+
+
+# ── Verb → JS handler name ──────────────────────────────────────────────────
+#
+# device.yaml stores hyphenated verbs ("load-manifest"). The JS module
+# exports camelCase function names. The mapping is explicit so we never have
+# to guess what the Max [js] message router will accept.
+VERB_TO_HANDLER = {
+    "load-manifest": "loadManifest",
+    "slice": "slice",
+    "recompute": "recompute",
+    "re-anchor": "reAnchor",
+    "curate": "curate",
+    "export": "exportPpak",
+    "open-editor": "openEditor",
+    "commit": "commit",
+}
+
+
+# ── Core builder ────────────────────────────────────────────────────────────
+
+
+def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
+    """Load device.yaml and return a complete Max patcher dict.
+
+    The patcher includes:
+      - plugin~/plugout~ pair (required for audio-effect M4L devices)
+      - Seven labelled [textbutton] objects → [t b] → message → [js sf_configurator]
+      - [jweb] for the popup (float window)
+      - [shell] for HTTP via curl + server-start
+      - Status dot + status text + footer + version stamp (live.* widgets)
+      - Loadbang → js (port discovery on device boot)
+    """
+    with open(device_yaml_path) as f:
+        spec = yaml.safe_load(f)
+
+    palette = spec["palette"]
+    ui = spec["ui"]
+    js_cfg = spec["js"]
+    server_cfg = spec["server"]
+    jweb_cfg = spec["jweb"]
+    device_cfg = spec["device"]
+
+    boxes: list[dict[str, Any]] = []
+    lines: list[dict[str, Any]] = []
+
+    # ── plugin~ / plugout~ — required for audio-effect M4L (pitfall #7) ─────
+    boxes.append(
+        _box(
+            OBJ_PLUGIN_IN,
+            "newobj",
+            (20.0, 360.0, 80.0, 22.0),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=["signal"],
+            extras={"text": "plugin~ 2"},
+        )
+    )
+    boxes.append(
+        _box(
+            OBJ_PLUGOUT,
+            "newobj",
+            (20.0, 400.0, 80.0, 22.0),
+            numinlets=1,
+            numoutlets=0,
+            extras={"text": "plugout~ 2"},
+        )
+    )
+    lines.append(_line(OBJ_PLUGIN_IN, 0, OBJ_PLUGOUT, 0))
+
+    # ── Buttons (presentation mode) ─────────────────────────────────────────
+    btn_geom = ui["buttons"]["geometry"]
+    btn_w = float(btn_geom["width"])
+    btn_h = float(btn_geom["height"])
+    btn_y = float(btn_geom["y"])
+    btn_gap = float(btn_geom["gap"])
+    btn_items = ui["buttons"]["items"]
+
+    x_cursor = 8.0
+    for btn in btn_items:
+        btn_id = btn["id"]
+        label = btn["label"]
+        verb = btn["verb"]
+        handler = VERB_TO_HANDLER.get(verb)
+        if handler is None:
+            raise ValueError(f"unknown verb in device.yaml: {verb}")
+
+        rect = (x_cursor, btn_y, btn_w, btn_h)
+
+        boxes.append(
+            _box(
+                _btn_box_id(btn_id),
+                "live.text",
+                rect,
+                presentation=True,
+                presentation_rect=rect,
+                numinlets=1,
+                numoutlets=2,
+                outlettype=["", ""],
+                extras={
+                    "varname": btn_id,
+                    # live.text mode 1 = momentary button. The button emits its
+                    # label (a symbol) on click — we trigger-bang downstream.
+                    "mode": 1,
+                    "text": label,
+                    "fontname": "Ableton Sans Medium",
+                    "fontsize": 10.0,
+                    "textcolor": palette["text"],
+                    "activebgcolor": palette["accent"],
+                    "bgcolor": palette["panel"],
+                    "activebgoncolor": palette["accent"],
+                    "bgoncolor": palette["panel"],
+                    "bordercolor": palette["panel"],
+                    "activebordercolor": palette["accent"],
+                    "activebordercoloroff": palette["panel"],
+                    "rounded": 6.0,
+                    "parameter_enable": 0,
+                },
+            )
+        )
+
+        # [t b] — converts the button's symbol output into a bang (pitfall #17).
+        boxes.append(
+            _box(
+                _btn_tb_id(btn_id),
+                "newobj",
+                (x_cursor, btn_y + btn_h + 4.0, 40.0, 22.0),
+                numinlets=1,
+                numoutlets=1,
+                outlettype=["bang"],
+                extras={"text": "t b"},
+            )
+        )
+
+        # Message box that names the JS handler — bang fires it, then the
+        # [js] runs the corresponding function.
+        boxes.append(
+            _box(
+                _btn_msg_id(btn_id),
+                "message",
+                (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
+                numinlets=2,
+                numoutlets=1,
+                outlettype=[""],
+                extras={"text": handler},
+            )
+        )
+
+        lines.append(_line(_btn_box_id(btn_id), 0, _btn_tb_id(btn_id), 0))
+        lines.append(_line(_btn_tb_id(btn_id), 0, _btn_msg_id(btn_id), 0))
+
+        x_cursor += btn_w + btn_gap
+
+    # ── Status indicator (live.text dot) ────────────────────────────────────
+    dot_cfg = ui["status"]["indicator"]
+    dot_rect = (
+        float(dot_cfg["pos"]["x"]),
+        float(dot_cfg["pos"]["y"]),
+        float(dot_cfg["size"]["width"]),
+        float(dot_cfg["size"]["height"]),
+    )
+    boxes.append(
+        _box(
+            OBJ_STATUS_DOT,
+            "live.text",
+            dot_rect,
+            presentation=True,
+            presentation_rect=dot_rect,
+            numinlets=1,
+            numoutlets=2,
+            outlettype=["", ""],
+            extras={
+                "varname": dot_cfg["id"],
+                "mode": 0,
+                "text": "",
+                "bgcolor": palette["dot_warn"],
+                "activebgcolor": palette["dot_warn"],
+                "bgoncolor": palette["dot_warn"],
+                "activebgoncolor": palette["dot_warn"],
+                "bordercolor": palette["dot_warn"],
+                "activebordercolor": palette["dot_warn"],
+                "activebordercoloroff": palette["dot_warn"],
+                "rounded": 16.0,
+                "fontsize": 1.0,
+                "parameter_enable": 0,
+            },
+        )
+    )
+
+    txt_cfg = ui["status"]["text"]
+    txt_rect = (
+        float(txt_cfg["pos"]["x"]),
+        float(txt_cfg["pos"]["y"]),
+        float(txt_cfg["size"]["width"]),
+        float(txt_cfg["size"]["height"]),
+    )
+    boxes.append(
+        _box(
+            OBJ_STATUS_TEXT,
+            "live.comment",
+            txt_rect,
+            presentation=True,
+            presentation_rect=txt_rect,
+            numinlets=1,
+            numoutlets=0,
+            extras={
+                "varname": txt_cfg["id"],
+                "text": "checking…",
+                "fontname": "Ableton Sans Medium",
+                "fontsize": 9.0,
+                "textcolor": palette["dim"],
+                "parameter_enable": 0,
+            },
+        )
+    )
+
+    footer_cfg = ui["status"]["footer"]
+    footer_rect = (
+        float(footer_cfg["pos"]["x"]),
+        float(footer_cfg["pos"]["y"]),
+        float(footer_cfg["size"]["width"]),
+        float(footer_cfg["size"]["height"]),
+    )
+    boxes.append(
+        _box(
+            OBJ_FOOTER_TEXT,
+            "live.comment",
+            footer_rect,
+            presentation=True,
+            presentation_rect=footer_rect,
+            numinlets=1,
+            numoutlets=0,
+            extras={
+                "varname": footer_cfg["id"],
+                "text": "starting…",
+                "fontname": "Ableton Sans Medium",
+                "fontsize": 9.0,
+                "textcolor": palette["dim"],
+                "parameter_enable": 0,
+            },
+        )
+    )
+
+    ver_cfg = ui["status"]["version_text"]
+    ver_rect = (
+        float(ver_cfg["pos"]["x"]),
+        float(ver_cfg["pos"]["y"]),
+        float(ver_cfg["size"]["width"]),
+        float(ver_cfg["size"]["height"]),
+    )
+    boxes.append(
+        _box(
+            OBJ_VERSION_TEXT,
+            "live.comment",
+            ver_rect,
+            presentation=True,
+            presentation_rect=ver_rect,
+            numinlets=1,
+            numoutlets=0,
+            extras={
+                "varname": ver_cfg["id"],
+                "text": f"v{device_cfg.get('version', '0.1.0')}",
+                "fontname": "Ableton Sans Medium",
+                "fontsize": 9.0,
+                "textcolor": palette["dim"],
+                "parameter_enable": 0,
+            },
+        )
+    )
+
+    # ── [js sf_configurator.js] — operations dispatcher ─────────────────────
+    js_filename = js_cfg["filename"]
+    js_scripting = js_cfg["scripting_name"]
+    js_numoutlets = int(js_cfg["numoutlets"])
+    boxes.append(
+        _box(
+            OBJ_JS,
+            "newobj",
+            (16.0, 200.0, 280.0, 22.0),
+            numinlets=1,
+            numoutlets=js_numoutlets,
+            outlettype=[""] * js_numoutlets,
+            extras={
+                "text": f"js {js_filename} @scripting_name {js_scripting}",
+                "saved_object_attributes": {
+                    "filename": js_filename,
+                    "parameter_enable": 0,
+                },
+            },
+        )
+    )
+
+    # Wire each button's message → JS inlet 0.
+    for btn in btn_items:
+        lines.append(_line(_btn_msg_id(btn["id"]), 0, OBJ_JS, 0))
+
+    # ── Loadbang → JS (boot-time port discovery) ────────────────────────────
+    boxes.append(
+        _box(
+            OBJ_LOADBANG,
+            "newobj",
+            (16.0, 170.0, 60.0, 22.0),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=["bang"],
+            extras={"text": "loadbang"},
+        )
+    )
+    # Loadbang fires the bare bang into the JS — sf_configurator.bang()
+    # calls discoverPort().
+    lines.append(_line(OBJ_LOADBANG, 0, OBJ_JS, 0))
+
+    # ── JS outlets routed to UI + shell + jweb ──────────────────────────────
+    # outlet 0 → status_text   (set <text>)
+    # outlet 1 → footer_text
+    # outlet 2 → status_dot    (bgcolor r g b a)
+    # outlet 3 → jweb          (openurl <url>)
+    # outlet 4 → shell         (exec <cmd>)
+    #
+    # We use [prepend set] for live.comment text targets so a bare string
+    # becomes `set <string>`. Status dot accepts `bgcolor r g b a` directly.
+    obj_prep_status = "obj-prep-status"
+    obj_prep_footer = "obj-prep-footer"
+    boxes.append(
+        _box(
+            obj_prep_status,
+            "newobj",
+            (16.0, 240.0, 90.0, 22.0),
+            numinlets=2,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": "prepend set"},
+        )
+    )
+    boxes.append(
+        _box(
+            obj_prep_footer,
+            "newobj",
+            (120.0, 240.0, 90.0, 22.0),
+            numinlets=2,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": "prepend set"},
+        )
+    )
+    lines.append(_line(OBJ_JS, 0, obj_prep_status, 0))
+    lines.append(_line(obj_prep_status, 0, OBJ_STATUS_TEXT, 0))
+    lines.append(_line(OBJ_JS, 1, obj_prep_footer, 0))
+    lines.append(_line(obj_prep_footer, 0, OBJ_FOOTER_TEXT, 0))
+    lines.append(_line(OBJ_JS, 2, OBJ_STATUS_DOT, 0))
+
+    # ── [jweb] — popup window. Phase 3 = float window (see device.yaml). ────
+    jweb_w = float(jweb_cfg["size"]["width"])
+    jweb_h = float(jweb_cfg["size"]["height"])
+    boxes.append(
+        _box(
+            OBJ_JWEB,
+            "jweb",
+            (300.0, 200.0, jweb_w, jweb_h),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=[""],
+            extras={
+                # Empty url at boot — `openurl` message fills it in when the
+                # user clicks Open Editor. The patcher-area rect is large so
+                # an opening developer can see the embedded view; in production
+                # users will see the float window (Open Editor uses openurl).
+                "url": "about:blank",
+                "parameter_enable": 0,
+            },
+        )
+    )
+    lines.append(_line(OBJ_JS, 3, OBJ_JWEB, 0))
+
+    # ── [shell] — curl + start-server commands ──────────────────────────────
+    boxes.append(
+        _box(
+            OBJ_SHELL,
+            "newobj",
+            (320.0, 170.0, 80.0, 22.0),
+            numinlets=1,
+            numoutlets=2,
+            outlettype=["", "bang"],
+            extras={"text": "shell"},
+        )
+    )
+    lines.append(_line(OBJ_JS, 4, OBJ_SHELL, 0))
+
+    # ── Final patcher dict ──────────────────────────────────────────────────
+    device_width = float(ui["size"]["width"])
+    device_height = float(ui["size"]["height"])
+    patcher = {
+        "patcher": {
+            "fileversion": 1,
+            "appversion": {
+                "major": 9,
+                "minor": 0,
+                "revision": 8,
+                "architecture": "x64",
+                "modernui": 1,
+            },
+            "classnamespace": "box",
+            "rect": [40.0, 96.0, 40.0 + device_width, 96.0 + device_height + 100.0],
+            "openinpresentation": 1,
+            "default_fontsize": 11.0,
+            "default_fontname": "Ableton Sans Medium",
+            "gridsize": [8.0, 8.0],
+            "devicewidth": device_width,
+            "description": (
+                f"{device_cfg.get('name', 'ConfiguratorStrip')} — "
+                "Phase 3 thin operations strip. Talks to local HTTP server "
+                f"via {server_cfg['intent_path_format']}."
+            ),
+            "boxes": boxes,
+            "lines": lines,
+            "project": {
+                "version": 1,
+                "creationdate": 3590052493,
+                "modificationdate": 3590052493,
+                "viewrect": [0.0, 0.0, device_width, device_height],
+                "autoorganize": 1,
+                "hideprojectwindow": 1,
+                "showdependencies": 1,
+                "autolocalize": 0,
+                "contents": {"patchers": {}, "code": {}},
+                "layout": {},
+                "searchpath": {},
+                "detailsvisible": 0,
+                # 1633771873 = 0x61616161 = b'aaaa' = audio effect.
+                # Must match the amxd sentinel at offset 8 — pitfall #14.
+                "amxdtype": 1633771873,
+                "readonly": 0,
+                "devpathtype": 0,
+                "devpath": ".",
+                "sortmode": 0,
+                "viewmode": 0,
+                "includepackages": 0,
+            },
+            "dependency_cache": [
+                {
+                    "name": js_filename,
+                    # The JS ships in StemForge's Max Package javascript/
+                    # path (same convention as the big device). When the
+                    # strip's installer runs it copies sf_configurator.js
+                    # into ~/Documents/Max 9/Packages/StemForge/javascript/.
+                    "bootpath": "~/Documents/Max 9/Packages/StemForge/javascript",
+                    "type": "TEXT",
+                    "implicit": 1,
+                },
+            ],
+            "autosave": 0,
+        }
+    }
+    return patcher
+
+
+# ── CLI entrypoint ──────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+
+    HERE = Path(__file__).resolve().parent
+    DEFAULT_YAML = HERE / "device.yaml"
+    DEFAULT_OUT = HERE.parents[2] / "build" / "ConfiguratorStrip.maxpat"
+
+    ap = argparse.ArgumentParser(description="Build the Configurator Strip .maxpat")
+    ap.add_argument("--device-yaml", default=str(DEFAULT_YAML))
+    ap.add_argument("--out", default=str(DEFAULT_OUT))
+    args = ap.parse_args()
+
+    patch = build_patcher(args.device_yaml)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(patch, indent="\t"))
+    print(f"wrote {out_path} ({out_path.stat().st_size} bytes)")

--- a/v0/src/m4l-devices/configurator-strip/device.yaml
+++ b/v0/src/m4l-devices/configurator-strip/device.yaml
@@ -1,0 +1,135 @@
+# Configurator Strip — Phase 3 thin operations device.
+#
+# Companion to StemForge.amxd (the big device). The strip runs the seven
+# canonical operations (load, slice, recompute, re-anchor, curate, export,
+# open editor) by talking to the local HTTP server that Lane A ships
+# (`stemforge-configurator`, default port discovered via
+# ~/stemforge/.configurator_port).
+#
+# This is NOT a refactor of UI v2. It is a fresh-build M4L device that
+# lives alongside the existing big device. See
+# `project_configurator_device_decision.md` and Phase 3 of
+# `docs/configurator/STEMFORGE_CONFIGURATOR_SPEC_v4.md`.
+#
+# Layout: thin horizontal strip ~ Live's narrow M4L device area.
+#   width  = 820 (matches StemForge.amxd canvas convention)
+#   height = 100 (one-row strip, leaves headroom for status footer)
+#
+#   ┌────────────────────────────────────────────────────────────────────────┐
+#   │ [Load] [Slice] [Recompute] [Re-anchor] [Curate] [Export] [Open Editor] │
+#   │                                                            • connected │
+#   └────────────────────────────────────────────────────────────────────────┘
+
+version: 1
+
+device:
+  name: "ConfiguratorStrip"
+  short_name: "CFG"
+  bundle_identifier: "com.stemforge.configurator.strip.v0"
+  version: "0.1.0"
+
+# Visual design language is StemForge — same orange accent (#F97316) and
+# graphite chrome. Buttons are flat (mode=0 live.text) with rounded corners.
+palette:
+  bg:         [0.055, 0.055, 0.055, 1.0]   # #0E0E0E — body
+  panel:      [0.118, 0.118, 0.137, 1.0]   # #1E1E23 — button background
+  text:       [0.878, 0.878, 0.878, 1.0]   # #E0E0E0
+  dim:        [0.533, 0.533, 0.533, 1.0]   # #888888
+  accent:     [0.976, 0.451, 0.086, 1.0]   # #F97316 — orange (StemForge brand)
+  dot_ok:     [0.220, 0.780, 0.376, 1.0]   # #38C760 — server connected
+  dot_warn:   [0.957, 0.741, 0.137, 1.0]   # #F4BD23 — checking
+  dot_error:  [0.871, 0.275, 0.275, 1.0]   # #DE4646 — server not running
+
+ui:
+  size: { width: 820, height: 100 }
+
+  # Seven operation buttons, evenly spaced across left ~720px. Each button
+  # is 96×40, gap=8.  Total strip: 7*96 + 6*8 = 720px wide. Status indicator
+  # sits in the right 100px.
+  buttons:
+    geometry:
+      width: 96
+      height: 40
+      gap: 8
+      y: 28          # vertical center within the 100px strip
+    items:
+      - id: btn_load
+        label: "LOAD"
+        verb: "load-manifest"
+        kind: "http"     # POSTs /intent/load-manifest after opendialog
+      - id: btn_slice
+        label: "SLICE"
+        verb: "slice"
+        kind: "http"     # POSTs /intent/slice (Lane A surfaces the slicer UI)
+      - id: btn_recompute
+        label: "RECOMPUTE"
+        verb: "recompute"
+        kind: "http"     # POSTs /intent/recompute
+      - id: btn_reanchor
+        label: "RE-ANCHOR"
+        verb: "re-anchor"
+        kind: "http"     # POSTs /intent/re-anchor (the actual LOM walk
+                          # happens inside the big device; the strip just
+                          # fires the intent which the server forwards)
+      - id: btn_curate
+        label: "CURATE"
+        verb: "curate"
+        kind: "http"     # POSTs /intent/curate
+      - id: btn_export
+        label: "EXPORT"
+        verb: "export"
+        kind: "http"     # POSTs /intent/export with target="ep133"
+      - id: btn_open_editor
+        label: "OPEN EDITOR"
+        verb: "open-editor"
+        kind: "jweb"     # opens the popup (separate float window for Phase 3)
+
+  # Connection indicator on the right side. Re-checked on loadbang + after
+  # every HTTP failure.
+  status:
+    indicator:
+      id: status_dot
+      pos: { x: 740, y: 36 }
+      size: { width: 14, height: 14 }
+    text:
+      id: status_text
+      pos: { x: 760, y: 36 }
+      size: { width: 56, height: 14 }
+    # Footer line shows server URL + last action.
+    footer:
+      id: footer_text
+      pos: { x: 8, y: 80 }
+      size: { width: 720, height: 14 }
+    # Version stamp on the right of the footer.
+    version_text:
+      id: version_text
+      pos: { x: 740, y: 80 }
+      size: { width: 76, height: 14 }
+
+# JS module that runs the operations dispatcher.
+js:
+  filename: sf_configurator.js
+  scripting_name: sf_configurator
+  numoutlets: 5
+  # outlet 0: status text → status_text
+  # outlet 1: footer text → footer_text
+  # outlet 2: dot color   → status_dot (RGB list)
+  # outlet 3: openurl     → [jweb]    (open editor)
+  # outlet 4: shell exec  → [shell]   (curl + server-start commands)
+
+# How the strip finds the HTTP server.
+server:
+  # Port-file path (resolved at runtime via ~). Lane A writes the port here.
+  port_file: "~/stemforge/.configurator_port"
+  base_url_format: "http://127.0.0.1:{port}"
+  # Command fired by the "Start server" CTA when the port file is missing.
+  start_command: "stemforge-configurator"
+  # POST endpoint pattern.
+  intent_path_format: "/intent/{verb}"
+
+# The popup window opened by Open Editor. Phase 3 is a float-window [jweb]
+# (not embedded in the M4L device area) — easier to position, no fight with
+# Live's narrow strip rect. Phase 4 may revisit embedding.
+jweb:
+  size: { width: 1200, height: 800 }
+  url_format: "http://127.0.0.1:{port}/"

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -1,0 +1,426 @@
+// sf_configurator.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Configurator Strip — operations dispatcher (Phase 3).
+//
+// Lives inside the ConfiguratorStrip.amxd device. The strip has seven labelled
+// buttons; each button fires a message into this script (see device.yaml for
+// the verb→button mapping). The script:
+//
+//   1. Discovers the local HTTP server's port (Lane A writes it to
+//      ~/stemforge/.configurator_port).
+//   2. For "http"-kind verbs: POSTs to http://127.0.0.1:<port>/intent/<verb>.
+//   3. For "jweb"-kind verb (open-editor): emits an `openurl` message that
+//      the patcher routes to a [jweb] float window.
+//   4. For commit specifically: walks session+arrangement view first
+//      (using the same algorithm as stemforge_loader.v0.js's
+//      _commitSessionTracks), then POSTs the resulting session_tracks dict.
+//
+// HTTP transport choice — `[js]` SpiderMonkey on macOS doesn't ship a
+// XMLHttpRequest binding that's reliable in M4L, so we use the shell-via-curl
+// fallback documented in `memory/m4l_device_development_guide.md` §3 (the
+// [shell] external is already a project dependency for the big device).
+// The JS emits curl commands out outlet 4 and the patcher pipes them through
+// [shell].
+//
+// Outlets (matched in device.yaml):
+//   0: status text   → live.comment status_text
+//   1: footer text   → live.comment footer_text
+//   2: dot color     → live.text status_dot   (sent as `bgcolor r g b a`)
+//   3: openurl       → [jweb]                 (open the popup)
+//   4: shell exec    → [shell]                (curl POST + server-start)
+// ─────────────────────────────────────────────────────────────────────────────
+
+inlets  = 1;
+outlets = 5;
+autowatch = 1;
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+// Path to the port file. We expand ~ at lookup time.
+var PORT_FILE = "~/stemforge/.configurator_port";
+
+// HTTP base + intent endpoint. Templated at runtime once we know the port.
+var SERVER_HOST = "127.0.0.1";
+
+// Console-script name fired by the "Start server" CTA.
+var START_COMMAND = "stemforge-configurator";
+
+// Cached state. Re-checked on COMMIT (in case the server restarted).
+var _port      = null;
+var _serverBase = null;
+var _connected = false;
+
+// Letters walked by COMMIT — matches stemforge_loader.v0.js convention.
+var COMMIT_LETTERS    = ["A", "B", "C", "D"];
+var COMMIT_SLOTS_PER  = 20;
+var COMMIT_SESSION_MAX = 31;
+
+// ── Status helpers ───────────────────────────────────────────────────────────
+
+function _status(line) {
+    outlet(0, line == null ? "" : String(line));
+}
+
+function _footer(line) {
+    outlet(1, line == null ? "" : String(line));
+}
+
+function _setDot(rgba) {
+    // rgba is a 4-element array. Emit as a Max message that [live.text]
+    // bgcolor recognizes.
+    outlet(2, "bgcolor", rgba[0], rgba[1], rgba[2], rgba[3]);
+}
+
+var DOT_OK    = [0.220, 0.780, 0.376, 1.0];
+var DOT_WARN  = [0.957, 0.741, 0.137, 1.0];
+var DOT_ERROR = [0.871, 0.275, 0.275, 1.0];
+
+function _post(msg) {
+    if (typeof post === "function") post(String(msg) + "\n");
+}
+
+// ── Port discovery ───────────────────────────────────────────────────────────
+
+function _expandTilde(p) {
+    if (typeof p !== "string") return p;
+    if (p.length === 0 || p.charAt(0) !== "~") return p;
+    // In Max [js] the `Folder` global doesn't expose $HOME, but `File` resolves
+    // ~ when given the path. We do the substitution defensively in case
+    // the runtime doesn't expand for us. Fall back to $HOME via env if needed.
+    var home = "";
+    try {
+        // Max 8+ exposes process.env via "max" module on Node — not here in
+        // classic [js]. We hardcode the convention from Live: the user
+        // running Live owns ~. Build the absolute path via shell substitution
+        // when the path is finally consumed by curl/shell.
+        home = "$HOME";
+    } catch (_) {}
+    return home + p.substring(1);
+}
+
+function discoverPort() {
+    // Read the port file. classic [js] `File` supports this; if it doesn't
+    // resolve `~`, we fall back to letting the shell-curl handle expansion.
+    _setDot(DOT_WARN);
+    _status("checking…");
+
+    var port = _readPortFile(PORT_FILE);
+    if (port == null) {
+        _port = null;
+        _serverBase = null;
+        _connected = false;
+        _setDot(DOT_ERROR);
+        _status("server down");
+        _footer("server not running — click Start Server");
+        return null;
+    }
+
+    _port = port;
+    _serverBase = "http://" + SERVER_HOST + ":" + port;
+    _setDot(DOT_OK);
+    _status("connected");
+    _footer(_serverBase);
+    _connected = true;
+    return port;
+}
+
+function _readPortFile(p) {
+    // The classic Max [js] `File` object reads file contents via .position +
+    // .readstring(). It accepts ~ on macOS — but not always reliably. We
+    // try File first, then defer to a shell read if that fails.
+    try {
+        var f = new File(_expandTilde(p), "read");
+        if (f && f.isopen) {
+            f.position = 0;
+            var raw = f.readstring(64);
+            f.close();
+            if (raw == null) return null;
+            var s = String(raw).replace(/\s+/g, "");
+            if (!s.length) return null;
+            var n = parseInt(s, 10);
+            if (!isFinite(n) || n <= 0) return null;
+            return n;
+        }
+    } catch (e) {
+        _post("[sf_configurator] File read failed for " + p + ": " + e);
+    }
+    return null;
+}
+
+// ── HTTP via shell + curl (see header doc for why) ───────────────────────────
+
+function _shellQuote(s) {
+    // Single-quote shell wrap; escape embedded single quotes.
+    if (s == null) return "''";
+    return "'" + String(s).replace(/'/g, "'\\''") + "'";
+}
+
+function _postIntent(verb, bodyObj) {
+    if (!_serverBase) {
+        if (discoverPort() == null) {
+            _footer("post " + verb + ": server down");
+            return false;
+        }
+    }
+    var url = _serverBase + "/intent/" + verb;
+    var bodyJson = "{}";
+    try {
+        if (bodyObj && typeof bodyObj === "object") {
+            bodyJson = JSON.stringify(bodyObj);
+        }
+    } catch (e) {
+        _post("[sf_configurator] JSON.stringify failed: " + e);
+        bodyJson = "{}";
+    }
+
+    // curl -X POST -H 'Content-Type: application/json' -d '<body>' <url>
+    // Use --silent + --max-time so we don't hang the patcher.
+    var cmd = "curl --silent --max-time 5 " +
+              "-H 'Content-Type: application/json' " +
+              "-X POST " +
+              "-d " + _shellQuote(bodyJson) + " " +
+              _shellQuote(url);
+
+    outlet(4, "exec", cmd);
+    _footer("→ " + verb);
+    return true;
+}
+
+// ── Public message handlers (one per button) ─────────────────────────────────
+
+function loadbang() {
+    discoverPort();
+}
+
+function bang() {
+    // Re-discover port (status indicator clicked or external bang).
+    discoverPort();
+}
+
+function ping() {
+    discoverPort();
+}
+
+// btn_load — POST /intent/load-manifest
+function loadManifest(path) {
+    var body = path ? { manifest_path: String(path) } : {};
+    if (_postIntent("load-manifest", body)) {
+        _status("load-manifest sent");
+    }
+}
+
+// btn_slice — POST /intent/slice
+function slice() {
+    if (_postIntent("slice", {})) _status("slice sent");
+}
+
+// btn_recompute — POST /intent/recompute
+function recompute() {
+    if (_postIntent("recompute", {})) _status("recompute sent");
+}
+
+// btn_reanchor — POST /intent/re-anchor
+function reAnchor() {
+    if (_postIntent("re-anchor", {})) _status("re-anchor sent");
+}
+// Alias matching device.yaml verb (hyphen → camel handled in the patcher).
+function reanchor() { reAnchor(); }
+
+// btn_curate — POST /intent/curate
+function curate() {
+    if (_postIntent("curate", {})) _status("curate sent");
+}
+
+// btn_export — POST /intent/export
+function exportPpak(outPath) {
+    var body = { target: "ep133" };
+    if (outPath != null) body.out_path = String(outPath);
+    if (_postIntent("export", body)) _status("export sent");
+}
+function exportTarget(target, outPath) {
+    var body = { target: String(target || "ep133") };
+    if (outPath != null) body.out_path = String(outPath);
+    if (_postIntent("export", body)) _status("export → " + body.target);
+}
+
+// btn_open_editor — open popup via [jweb]
+function openEditor() {
+    // Re-check port in case the server has restarted since boot.
+    if (!_serverBase) discoverPort();
+    if (!_serverBase) {
+        _footer("open-editor: server down");
+        return;
+    }
+    outlet(3, "openurl", _serverBase + "/");
+    _status("editor opened");
+    _footer("editor → " + _serverBase + "/");
+}
+
+// "Start server" CTA fired when port-file is missing.
+function startServer() {
+    outlet(4, "exec", START_COMMAND + " &");
+    _status("starting…");
+    _footer("starting " + START_COMMAND);
+}
+
+// ── COMMIT — walk session+arrangement view, POST result ──────────────────────
+//
+// Mirrors the algorithm in stemforge_loader.v0.js's `_commitSessionTracks`.
+// We duplicate the walker here for Phase 3 to keep the strip independent of
+// the big device's JS bundle. TODO: factor a shared walker into
+// v0/src/m4l-js/sf_commit_walker.js (or similar) and have both devices load
+// it; tracking issue to follow this PR.
+
+function _findTrackByName(name) {
+    try {
+        var ls = new LiveAPI("live_set");
+        var cnt = ls.getcount("tracks");
+        for (var i = 0; i < cnt; i++) {
+            var t = new LiveAPI("live_set tracks " + i);
+            var got = t.get("name");
+            var s = Array.isArray(got) ? got[0] : got;
+            if (String(s) === String(name)) return i;
+        }
+    } catch (e) {
+        _post("[sf_configurator] findTrackByName error: " + e);
+    }
+    return -1;
+}
+
+function _getProp(api, prop) {
+    try {
+        var v = api.get(prop);
+        if (Array.isArray(v) && v.length === 1) return v[0];
+        return v;
+    } catch (_) { return null; }
+}
+
+function _stripHfs(p) {
+    if (p == null) return "";
+    var s = String(p);
+    if (s.indexOf("Macintosh HD:") === 0) s = s.substring("Macintosh HD:".length);
+    return s;
+}
+
+function _entryFromClip(clipApi, slot, beatToSec) {
+    var fpRaw = _getProp(clipApi, "file_path");
+    if (fpRaw == null || fpRaw === "") return null;
+    var file = _stripHfs(fpRaw);
+    var startMarker = Number(_getProp(clipApi, "start_marker")) || 0;
+    var endMarker   = Number(_getProp(clipApi, "end_marker"))   || 0;
+    var lengthBeats = Number(_getProp(clipApi, "length"))       || 0;
+    var warping     = Number(_getProp(clipApi, "warping"))      || 0;
+    var startSec, endSec, lengthSec;
+    if (warping) {
+        startSec  = startMarker * beatToSec;
+        endSec    = endMarker   * beatToSec;
+        lengthSec = lengthBeats * beatToSec;
+    } else {
+        startSec  = startMarker;
+        endSec    = endMarker;
+        lengthSec = lengthBeats;
+    }
+    var mode = (Math.abs(endSec - lengthSec) < 0.010) ? "rotate" : "trim";
+    return {
+        file:        file,
+        slot:        slot,
+        start_sec:   startSec,
+        end_sec:     endSec,
+        length_sec:  lengthSec,
+        warping:     warping ? 1 : 0,
+        mode:        mode,
+    };
+}
+
+function _walkSessionAndArrangement() {
+    // Returns { A: [...], B: [...], C: [...], D: [...] } per the same
+    // contract as the big device's _commitSessionTracks. BPM falls back to
+    // 120 if the LiveAPI isn't seeded.
+    var bpm = 120.0;
+    try {
+        var lsApi = new LiveAPI("live_set");
+        var t = Number(_getProp(lsApi, "tempo"));
+        if (t > 0) bpm = t;
+    } catch (_) {}
+    var beatToSec = 60.0 / bpm;
+    var result = { A: [], B: [], C: [], D: [] };
+
+    for (var li = 0; li < COMMIT_LETTERS.length; li++) {
+        var letter = COMMIT_LETTERS[li];
+        var ti = _findTrackByName(letter);
+        if (ti < 0) continue;
+        var seen = {};
+        var used = {};
+        var entries = [];
+
+        // Session view — slot = clip_slot index (preserve historical layout).
+        for (var sj = 0; sj < COMMIT_SESSION_MAX; sj++) {
+            var clipApi;
+            try { clipApi = new LiveAPI("live_set tracks " + ti + " clip_slots " + sj + " clip"); }
+            catch (_) { continue; }
+            if (!clipApi || clipApi.id === "0") continue;
+            var entry = _entryFromClip(clipApi, sj, beatToSec);
+            if (!entry) continue;
+            if (seen.hasOwnProperty(entry.file)) continue;
+            entries.push(entry);
+            seen[entry.file] = entry.slot;
+            used[entry.slot] = true;
+        }
+
+        // Arrangement view — claim next free slot in 0..19.
+        var trackApi;
+        try { trackApi = new LiveAPI("live_set tracks " + ti); } catch (_) { trackApi = null; }
+        var arrCount = 0;
+        if (trackApi) {
+            try { arrCount = trackApi.getcount("arrangement_clips") | 0; } catch (_) {}
+        }
+        for (var ai = 0; ai < arrCount; ai++) {
+            var aClip;
+            try { aClip = new LiveAPI("live_set tracks " + ti + " arrangement_clips " + ai); }
+            catch (_) { continue; }
+            if (!aClip || aClip.id === "0") continue;
+            var afpRaw = _getProp(aClip, "file_path");
+            if (!afpRaw) continue;
+            var afp = _stripHfs(afpRaw);
+            if (seen.hasOwnProperty(afp)) continue;
+            var nextSlot = -1;
+            for (var s = 0; s < COMMIT_SLOTS_PER; s++) {
+                if (!used[s]) { nextSlot = s; break; }
+            }
+            if (nextSlot < 0) continue;
+            var aEntry = _entryFromClip(aClip, nextSlot, beatToSec);
+            if (!aEntry) continue;
+            entries.push(aEntry);
+            seen[aEntry.file] = aEntry.slot;
+            used[aEntry.slot] = true;
+        }
+
+        result[letter] = entries;
+    }
+    return result;
+}
+
+// btn_commit — walk views, POST /intent/commit
+function commit() {
+    // Re-check port — server may have restarted since boot.
+    discoverPort();
+    var session_tracks;
+    try {
+        session_tracks = _walkSessionAndArrangement();
+    } catch (e) {
+        _post("[sf_configurator] commit walker failed: " + e);
+        _footer("commit walker failed: " + e);
+        return;
+    }
+    var summary = COMMIT_LETTERS.map(function (l) {
+        return l + "=" + (session_tracks[l] ? session_tracks[l].length : 0);
+    }).join(" ");
+    _status("commit: " + summary);
+    _postIntent("commit", { session_tracks: session_tracks });
+}
+
+// Expose the walker for unit tests (sandbox can reach it via the global).
+this._walkSessionAndArrangement = _walkSessionAndArrangement;
+this._entryFromClip             = _entryFromClip;
+this._postIntent                = _postIntent;
+this._discoverPort              = discoverPort;

--- a/v0/src/m4l-devices/configurator-strip/tests/conftest.py
+++ b/v0/src/m4l-devices/configurator-strip/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest config: makes the strip's builder importable as a bare module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The strip's source lives one level up. The directory name contains hyphens,
+# so we can't import it as a normal Python package — add it to sys.path so
+# `from builder import build_patcher` works inside test files.
+HERE = Path(__file__).resolve().parent
+SRC = HERE.parent
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/v0/src/m4l-devices/configurator-strip/tests/test_strip_builder.py
+++ b/v0/src/m4l-devices/configurator-strip/tests/test_strip_builder.py
@@ -1,0 +1,270 @@
+"""Unit tests for the Configurator Strip patcher builder.
+
+Static-analysis only — these run without Max installed. They assert on the
+generated .maxpat JSON structure: every operation button is wired, the
+HTTP/[jweb]/[shell] infrastructure is present, the strip's audio-effect
+container fields are correct, and the JS dependency cache is set.
+
+Phase 3 acceptance gate: `pytest v0/src/m4l-devices/configurator-strip/tests`
+plus the Node-based JS suite must both pass before .amxd packaging.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from builder import (
+    OBJ_JS,
+    OBJ_JWEB,
+    OBJ_LOADBANG,
+    OBJ_PLUGIN_IN,
+    OBJ_PLUGOUT,
+    OBJ_SHELL,
+    OBJ_STATUS_DOT,
+    OBJ_STATUS_TEXT,
+    OBJ_FOOTER_TEXT,
+    OBJ_VERSION_TEXT,
+    VERB_TO_HANDLER,
+    _btn_box_id,
+    _btn_msg_id,
+    _btn_tb_id,
+    build_patcher,
+)
+
+HERE = Path(__file__).resolve().parent
+DEVICE_YAML = HERE.parent / "device.yaml"
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict:
+    with open(DEVICE_YAML) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def patcher() -> dict:
+    return build_patcher(DEVICE_YAML)
+
+
+@pytest.fixture(scope="module")
+def boxes(patcher) -> list[dict]:
+    return [b["box"] for b in patcher["patcher"]["boxes"]]
+
+
+@pytest.fixture(scope="module")
+def box_by_id(boxes) -> dict[str, dict]:
+    return {b["id"]: b for b in boxes}
+
+
+@pytest.fixture(scope="module")
+def line_pairs(patcher) -> set[tuple[str, str]]:
+    """Return set of (src_id, dst_id) pairs across all patchlines."""
+    return {
+        (ln["patchline"]["source"][0], ln["patchline"]["destination"][0])
+        for ln in patcher["patcher"]["lines"]
+    }
+
+
+# ── Top-level shape ─────────────────────────────────────────────────────────
+
+
+def test_patcher_has_required_top_level_fields(patcher):
+    p = patcher["patcher"]
+    assert p["openinpresentation"] == 1
+    assert p["appversion"]["modernui"] == 1
+    assert isinstance(p["boxes"], list) and p["boxes"]
+    assert isinstance(p["lines"], list) and p["lines"]
+
+
+def test_devicewidth_matches_yaml(spec, patcher):
+    assert patcher["patcher"]["devicewidth"] == float(spec["ui"]["size"]["width"])
+
+
+def test_project_field_present_with_audio_effect_amxdtype(patcher):
+    """Pitfall #6 — without `project`, Max rejects the device. Pitfall #14 —
+    amxdtype must be 0x61616161 ('aaaa') for audio effects."""
+    proj = patcher["patcher"]["project"]
+    assert proj["version"] == 1
+    # 0x61616161 = 1633771873 = b'aaaa' as u32 LE.
+    assert proj["amxdtype"] == 1633771873
+
+
+# ── Audio passthrough — pitfall #7 ──────────────────────────────────────────
+
+
+def test_plugin_in_and_plugout_present(box_by_id, line_pairs):
+    assert OBJ_PLUGIN_IN in box_by_id
+    assert OBJ_PLUGOUT in box_by_id
+    assert box_by_id[OBJ_PLUGIN_IN]["text"] == "plugin~ 2"
+    assert box_by_id[OBJ_PLUGOUT]["text"] == "plugout~ 2"
+    assert (OBJ_PLUGIN_IN, OBJ_PLUGOUT) in line_pairs
+
+
+# ── Buttons: exactly seven, each wired ──────────────────────────────────────
+
+
+def test_exactly_seven_operation_buttons(spec, boxes):
+    button_ids = {b["id"] for b in spec["ui"]["buttons"]["items"]}
+    assert len(button_ids) == 7, "device.yaml must declare exactly 7 buttons"
+    btn_boxes = [b for b in boxes if b["id"].startswith("obj-btn-")]
+    assert len(btn_boxes) == 7, "patcher must contain exactly 7 button boxes"
+
+
+def test_every_button_is_live_text_with_label_and_accent(spec, box_by_id):
+    palette = spec["palette"]
+    for btn in spec["ui"]["buttons"]["items"]:
+        bid = _btn_box_id(btn["id"])
+        assert bid in box_by_id, f"missing button box {bid}"
+        b = box_by_id[bid]
+        assert b["maxclass"] == "live.text"
+        assert b["presentation"] == 1
+        assert b["text"] == btn["label"]
+        # Accent matches the orange brand color.
+        assert b["activebgcolor"] == palette["accent"]
+        # Display-only — opt out of M4L parameter enrollment.
+        assert b["parameter_enable"] == 0
+
+
+def test_every_button_has_tb_and_message_handler(spec, box_by_id, line_pairs):
+    """Pitfall #17 — buttons need [t b] to convert label-symbol into a bang
+    before firing the JS handler-name message."""
+    for btn in spec["ui"]["buttons"]["items"]:
+        verb = btn["verb"]
+        handler = VERB_TO_HANDLER[verb]
+
+        btn_box = _btn_box_id(btn["id"])
+        tb_box = _btn_tb_id(btn["id"])
+        msg_box = _btn_msg_id(btn["id"])
+
+        assert tb_box in box_by_id
+        assert box_by_id[tb_box]["text"] == "t b"
+
+        assert msg_box in box_by_id
+        assert box_by_id[msg_box]["text"] == handler
+
+        # Wiring: button → t b → message → JS.
+        assert (btn_box, tb_box) in line_pairs
+        assert (tb_box, msg_box) in line_pairs
+        assert (msg_box, OBJ_JS) in line_pairs
+
+
+# ── JS dispatcher object ────────────────────────────────────────────────────
+
+
+def test_js_object_present_with_scripting_name(spec, box_by_id):
+    js_cfg = spec["js"]
+    assert OBJ_JS in box_by_id
+    text = box_by_id[OBJ_JS]["text"]
+    assert text.startswith(f"js {js_cfg['filename']}")
+    assert f"@scripting_name {js_cfg['scripting_name']}" in text
+    assert box_by_id[OBJ_JS]["numoutlets"] == js_cfg["numoutlets"]
+
+
+def test_js_dependency_cache_points_at_stemforge_package(spec, patcher):
+    js_cfg = spec["js"]
+    cache = patcher["patcher"]["dependency_cache"]
+    names = [entry["name"] for entry in cache]
+    assert js_cfg["filename"] in names
+    entry = next(e for e in cache if e["name"] == js_cfg["filename"])
+    assert "StemForge/javascript" in entry["bootpath"]
+
+
+def test_loadbang_fires_into_js(box_by_id, line_pairs):
+    assert OBJ_LOADBANG in box_by_id
+    assert box_by_id[OBJ_LOADBANG]["text"] == "loadbang"
+    assert (OBJ_LOADBANG, OBJ_JS) in line_pairs
+
+
+# ── jweb (popup) ────────────────────────────────────────────────────────────
+
+
+def test_jweb_object_present_and_sized(spec, box_by_id, line_pairs):
+    assert OBJ_JWEB in box_by_id
+    jweb_box = box_by_id[OBJ_JWEB]
+    assert jweb_box["maxclass"] == "jweb"
+    # Default URL is about:blank — script sends openurl on user click.
+    assert jweb_box["url"] == "about:blank"
+    # Size matches device.yaml.
+    expected_w = float(spec["jweb"]["size"]["width"])
+    expected_h = float(spec["jweb"]["size"]["height"])
+    assert jweb_box["patching_rect"][2] == expected_w
+    assert jweb_box["patching_rect"][3] == expected_h
+    # JS outlet 3 → jweb.
+    assert (OBJ_JS, OBJ_JWEB) in line_pairs
+
+
+# ── shell (HTTP via curl + start-server) ────────────────────────────────────
+
+
+def test_shell_object_present_and_wired(box_by_id, line_pairs):
+    assert OBJ_SHELL in box_by_id
+    assert box_by_id[OBJ_SHELL]["text"] == "shell"
+    # JS outlet 4 → shell.
+    assert (OBJ_JS, OBJ_SHELL) in line_pairs
+
+
+# ── Status indicator + footer + version ─────────────────────────────────────
+
+
+def test_status_indicator_present_in_presentation(spec, box_by_id):
+    palette = spec["palette"]
+    assert OBJ_STATUS_DOT in box_by_id
+    dot = box_by_id[OBJ_STATUS_DOT]
+    assert dot["maxclass"] == "live.text"
+    assert dot["presentation"] == 1
+    # Initial state is "checking" (warn).
+    assert dot["bgcolor"] == palette["dot_warn"]
+    assert dot["parameter_enable"] == 0
+
+
+def test_status_text_and_footer_and_version_present(box_by_id, line_pairs):
+    for obj_id in (OBJ_STATUS_TEXT, OBJ_FOOTER_TEXT, OBJ_VERSION_TEXT):
+        assert obj_id in box_by_id
+        assert box_by_id[obj_id]["maxclass"] == "live.comment"
+        assert box_by_id[obj_id]["presentation"] == 1
+        assert box_by_id[obj_id]["parameter_enable"] == 0
+
+    # JS outlets 0/1/2 must reach the live.* widgets.
+    # outlet 0 → status_text (via [prepend set])
+    # outlet 1 → footer_text (via [prepend set])
+    # outlet 2 → status_dot
+    js_outlet_destinations = {dst for src, dst in line_pairs if src == OBJ_JS}
+    assert OBJ_STATUS_DOT in js_outlet_destinations
+    # status_text and footer_text receive via prepend boxes — assert each is
+    # reachable from JS through one hop.
+    prep_targets = {dst for src, dst in line_pairs if src.startswith("obj-prep-")}
+    assert OBJ_STATUS_TEXT in prep_targets
+    assert OBJ_FOOTER_TEXT in prep_targets
+
+
+# ── Verb table integrity ────────────────────────────────────────────────────
+
+
+def test_every_yaml_verb_has_handler_mapping(spec):
+    for btn in spec["ui"]["buttons"]["items"]:
+        assert btn["verb"] in VERB_TO_HANDLER, (
+            f"device.yaml verb {btn['verb']!r} has no handler in VERB_TO_HANDLER"
+        )
+
+
+def test_commit_handler_exists_even_though_not_a_button():
+    """COMMIT walks LOM and POSTs /intent/commit. The big device's COMMIT
+    button fires it via the shared message dispatcher — the strip script
+    exposes the same function name so future wiring is one-line."""
+    assert VERB_TO_HANDLER["commit"] == "commit"
+
+
+# ── Patcher pack sanity ─────────────────────────────────────────────────────
+
+
+def test_patcher_is_json_serialisable(patcher):
+    import json
+
+    s = json.dumps(patcher)
+    assert "ConfiguratorStrip" in s or "Phase 3" in s


### PR DESCRIPTION
## Summary

- Phase 3 fresh-build M4L strip device that runs the seven canonical Configurator operations by POSTing to Lane A's local HTTP server. Lives alongside `StemForge.amxd` as a separate device per `project_configurator_device_decision.md`.
- Programmatic patcher generator + classic `[js]` operations dispatcher + 31 tests (17 Python builder + 14 JS sandbox) — all run without Max/Ableton.
- HTTP transport via `[shell]`+`curl` (Max 9 SpiderMonkey lacks reliable XHR). Popup is a float-window `[jweb]` opened on demand.

## Module layout

```
v0/src/m4l-devices/configurator-strip/
  device.yaml                # operation table, palette, geometry, server config
  builder.py                 # programmatic .maxpat generator
  js/sf_configurator.js      # operations dispatcher (classic [js])
  tests/test_strip_builder.py
  README.md                  # build + install recipe, transport rationale

tests/js_mocks/test_sf_configurator.test.js   # auto-discovered by test_js_bridge.py
tests/js_mocks/_yaml_lite.js                  # tiny YAML extractor for tests
```

## Operations wired

| Button       | Verb            | Transport |
|--------------|-----------------|-----------|
| LOAD         | load-manifest   | curl POST /intent/load-manifest |
| SLICE        | slice           | curl POST /intent/slice |
| RECOMPUTE    | recompute       | curl POST /intent/recompute |
| RE-ANCHOR    | re-anchor       | curl POST /intent/re-anchor |
| CURATE       | curate          | curl POST /intent/curate |
| EXPORT       | export          | curl POST /intent/export (target=ep133) |
| OPEN EDITOR  | open-editor     | openurl -> [jweb] float window |

COMMIT is also implemented in the JS (walks session+arrangement view, POSTs `/intent/commit` with `session_tracks`). It is not wired to a button in Phase 3 to keep the strip surface to seven ops, but the handler exists and is tested — wire it up by adding one entry to `device.yaml`.

## Port discovery flow

1. On loadbang, JS reads `~/stemforge/.configurator_port` (Lane A's port file).
2. Found -> cache port, set dot green, footer = serverBase URL.
3. Missing -> dot red, footer = "server not running — click Start Server".
4. The Start-server CTA emits `exec stemforge-configurator &` on the `[shell]` outlet.
5. Port is re-read on every COMMIT click (in case the server restarted).

## jweb embedding choice

Float window, not embedded. Popup is 1200x800; strip rect is 820x100 — embedding does not fit. Phase 4 may revisit.

## Test count

- Python: 17 passing (`uv run pytest v0/src/m4l-devices/configurator-strip/tests/`)
- JS: 14 passing (`node tests/js_mocks/test_sf_configurator.test.js`, auto-discovered by `test_js_bridge.py`)

JS bridge went from 10 -> 11 parametrized cases. Total new = 31 tests.

## What is stubbed pending on-device verify

- `.amxd` is NOT built in this PR per `feedback_test_deploy_discipline.md`. The user packs + installs to verify on hardware (recipe in `README.md`).
- The JS uses literal `$HOME` substitution for `~` expansion. Max `[js]` File may handle `~` natively at runtime; on-device verify should confirm port-file read happens cleanly.
- The session+arrangement walker is duplicated from `stemforge_loader.v0.js`. TODO in README to factor into a shared module once Phase 3 lands on hardware.
- No installer wrapper yet; manual `cp` recipe documented. `tools/install_configurator_strip.sh` is the right follow-up.

## Test plan

- [ ] `uv run pytest v0/src/m4l-devices/configurator-strip/tests/ tests/test_js_bridge.py -q` passes.
- [ ] `node tests/js_mocks/test_sf_configurator.test.js` passes (14/14).
- [ ] `python v0/src/m4l-devices/configurator-strip/builder.py --out /tmp/x.maxpat` writes a parseable JSON file; boxes >= 30, lines >= 28.
- [ ] Visual check in standalone Max: `open /tmp/x.maxpat` shows seven labelled orange-accent buttons in presentation mode plus a status indicator.

## On-device verify (manual; not in CI)

1. Build the maxpat: `python v0/src/m4l-devices/configurator-strip/builder.py --out v0/build/ConfiguratorStrip.maxpat`
2. Pack via the existing `amxd_pack.pack_amxd` (one-liner in `README.md`).
3. Sync the JS into the StemForge Max Package: `cp v0/src/m4l-devices/configurator-strip/js/sf_configurator.js ~/Documents/Max\ 9/Packages/StemForge/javascript/`
4. Install: `cp v0/build/ConfiguratorStrip.amxd ~/Music/Ableton/User\ Library/Presets/Audio\ Effects/Max\ Audio\ Effect/`
5. In Ableton: drop ConfiguratorStrip onto an audio track. Status dot should be amber -> red within ~1s if Lane A's server is not running; click Start Server -> dot turns green.
6. Click Open Editor — the popup (Lane B's frontend) should load in a float jweb window pointing at `http://127.0.0.1:<port>/`.
7. Click each remaining button; confirm Lane A's server log shows `/intent/<verb>` POSTs.

Generated with [Claude Code](https://claude.com/claude-code)
