### PR TITLE
fix(ci): install [configurator] extra so unit tests can import fastapi+httpx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install (core + dev, no ML extras)
+      - name: Install (core + dev + configurator, no ML extras)
         run: |
           pip install uv
-          uv pip install --system -e '.[dev]'
+          uv pip install --system -e '.[dev,configurator]'
 
       - name: Assert no heavy deps imported at import time
         # Track B acceptance: importing stemforge.cli must NOT pull torch.


### PR DESCRIPTION
PR #91 (Lane A — HTTP server) added a `[configurator]` optional-deps group (fastapi, uvicorn, soundfile, httpx) but the CI unit-tests stage installs `.[dev]` only. Every PR opened after #91 merged fails at test-collection on `tests/configurator/test_preview.py` and `tests/configurator/test_server_smoke.py` with ModuleNotFoundError.

Single-line bump: `.[dev]` → `.[dev,configurator]`. No other CI stage needs it (lint is ruff-only, build stages don't run pytest).

After this merges, push a no-op commit or rebase on #92 and #93 to retrigger their CI and they should go green.