### PR TITLE
fix(configurator-strip): pass ~ to File API instead of literal $HOME substitution

### DIFF
--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -32,11 +32,12 @@ const SF_CONF = path.join(
     'js', 'sf_configurator.js',
 );
 
-// Path the script will read at boot — the script expands `~` to `$HOME`
-// literally, so we seed that key. The real Max [js] File object resolves ~
-// against the running user's home; the mock has no such logic, so we seed
-// the literal post-expansion path.
-const PORT_FILE_KEY = '$HOME/stemforge/.configurator_port';
+// Path the script will read at boot. The script now passes `~` through
+// to Max's File API (which expands it against the running user's home
+// on macOS); the broken `$HOME`-substitution that motivated the original
+// seed has been removed. Mock has no expansion logic, so we seed the
+// literal `~`-prefixed key the script will look up.
+const PORT_FILE_KEY = '~/stemforge/.configurator_port';
 
 function loadConf() {
     maxApi.resetState();

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -82,20 +82,12 @@ function _post(msg) {
 // ── Port discovery ───────────────────────────────────────────────────────────
 
 function _expandTilde(p) {
-    if (typeof p !== "string") return p;
-    if (p.length === 0 || p.charAt(0) !== "~") return p;
-    // In Max [js] the `Folder` global doesn't expose $HOME, but `File` resolves
-    // ~ when given the path. We do the substitution defensively in case
-    // the runtime doesn't expand for us. Fall back to $HOME via env if needed.
-    var home = "";
-    try {
-        // Max 8+ exposes process.env via "max" module on Node — not here in
-        // classic [js]. We hardcode the convention from Live: the user
-        // running Live owns ~. Build the absolute path via shell substitution
-        // when the path is finally consumed by curl/shell.
-        home = "$HOME";
-    } catch (_) {}
-    return home + p.substring(1);
+    // Max [js] File API accepts ~ directly on macOS. An earlier "defensive"
+    // substitution to the literal string "$HOME" broke port discovery —
+    // Max's File constructor doesn't expand shell variables, so the
+    // substituted path was meaningless. Pass through as-is; the File
+    // constructor handles ~ resolution.
+    return p;
 }
 
 function discoverPort() {


### PR DESCRIPTION
Strip device's port discovery was substituting literal "$HOME" for `~`, then passing the unexpanded string to Max's File API which doesn't expand shell variables. Status dot stayed red even with a healthy server.

Caught on the first on-device test. Fix: `_expandTilde()` passes the path through unchanged — Max's File API resolves `~` directly on macOS.

Test mock seed updated to match new behavior. 14/14 JS mock cases pass.