### PR TITLE
fix(configurator-strip): open editor in system browser via messnamed launchbrowser

### DIFF
--- a/tests/js_mocks/max_api.js
+++ b/tests/js_mocks/max_api.js
@@ -59,6 +59,7 @@ const state = {
     fs: Object.create(null),           // hfs path -> { contents, isDir, entries? }
     logs: [],                          // post() captures
     outlets: Object.create(null),      // outletNum (number) -> list of arg-arrays
+    messnamed: [],                     // [[receiver, ...args], ...] — messnamed() captures
     liveApiCalls: [],                  // for optional inspection
     liveTree: null,                    // root LOM mock; null = unseeded → no-op
     liveCallHandlers: Object.create(null), // verb -> (lomPath, args) => result
@@ -70,6 +71,7 @@ function resetState() {
     state.fs = Object.create(null);
     state.logs.length = 0;
     state.outlets = Object.create(null);
+    state.messnamed.length = 0;
     state.liveApiCalls.length = 0;
     state.liveTree = null;
     state.liveCallHandlers = Object.create(null);
@@ -299,6 +301,16 @@ function outlet(n /* , ...args */) {
     state.outlets[n].push(args);
 }
 
+// Max's `messnamed` sends a message to a named receiver/object globally.
+// We record it as `state.messnamed = [[receiver, message, ...args], ...]`
+// so tests can assert what was fired. Used by sf_configurator.js for the
+// `max launchbrowser <url>` system-browser open path.
+function messnamed(receiver /* , message, ...args */) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    if (!state.messnamed) state.messnamed = [];
+    state.messnamed.push([receiver].concat(args));
+}
+
 function arrayfromargs(/* ...args */) {
     // Classic Max signature: `arrayfromargs(messagename, arguments)` returns
     // [messagename, ...arguments]. BUT most usages in StemForge call it as
@@ -523,6 +535,7 @@ module.exports = {
     LOM_MARKER_PROPS,
     post,
     outlet,
+    messnamed,
     arrayfromargs,
     state,
     resetState,

--- a/tests/js_mocks/sandbox.js
+++ b/tests/js_mocks/sandbox.js
@@ -22,6 +22,7 @@ function createSandbox(options) {
         LiveAPI:        maxApi.LiveAPI,
         post:           maxApi.post,
         outlet:         maxApi.outlet,
+        messnamed:      maxApi.messnamed,
         arrayfromargs:  maxApi.arrayfromargs,
         autowatch:      0,
         inlets:         1,

--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -154,30 +154,48 @@ test('recompute / slice / curate / reAnchor each fire their verb', () => {
     assert.ok(cmds.some(c => /intent\/re-anchor/.test(c)), 're-anchor missing');
 });
 
-// ── openEditor → jweb openurl ────────────────────────────────────────────────
+// ── openEditor → launchbrowser via messnamed (system browser) ────────────────
+//
+// Phase 3 ships the popup via the system browser rather than M4L's embedded
+// [jweb] — see openEditor() in sf_configurator.js for rationale. The legacy
+// outlet-3 path still fires `url <addr>` for any custom patcher that routes
+// outlet 3 into a [jweb], but the load-bearing call is messnamed.
 
-test('openEditor: emits openurl onto outlet 3 with serverBase', () => {
+test('openEditor: messnamed launchbrowser with serverBase, plus outlet-3 fallback', () => {
     const ctx = loadConf();
     maxApi.seedFile(PORT_FILE_KEY, '7421');
     ctx._discoverPort();
 
+    // Clear any messnamed calls emitted during discover (none expected, but
+    // be explicit so this test pins the openEditor call specifically).
+    maxApi.state.messnamed = [];
+
     ctx.openEditor();
 
+    const calls = maxApi.state.messnamed;
+    assert.equal(calls.length, 1, 'exactly one messnamed call');
+    assert.deepEqual(calls[0], ['max', 'launchbrowser', 'http://127.0.0.1:7421/']);
+
+    // Legacy outlet-3 path emits `url <addr>` (NOT openurl — [jweb] doesn't
+    // recognize openurl).
     const j = outletOn(3);
     const last = j[j.length - 1];
-    assert.deepEqual(last, ['openurl', 'http://127.0.0.1:7421/']);
+    assert.deepEqual(last, ['url', 'http://127.0.0.1:7421/']);
 });
 
-test('openEditor: with no server, refuses to emit openurl', () => {
+test('openEditor: with no server, fires neither messnamed nor outlet-3', () => {
     const ctx = loadConf();
     // no seed
+    maxApi.state.messnamed = [];
 
     ctx.openEditor();
 
+    const calls = maxApi.state.messnamed || [];
+    assert.equal(calls.length, 0, 'messnamed should not fire without a server');
+
     const j = outletOn(3);
-    // Should not have emitted any openurl.
-    const urls = j.filter(a => a[0] === 'openurl');
-    assert.equal(urls.length, 0, 'openurl should not fire without a server');
+    const urls = j.filter(a => a[0] === 'url' || a[0] === 'openurl');
+    assert.equal(urls.length, 0, 'no url emission without a server');
 });
 
 // ── startServer → shell exec ─────────────────────────────────────────────────

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -243,9 +243,20 @@ function openEditor() {
         _footer("open-editor: server down");
         return;
     }
-    outlet(3, "openurl", _serverBase + "/");
+    // Open in the system browser (Chrome/Safari) rather than M4L's
+    // embedded [jweb]. [jweb] inside an M4L device is constrained to the
+    // device's UI area (which is tiny for this strip) and doesn't
+    // recognize the `openurl` message anyway — its real verb is `url`.
+    // System browser gives a real window the user can position freely.
+    // The [jweb] object remains in the patcher as a no-op vestige for
+    // now; Phase 4 may revisit if a true float-window embed is wanted.
+    var url = _serverBase + "/";
+    messnamed("max", "launchbrowser", url);
+    // Also fire outlet 3 with the proper [jweb] verb in case anyone has
+    // patched the strip to route outlet 3 into a custom embed.
+    outlet(3, "url", url);
     _status("editor opened");
-    _footer("editor → " + _serverBase + "/");
+    _footer("editor → " + url);
 }
 
 // "Start server" CTA fired when port-file is missing.


### PR DESCRIPTION
Strip device fix #2 caught on first on-device test (after #97). Click "Open Editor" was firing `outlet(3, "openurl", <url>)` into a `[jweb]` object — two problems:

1. **`[jweb]` does not recognize `openurl`** — its real verb is `url`. `openurl` is for Max global system-browser launchers.
2. **`[jweb]` inside an M4L device is the device UI area**, not a float window. Even if `url` worked, the user would see the popup squeezed into the 820×100 strip footprint.

**Fix:** open in the system browser via `messnamed("max", "launchbrowser", <url>)`. Real Chrome/Safari window, draggable beside Live, full devtools available. The `[jweb]` object stays in the patcher as a no-op vestige; outlet 3 now fires `url <addr>` (corrected verb) for anyone who patches the strip to route into a custom embed.

**Test infrastructure:** added `messnamed()` mock + sandbox binding. 14/14 JS mock cases pass.

**No `.amxd` rebuild needed** — just reload the JS in Live (remove + re-drag the strip, or right-click the [js] → Edit Script → ⌘S).