### PR TITLE
fix(configurator-strip): native file pickers + Chrome app-mode editor window

### DIFF
--- a/tests/js_mocks/max_api.js
+++ b/tests/js_mocks/max_api.js
@@ -59,6 +59,7 @@ const state = {
     fs: Object.create(null),           // hfs path -> { contents, isDir, entries? }
     logs: [],                          // post() captures
     outlets: Object.create(null),      // outletNum (number) -> list of arg-arrays
+    messnamed: [],                     // [[receiver, ...args], ...] — messnamed() captures
     liveApiCalls: [],                  // for optional inspection
     liveTree: null,                    // root LOM mock; null = unseeded → no-op
     liveCallHandlers: Object.create(null), // verb -> (lomPath, args) => result
@@ -70,6 +71,7 @@ function resetState() {
     state.fs = Object.create(null);
     state.logs.length = 0;
     state.outlets = Object.create(null);
+    state.messnamed.length = 0;
     state.liveApiCalls.length = 0;
     state.liveTree = null;
     state.liveCallHandlers = Object.create(null);
@@ -299,6 +301,16 @@ function outlet(n /* , ...args */) {
     state.outlets[n].push(args);
 }
 
+// Max's `messnamed` sends a message to a named receiver/object globally.
+// We record it as `state.messnamed = [[receiver, message, ...args], ...]`
+// so tests can assert what was fired. Used by sf_configurator.js for the
+// `max launchbrowser <url>` system-browser open path.
+function messnamed(receiver /* , message, ...args */) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    if (!state.messnamed) state.messnamed = [];
+    state.messnamed.push([receiver].concat(args));
+}
+
 function arrayfromargs(/* ...args */) {
     // Classic Max signature: `arrayfromargs(messagename, arguments)` returns
     // [messagename, ...arguments]. BUT most usages in StemForge call it as
@@ -523,6 +535,7 @@ module.exports = {
     LOM_MARKER_PROPS,
     post,
     outlet,
+    messnamed,
     arrayfromargs,
     state,
     resetState,

--- a/tests/js_mocks/sandbox.js
+++ b/tests/js_mocks/sandbox.js
@@ -22,6 +22,7 @@ function createSandbox(options) {
         LiveAPI:        maxApi.LiveAPI,
         post:           maxApi.post,
         outlet:         maxApi.outlet,
+        messnamed:      maxApi.messnamed,
         arrayfromargs:  maxApi.arrayfromargs,
         autowatch:      0,
         inlets:         1,

--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -154,49 +154,51 @@ test('recompute / slice / curate / reAnchor each fire their verb', () => {
     assert.ok(cmds.some(c => /intent\/re-anchor/.test(c)), 're-anchor missing');
 });
 
-// ── openEditor → Chrome app-mode via shell exec ──────────────────────────────
+// ── openEditor → launchbrowser via messnamed (default browser, new tab) ─────
 //
-// Phase 3 ships the popup via a Chrome app-mode window: a chromeless dedicated
-// window (no tabs/URL bar/bookmarks) rather than M4L's embedded [jweb] (too
-// small) or messnamed launchbrowser (lands as a tab in an existing Chrome
-// session, which is exactly what Zak hit on the first on-device test).
-// The exec command is `open -na "Google Chrome" --args --new-window --app=<url>`.
+// Tried in Phase 3:
+//   1. outlet(3, "openurl", url) → [jweb]      — [jweb] doesn't recognize
+//                                                "openurl"; verb is "url".
+//      Plus [jweb] in M4L is embedded in the device UI area (too small).
+//   2. shell `open -na "Google Chrome" --args --new-window --app=<url>`
+//      — macOS + Chrome silently drops -n when Chrome is already running,
+//      and --app= from a re-launch attempt is ignored. Tested on-device.
+//   3. AppleScript `tell app "Chrome" to make new window` — AppleEvent
+//      timeout (Chrome's automation permissions). Tested on-device.
+//   4. Direct binary `/Applications/Google Chrome.app/.../Google Chrome
+//      --app=<url> --new-window` — focuses existing instance, no window.
+//
+// Reliable cross-permission path: launchbrowser → tab in default browser.
+// Phase 4 adds an in-popup "Pop out" button that uses window.open() to
+// spawn a proper popup window (works from inside the browser without OS
+// automation grants).
 
-test('openEditor: shell exec launches Chrome in app mode with serverBase', () => {
+test('openEditor: emits messnamed launchbrowser with serverBase', () => {
     const ctx = loadConf();
     maxApi.seedFile(PORT_FILE_KEY, '7421');
     ctx._discoverPort();
 
+    maxApi.state.messnamed = [];
     ctx.openEditor();
 
-    const sh = outletOn(4);
-    const exec = sh.find(a => a[0] === 'exec' &&
-        typeof a[1] === 'string' &&
-        a[1].indexOf('Google Chrome') >= 0);
-    assert.ok(exec, 'expected shell exec with Google Chrome target');
-    assert.ok(exec[1].indexOf('--app=') >= 0, 'expected --app= flag');
-    assert.ok(exec[1].indexOf('--new-window') >= 0, 'expected --new-window flag');
-    assert.ok(exec[1].indexOf('http://127.0.0.1:7421/') >= 0,
-        'expected serverBase URL in command');
+    const calls = maxApi.state.messnamed;
+    assert.equal(calls.length, 1, 'exactly one messnamed call');
+    assert.deepEqual(calls[0], ['max', 'launchbrowser', 'http://127.0.0.1:7421/']);
 
-    // Legacy outlet-3 path emits `url <addr>` (NOT openurl — [jweb] doesn't
-    // recognize openurl).
+    // Legacy outlet-3 path emits `url <addr>` for custom-patched routes.
     const j = outletOn(3);
     const last = j[j.length - 1];
     assert.deepEqual(last, ['url', 'http://127.0.0.1:7421/']);
 });
 
-test('openEditor: with no server, fires neither shell exec nor outlet-3', () => {
+test('openEditor: with no server, fires neither launchbrowser nor outlet-3', () => {
     const ctx = loadConf();
-    // no seed
+    maxApi.state.messnamed = [];
 
     ctx.openEditor();
 
-    const sh = outletOn(4);
-    const browserExecs = sh.filter(a => a[0] === 'exec' &&
-        typeof a[1] === 'string' &&
-        a[1].indexOf('Google Chrome') >= 0);
-    assert.equal(browserExecs.length, 0, 'no browser exec without a server');
+    assert.equal((maxApi.state.messnamed || []).length, 0,
+        'no launchbrowser without a server');
 
     const j = outletOn(3);
     const urls = j.filter(a => a[0] === 'url' || a[0] === 'openurl');

--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -136,6 +136,89 @@ test('exportPpak: POSTs /intent/export with target=ep133', () => {
     assert.match(curl[1], /out\.ppak/);
 });
 
+// ── File-picker plumbing (osascript via [shell] + return-trip) ──────────────
+
+test('loadManifest: with no path → pops osascript file picker on outlet 4', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+
+    ctx.loadManifest();
+
+    const shellEmits = outletOn(4);
+    const osa = shellEmits.find(
+        a => a[0] === 'exec' && /osascript/.test(a[1]) && /choose file/.test(a[1])
+    );
+    assert.ok(osa, 'expected an osascript choose-file emission');
+    assert.match(osa[1], /\.pick-load/, 'osascript writes the chosen path to the load temp file');
+    assert.match(osa[1], /echo PICKEDLOAD/, 'osascript signals completion with PICKEDLOAD');
+});
+
+test('pickedLoad: reads temp file + dispatches loadManifest with the path', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+    // Seed the temp file as if osascript had written a path there.
+    maxApi.seedFile('~/stemforge/.pick-load', '/Users/zak/song/curated/manifest.json');
+
+    ctx.pickedLoad();
+
+    const shellEmits = outletOn(4);
+    const curl = shellEmits.find(
+        a => a[0] === 'exec' && /intent\/load-manifest/.test(a[1])
+    );
+    assert.ok(curl, 'expected load-manifest curl after pickedLoad');
+    assert.match(curl[1], /curated\/manifest\.json/);
+});
+
+test('pickedLoad: empty temp file → no curl emission (cancel path)', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+    maxApi.seedFile('~/stemforge/.pick-load', '');
+
+    ctx.pickedLoad();
+
+    const shellEmits = outletOn(4);
+    const curl = shellEmits.find(
+        a => a[0] === 'exec' && /intent\/load-manifest/.test(a[1])
+    );
+    assert.equal(curl, undefined, 'no curl should fire when cancel produced empty file');
+});
+
+test('exportPpak: with no path → pops osascript save dialog on outlet 4', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+
+    ctx.exportPpak();
+
+    const shellEmits = outletOn(4);
+    const osa = shellEmits.find(
+        a => a[0] === 'exec' && /osascript/.test(a[1]) && /choose file name/.test(a[1])
+    );
+    assert.ok(osa, 'expected an osascript save-dialog emission');
+    assert.match(osa[1], /\.pick-export/);
+    assert.match(osa[1], /echo PICKEDEXPORT/);
+    assert.match(osa[1], /configurator-export\.ppak/, 'default filename suggested');
+});
+
+test('pickedExport: reads temp file + dispatches exportPpak with the path', () => {
+    const ctx = loadConf();
+    maxApi.seedFile(PORT_FILE_KEY, '7421');
+    ctx._discoverPort();
+    maxApi.seedFile('~/stemforge/.pick-export', '/Users/zak/Desktop/my-deck.ppak');
+
+    ctx.pickedExport();
+
+    const shellEmits = outletOn(4);
+    const curl = shellEmits.find(
+        a => a[0] === 'exec' && /intent\/export/.test(a[1])
+    );
+    assert.ok(curl, 'expected export curl after pickedExport');
+    assert.match(curl[1], /my-deck\.ppak/);
+});
+
 test('recompute / slice / curate / reAnchor each fire their verb', () => {
     const ctx = loadConf();
     maxApi.seedFile(PORT_FILE_KEY, '7421');

--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -154,30 +154,48 @@ test('recompute / slice / curate / reAnchor each fire their verb', () => {
     assert.ok(cmds.some(c => /intent\/re-anchor/.test(c)), 're-anchor missing');
 });
 
-// ── openEditor → jweb openurl ────────────────────────────────────────────────
+// ── openEditor → launchbrowser via messnamed (system browser) ────────────────
+//
+// Phase 3 ships the popup via the system browser rather than M4L's embedded
+// [jweb] — see openEditor() in sf_configurator.js for rationale. The legacy
+// outlet-3 path still fires `url <addr>` for any custom patcher that routes
+// outlet 3 into a [jweb], but the load-bearing call is messnamed.
 
-test('openEditor: emits openurl onto outlet 3 with serverBase', () => {
+test('openEditor: messnamed launchbrowser with serverBase, plus outlet-3 fallback', () => {
     const ctx = loadConf();
     maxApi.seedFile(PORT_FILE_KEY, '7421');
     ctx._discoverPort();
 
+    // Clear any messnamed calls emitted during discover (none expected, but
+    // be explicit so this test pins the openEditor call specifically).
+    maxApi.state.messnamed = [];
+
     ctx.openEditor();
 
+    const calls = maxApi.state.messnamed;
+    assert.equal(calls.length, 1, 'exactly one messnamed call');
+    assert.deepEqual(calls[0], ['max', 'launchbrowser', 'http://127.0.0.1:7421/']);
+
+    // Legacy outlet-3 path emits `url <addr>` (NOT openurl — [jweb] doesn't
+    // recognize openurl).
     const j = outletOn(3);
     const last = j[j.length - 1];
-    assert.deepEqual(last, ['openurl', 'http://127.0.0.1:7421/']);
+    assert.deepEqual(last, ['url', 'http://127.0.0.1:7421/']);
 });
 
-test('openEditor: with no server, refuses to emit openurl', () => {
+test('openEditor: with no server, fires neither messnamed nor outlet-3', () => {
     const ctx = loadConf();
     // no seed
+    maxApi.state.messnamed = [];
 
     ctx.openEditor();
 
+    const calls = maxApi.state.messnamed || [];
+    assert.equal(calls.length, 0, 'messnamed should not fire without a server');
+
     const j = outletOn(3);
-    // Should not have emitted any openurl.
-    const urls = j.filter(a => a[0] === 'openurl');
-    assert.equal(urls.length, 0, 'openurl should not fire without a server');
+    const urls = j.filter(a => a[0] === 'url' || a[0] === 'openurl');
+    assert.equal(urls.length, 0, 'no url emission without a server');
 });
 
 // ── startServer → shell exec ─────────────────────────────────────────────────

--- a/tests/js_mocks/test_sf_configurator.test.js
+++ b/tests/js_mocks/test_sf_configurator.test.js
@@ -154,27 +154,30 @@ test('recompute / slice / curate / reAnchor each fire their verb', () => {
     assert.ok(cmds.some(c => /intent\/re-anchor/.test(c)), 're-anchor missing');
 });
 
-// ── openEditor → launchbrowser via messnamed (system browser) ────────────────
+// ── openEditor → Chrome app-mode via shell exec ──────────────────────────────
 //
-// Phase 3 ships the popup via the system browser rather than M4L's embedded
-// [jweb] — see openEditor() in sf_configurator.js for rationale. The legacy
-// outlet-3 path still fires `url <addr>` for any custom patcher that routes
-// outlet 3 into a [jweb], but the load-bearing call is messnamed.
+// Phase 3 ships the popup via a Chrome app-mode window: a chromeless dedicated
+// window (no tabs/URL bar/bookmarks) rather than M4L's embedded [jweb] (too
+// small) or messnamed launchbrowser (lands as a tab in an existing Chrome
+// session, which is exactly what Zak hit on the first on-device test).
+// The exec command is `open -na "Google Chrome" --args --new-window --app=<url>`.
 
-test('openEditor: messnamed launchbrowser with serverBase, plus outlet-3 fallback', () => {
+test('openEditor: shell exec launches Chrome in app mode with serverBase', () => {
     const ctx = loadConf();
     maxApi.seedFile(PORT_FILE_KEY, '7421');
     ctx._discoverPort();
 
-    // Clear any messnamed calls emitted during discover (none expected, but
-    // be explicit so this test pins the openEditor call specifically).
-    maxApi.state.messnamed = [];
-
     ctx.openEditor();
 
-    const calls = maxApi.state.messnamed;
-    assert.equal(calls.length, 1, 'exactly one messnamed call');
-    assert.deepEqual(calls[0], ['max', 'launchbrowser', 'http://127.0.0.1:7421/']);
+    const sh = outletOn(4);
+    const exec = sh.find(a => a[0] === 'exec' &&
+        typeof a[1] === 'string' &&
+        a[1].indexOf('Google Chrome') >= 0);
+    assert.ok(exec, 'expected shell exec with Google Chrome target');
+    assert.ok(exec[1].indexOf('--app=') >= 0, 'expected --app= flag');
+    assert.ok(exec[1].indexOf('--new-window') >= 0, 'expected --new-window flag');
+    assert.ok(exec[1].indexOf('http://127.0.0.1:7421/') >= 0,
+        'expected serverBase URL in command');
 
     // Legacy outlet-3 path emits `url <addr>` (NOT openurl — [jweb] doesn't
     // recognize openurl).
@@ -183,15 +186,17 @@ test('openEditor: messnamed launchbrowser with serverBase, plus outlet-3 fallbac
     assert.deepEqual(last, ['url', 'http://127.0.0.1:7421/']);
 });
 
-test('openEditor: with no server, fires neither messnamed nor outlet-3', () => {
+test('openEditor: with no server, fires neither shell exec nor outlet-3', () => {
     const ctx = loadConf();
     // no seed
-    maxApi.state.messnamed = [];
 
     ctx.openEditor();
 
-    const calls = maxApi.state.messnamed || [];
-    assert.equal(calls.length, 0, 'messnamed should not fire without a server');
+    const sh = outletOn(4);
+    const browserExecs = sh.filter(a => a[0] === 'exec' &&
+        typeof a[1] === 'string' &&
+        a[1].indexOf('Google Chrome') >= 0);
+    assert.equal(browserExecs.length, 0, 'no browser exec without a server');
 
     const j = outletOn(3);
     const urls = j.filter(a => a[0] === 'url' || a[0] === 'openurl');

--- a/v0/src/m4l-devices/configurator-strip/README.md
+++ b/v0/src/m4l-devices/configurator-strip/README.md
@@ -134,6 +134,43 @@ Trade-offs:
   hidden in `[shell]` stdout). Phase 3.1 may parse `curl --write-out` and
   surface non-200s on the footer line.
 
+## First-run gotchas (on-device)
+
+### macOS "Allow Chrome to open" permission
+
+The first time you click **OPEN EDITOR**, macOS may pop a dialog asking
+permission for Max/Live to control "Google Chrome" (or whatever your
+default browser is). It's a small system-style alert that's easy to
+miss behind Live's window — caught Zak on the first smoke test.
+
+**If OPEN EDITOR seems to do nothing**:
+
+1. Bring focus away from Live (Cmd-Tab to Finder).
+2. Look for a `"Live" would like to control "Google Chrome"` dialog.
+3. Click **Allow**.
+4. Re-click OPEN EDITOR. The popup should now open.
+
+You'll only need to grant this once per app.
+
+### Status dot stays yellow (cosmetic)
+
+The connection indicator dot stays amber/yellow even after the strip
+shows `connected` status text. The functional state (`_serverBase` set,
+intents fire correctly) is fine — only the visual dot is stuck on the
+warning color. Known M4L `live.text` `bgcolor`-message quirk; a Phase
+4 follow-up will switch to `presentation_color` or a different widget.
+
+### "Open Editor" opens in a tab, not a new window
+
+This is intentional for Phase 3. macOS + Chrome resists every attempt
+to spawn a new chromeless window from outside the browser (open -na,
+AppleScript, direct binary launch — all fail when Chrome is running).
+**Workaround**: drag the tab out into its own window once.
+
+Phase 4 will add an in-popup "Pop out" button that uses `window.open()`
+from inside the browser — the only cross-permission path that
+reliably spawns a popup window without OS automation grants.
+
 ## [jweb] embedding choice
 
 Phase 3 uses a **float-window** `[jweb]` (separate window, openurl-driven),

--- a/v0/src/m4l-devices/configurator-strip/builder.py
+++ b/v0/src/m4l-devices/configurator-strip/builder.py
@@ -244,86 +244,23 @@ def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
         )
         lines.append(_line(_btn_box_id(btn_id), 0, _btn_tb_id(btn_id), 0))
 
-        # File-picker insertion for verbs that need a path argument.
-        #
-        #   load-manifest → [opendialog] → [prepend loadManifest] → js
-        #   export        → [savedialog] → [prepend exportPpak]   → js
-        #
-        # Other verbs go directly via a [message <handler>] that calls the
-        # JS function with no args.
-        if verb == "load-manifest":
-            dlg_id = f"{_btn_msg_id(btn_id)}-opendialog"
-            prep_id = f"{_btn_msg_id(btn_id)}-prep"
-            boxes.append(
-                _box(
-                    dlg_id,
-                    "newobj",
-                    (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
-                    numinlets=1,
-                    numoutlets=1,
-                    outlettype=[""],
-                    # No filter — accept any file the user picks (manifests
-                    # are .json today but we don't constrain).
-                    extras={"text": "opendialog"},
-                )
+        # Standard path: bang → [message <handler>] → JS. For verbs that
+        # need a path argument (load-manifest, export), the JS function
+        # is called with no args and pops an osascript file dialog via
+        # [shell]; the chosen path is routed back to JS through the shell
+        # output → [route PICKEDLOAD/PICKEDEXPORT] chain wired below.
+        boxes.append(
+            _box(
+                _btn_msg_id(btn_id),
+                "message",
+                (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
+                numinlets=2,
+                numoutlets=1,
+                outlettype=[""],
+                extras={"text": handler},
             )
-            boxes.append(
-                _box(
-                    prep_id,
-                    "newobj",
-                    (x_cursor, btn_y + btn_h + 56.0, 120.0, 22.0),
-                    numinlets=1,
-                    numoutlets=1,
-                    outlettype=[""],
-                    extras={"text": "prepend loadManifest"},
-                )
-            )
-            lines.append(_line(_btn_tb_id(btn_id), 0, dlg_id, 0))
-            lines.append(_line(dlg_id, 0, prep_id, 0))
-            lines.append(_line(prep_id, 0, OBJ_JS, 0))
-        elif verb == "export":
-            dlg_id = f"{_btn_msg_id(btn_id)}-savedialog"
-            prep_id = f"{_btn_msg_id(btn_id)}-prep"
-            boxes.append(
-                _box(
-                    dlg_id,
-                    "newobj",
-                    (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
-                    numinlets=1,
-                    numoutlets=1,
-                    outlettype=[""],
-                    # Default filename suggestion for the save dialog.
-                    extras={"text": "savedialog configurator-export.ppak"},
-                )
-            )
-            boxes.append(
-                _box(
-                    prep_id,
-                    "newobj",
-                    (x_cursor, btn_y + btn_h + 56.0, 120.0, 22.0),
-                    numinlets=1,
-                    numoutlets=1,
-                    outlettype=[""],
-                    extras={"text": "prepend exportPpak"},
-                )
-            )
-            lines.append(_line(_btn_tb_id(btn_id), 0, dlg_id, 0))
-            lines.append(_line(dlg_id, 0, prep_id, 0))
-            lines.append(_line(prep_id, 0, OBJ_JS, 0))
-        else:
-            # Standard path: bang → [message <handler>] → JS.
-            boxes.append(
-                _box(
-                    _btn_msg_id(btn_id),
-                    "message",
-                    (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
-                    numinlets=2,
-                    numoutlets=1,
-                    outlettype=[""],
-                    extras={"text": handler},
-                )
-            )
-            lines.append(_line(_btn_tb_id(btn_id), 0, _btn_msg_id(btn_id), 0))
+        )
+        lines.append(_line(_btn_tb_id(btn_id), 0, _btn_msg_id(btn_id), 0))
 
         x_cursor += btn_w + btn_gap
 
@@ -466,14 +403,8 @@ def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
         )
     )
 
-    # Wire each standard button's message → JS inlet 0.
-    # Dialog-bearing verbs (load-manifest, export) wire directly inside the
-    # per-button loop above via [opendialog]/[savedialog] → [prepend H] → JS;
-    # those do not have a [message H] object to connect here.
-    DIALOG_VERBS = {"load-manifest", "export"}
+    # Wire every button's message → JS inlet 0.
     for btn in btn_items:
-        if btn["verb"] in DIALOG_VERBS:
-            continue
         lines.append(_line(_btn_msg_id(btn["id"]), 0, OBJ_JS, 0))
 
     # ── Loadbang → JS (boot-time port discovery) ────────────────────────────
@@ -554,7 +485,7 @@ def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
     )
     lines.append(_line(OBJ_JS, 3, OBJ_JWEB, 0))
 
-    # ── [shell] — curl + start-server commands ──────────────────────────────
+    # ── [shell] — curl + start-server + osascript file pickers ─────────────
     boxes.append(
         _box(
             OBJ_SHELL,
@@ -567,6 +498,64 @@ def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
         )
     )
     lines.append(_line(OBJ_JS, 4, OBJ_SHELL, 0))
+
+    # ── Shell output → JS for picker results ────────────────────────────────
+    #
+    # The osascript-based file pickers (loadManifest / exportPpak with no
+    # args) emit a single token to stdout when the user picks a file:
+    # `PICKEDLOAD` (manifest open) or `PICKEDEXPORT` (deck save). The
+    # actual chosen path is written by osascript to a known temp file
+    # (~/stemforge/.pick-load or .pick-export) which JS reads via the
+    # `File` API on the callback.
+    #
+    # This 2-channel design (signal via shell-stdout, payload via file)
+    # avoids two real M4L issues:
+    #   1. [opendialog] doesn't fire reliably in M4L's sandbox
+    #      (confirmed on Zak's Live 2026-05-12).
+    #   2. Paths with spaces split into multiple atoms when routed
+    #      through Max [shell] stdout. Writing to file sidesteps that.
+    obj_route = "obj-sf-configurator-shell-route"
+    obj_prep_picked_load = "obj-sf-configurator-prep-picked-load"
+    obj_prep_picked_export = "obj-sf-configurator-prep-picked-export"
+    boxes.append(
+        _box(
+            obj_route,
+            "newobj",
+            (320.0, 200.0, 220.0, 22.0),
+            numinlets=1,
+            # PICKEDLOAD, PICKEDEXPORT, otherwise (3 outlets total).
+            numoutlets=3,
+            outlettype=["", "", ""],
+            extras={"text": "route PICKEDLOAD PICKEDEXPORT"},
+        )
+    )
+    boxes.append(
+        _box(
+            obj_prep_picked_load,
+            "newobj",
+            (320.0, 226.0, 120.0, 22.0),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": "prepend pickedLoad"},
+        )
+    )
+    boxes.append(
+        _box(
+            obj_prep_picked_export,
+            "newobj",
+            (450.0, 226.0, 120.0, 22.0),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": "prepend pickedExport"},
+        )
+    )
+    lines.append(_line(OBJ_SHELL, 0, obj_route, 0))
+    lines.append(_line(obj_route, 0, obj_prep_picked_load, 0))
+    lines.append(_line(obj_route, 1, obj_prep_picked_export, 0))
+    lines.append(_line(obj_prep_picked_load, 0, OBJ_JS, 0))
+    lines.append(_line(obj_prep_picked_export, 0, OBJ_JS, 0))
 
     # ── Final patcher dict ──────────────────────────────────────────────────
     device_width = float(ui["size"]["width"])

--- a/v0/src/m4l-devices/configurator-strip/builder.py
+++ b/v0/src/m4l-devices/configurator-strip/builder.py
@@ -242,23 +242,88 @@ def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
                 extras={"text": "t b"},
             )
         )
-
-        # Message box that names the JS handler — bang fires it, then the
-        # [js] runs the corresponding function.
-        boxes.append(
-            _box(
-                _btn_msg_id(btn_id),
-                "message",
-                (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
-                numinlets=2,
-                numoutlets=1,
-                outlettype=[""],
-                extras={"text": handler},
-            )
-        )
-
         lines.append(_line(_btn_box_id(btn_id), 0, _btn_tb_id(btn_id), 0))
-        lines.append(_line(_btn_tb_id(btn_id), 0, _btn_msg_id(btn_id), 0))
+
+        # File-picker insertion for verbs that need a path argument.
+        #
+        #   load-manifest → [opendialog] → [prepend loadManifest] → js
+        #   export        → [savedialog] → [prepend exportPpak]   → js
+        #
+        # Other verbs go directly via a [message <handler>] that calls the
+        # JS function with no args.
+        if verb == "load-manifest":
+            dlg_id = f"{_btn_msg_id(btn_id)}-opendialog"
+            prep_id = f"{_btn_msg_id(btn_id)}-prep"
+            boxes.append(
+                _box(
+                    dlg_id,
+                    "newobj",
+                    (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
+                    numinlets=1,
+                    numoutlets=1,
+                    outlettype=[""],
+                    # No filter — accept any file the user picks (manifests
+                    # are .json today but we don't constrain).
+                    extras={"text": "opendialog"},
+                )
+            )
+            boxes.append(
+                _box(
+                    prep_id,
+                    "newobj",
+                    (x_cursor, btn_y + btn_h + 56.0, 120.0, 22.0),
+                    numinlets=1,
+                    numoutlets=1,
+                    outlettype=[""],
+                    extras={"text": "prepend loadManifest"},
+                )
+            )
+            lines.append(_line(_btn_tb_id(btn_id), 0, dlg_id, 0))
+            lines.append(_line(dlg_id, 0, prep_id, 0))
+            lines.append(_line(prep_id, 0, OBJ_JS, 0))
+        elif verb == "export":
+            dlg_id = f"{_btn_msg_id(btn_id)}-savedialog"
+            prep_id = f"{_btn_msg_id(btn_id)}-prep"
+            boxes.append(
+                _box(
+                    dlg_id,
+                    "newobj",
+                    (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
+                    numinlets=1,
+                    numoutlets=1,
+                    outlettype=[""],
+                    # Default filename suggestion for the save dialog.
+                    extras={"text": "savedialog configurator-export.ppak"},
+                )
+            )
+            boxes.append(
+                _box(
+                    prep_id,
+                    "newobj",
+                    (x_cursor, btn_y + btn_h + 56.0, 120.0, 22.0),
+                    numinlets=1,
+                    numoutlets=1,
+                    outlettype=[""],
+                    extras={"text": "prepend exportPpak"},
+                )
+            )
+            lines.append(_line(_btn_tb_id(btn_id), 0, dlg_id, 0))
+            lines.append(_line(dlg_id, 0, prep_id, 0))
+            lines.append(_line(prep_id, 0, OBJ_JS, 0))
+        else:
+            # Standard path: bang → [message <handler>] → JS.
+            boxes.append(
+                _box(
+                    _btn_msg_id(btn_id),
+                    "message",
+                    (x_cursor, btn_y + btn_h + 30.0, 96.0, 22.0),
+                    numinlets=2,
+                    numoutlets=1,
+                    outlettype=[""],
+                    extras={"text": handler},
+                )
+            )
+            lines.append(_line(_btn_tb_id(btn_id), 0, _btn_msg_id(btn_id), 0))
 
         x_cursor += btn_w + btn_gap
 
@@ -401,8 +466,14 @@ def build_patcher(device_yaml_path: str | Path) -> dict[str, Any]:
         )
     )
 
-    # Wire each button's message → JS inlet 0.
+    # Wire each standard button's message → JS inlet 0.
+    # Dialog-bearing verbs (load-manifest, export) wire directly inside the
+    # per-button loop above via [opendialog]/[savedialog] → [prepend H] → JS;
+    # those do not have a [message H] object to connect here.
+    DIALOG_VERBS = {"load-manifest", "export"}
     for btn in btn_items:
+        if btn["verb"] in DIALOG_VERBS:
+            continue
         lines.append(_line(_btn_msg_id(btn["id"]), 0, OBJ_JS, 0))
 
     # ── Loadbang → JS (boot-time port discovery) ────────────────────────────

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -243,15 +243,17 @@ function openEditor() {
         _footer("open-editor: server down");
         return;
     }
-    // Open in the system browser (Chrome/Safari) rather than M4L's
-    // embedded [jweb]. [jweb] inside an M4L device is constrained to the
-    // device's UI area (which is tiny for this strip) and doesn't
-    // recognize the `openurl` message anyway — its real verb is `url`.
-    // System browser gives a real window the user can position freely.
-    // The [jweb] object remains in the patcher as a no-op vestige for
-    // now; Phase 4 may revisit if a true float-window embed is wanted.
     var url = _serverBase + "/";
-    messnamed("max", "launchbrowser", url);
+    // Open Chrome in app-mode: a chromeless dedicated window with no
+    // tabs/URL bar/bookmarks. Looks native, lives separately from the
+    // user's existing Chrome session. `messnamed("max", "launchbrowser")`
+    // would just spawn a tab in an existing Chrome window — not what
+    // we want for the popup. Fallback to launchbrowser if Chrome isn't
+    // installed is documented in the issue file; for the user's machine
+    // Chrome is the working browser.
+    var cmd = 'open -na "Google Chrome" --args --new-window --app=' +
+              _shellQuote(url);
+    outlet(4, "exec", cmd);
     // Also fire outlet 3 with the proper [jweb] verb in case anyone has
     // patched the strip to route outlet 3 into a custom embed.
     outlet(3, "url", url);

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -244,21 +244,22 @@ function openEditor() {
         return;
     }
     var url = _serverBase + "/";
-    // Open Chrome in app-mode: a chromeless dedicated window with no
-    // tabs/URL bar/bookmarks. Looks native, lives separately from the
-    // user's existing Chrome session. `messnamed("max", "launchbrowser")`
-    // would just spawn a tab in an existing Chrome window — not what
-    // we want for the popup. Fallback to launchbrowser if Chrome isn't
-    // installed is documented in the issue file; for the user's machine
-    // Chrome is the working browser.
-    var cmd = 'open -na "Google Chrome" --args --new-window --app=' +
-              _shellQuote(url);
-    outlet(4, "exec", cmd);
+    // Open in the default browser. macOS + Chrome combination resists
+    // every attempt to spawn a NEW chromeless window from outside the
+    // browser when Chrome is already running — `open -na --args
+    // --new-window --app=` is silently dropped, AppleScript times out
+    // on AppleEvent permission, direct-binary launch focuses the
+    // existing instance. The reliable path is launchbrowser → tab in
+    // existing Chrome, plus a Phase-4 "Pop out" button INSIDE the
+    // popup that uses window.open() to spawn a proper popup window
+    // (the only cross-permission path that works without OS-level
+    // automation grants).
+    messnamed("max", "launchbrowser", url);
     // Also fire outlet 3 with the proper [jweb] verb in case anyone has
     // patched the strip to route outlet 3 into a custom embed.
     outlet(3, "url", url);
     _status("editor opened");
-    _footer("editor → " + url);
+    _footer("editor → " + url + " — drag the tab out for a dedicated window");
 }
 
 // "Start server" CTA fired when port-file is missing.

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -193,12 +193,70 @@ function ping() {
     discoverPort();
 }
 
-// btn_load — POST /intent/load-manifest
-function loadManifest(path) {
-    var body = path ? { manifest_path: String(path) } : {};
-    if (_postIntent("load-manifest", body)) {
-        _status("load-manifest sent");
+// ── File-picker plumbing ─────────────────────────────────────────────────────
+//
+// [opendialog] / [savedialog] don't fire reliably in M4L's sandbox
+// (confirmed on Zak's Live 2026-05-12). Instead we use osascript via the
+// existing [shell] object:
+//
+//   1. JS fires `osascript -e '...' > ~/stemforge/.pick-X && echo PICKEDX`
+//      out outlet 4 → [shell].
+//   2. On user pick, osascript writes the chosen path to ~/stemforge/.pick-X
+//      AND prints `PICKEDX` to stdout. On cancel, neither happens
+//      (osascript exits non-zero so the && short-circuits).
+//   3. [shell]'s stdout routes through [route PICKEDLOAD PICKEDEXPORT] →
+//      [prepend pickedLoad/pickedExport] → JS inlet 0.
+//   4. The pickedLoad/pickedExport handlers below read the chosen path
+//      from the temp file and dispatch to the real intent.
+//
+// This 2-channel design (signal via stdout, payload via file) sidesteps
+// the Max-[shell]-splits-paths-with-spaces problem.
+
+var PICK_LOAD_FILE = "~/stemforge/.pick-load";
+var PICK_EXPORT_FILE = "~/stemforge/.pick-export";
+
+function _readPickFile(p) {
+    try {
+        var f = new File(_expandTilde(p), "read");
+        if (!f.isopen) return null;
+        f.position = 0;
+        var raw = f.readstring(4096);
+        f.close();
+        if (raw == null) return null;
+        var s = String(raw).replace(/[\r\n]+$/, "");
+        return s.length ? s : null;
+    } catch (_) {
+        return null;
     }
+}
+
+// btn_load — POST /intent/load-manifest.
+// With no path → pop native file picker via osascript.
+function loadManifest(path) {
+    if (path != null && String(path).length > 0) {
+        if (_postIntent("load-manifest", { manifest_path: String(path) })) {
+            _status("load-manifest sent");
+        }
+        return;
+    }
+    // Pop file picker. The result lands in the file at PICK_LOAD_FILE
+    // and PICKEDLOAD lands on stdout — see the [route] block in the
+    // patcher.
+    var inner = 'POSIX path of (choose file with prompt "Select manifest" of type {"public.json", "json"})';
+    var cmd = "mkdir -p ~/stemforge && osascript -e " + _shellQuote(inner) +
+              " > " + PICK_LOAD_FILE + " 2>/dev/null && echo PICKEDLOAD";
+    outlet(4, "exec", cmd);
+    _footer("waiting for file pick…");
+}
+
+// Patcher routes shell stdout PICKEDLOAD → pickedLoad here.
+function pickedLoad() {
+    var path = _readPickFile(PICK_LOAD_FILE);
+    if (!path) {
+        _footer("load-manifest: pick canceled or empty");
+        return;
+    }
+    loadManifest(path);
 }
 
 // btn_slice — POST /intent/slice
@@ -223,11 +281,30 @@ function curate() {
     if (_postIntent("curate", {})) _status("curate sent");
 }
 
-// btn_export — POST /intent/export
+// btn_export — POST /intent/export.
+// With no out_path → pop native save dialog via osascript.
 function exportPpak(outPath) {
-    var body = { target: "ep133" };
-    if (outPath != null) body.out_path = String(outPath);
-    if (_postIntent("export", body)) _status("export sent");
+    if (outPath != null && String(outPath).length > 0) {
+        var body = { target: "ep133", out_path: String(outPath) };
+        if (_postIntent("export", body)) _status("export sent");
+        return;
+    }
+    // Pop save dialog with a sensible default filename.
+    var inner = 'POSIX path of (choose file name with prompt "Save deck as" default name "configurator-export.ppak")';
+    var cmd = "mkdir -p ~/stemforge && osascript -e " + _shellQuote(inner) +
+              " > " + PICK_EXPORT_FILE + " 2>/dev/null && echo PICKEDEXPORT";
+    outlet(4, "exec", cmd);
+    _footer("waiting for save path…");
+}
+
+// Patcher routes shell stdout PICKEDEXPORT → pickedExport here.
+function pickedExport() {
+    var path = _readPickFile(PICK_EXPORT_FILE);
+    if (!path) {
+        _footer("export: save canceled or empty");
+        return;
+    }
+    exportPpak(path);
 }
 function exportTarget(target, outPath) {
     var body = { target: String(target || "ep133") };

--- a/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
+++ b/v0/src/m4l-devices/configurator-strip/js/sf_configurator.js
@@ -243,9 +243,20 @@ function openEditor() {
         _footer("open-editor: server down");
         return;
     }
-    outlet(3, "openurl", _serverBase + "/");
+    // Open in the system browser (Chrome/Safari) rather than M4L's
+    // embedded [jweb]. [jweb] inside an M4L device is constrained to the
+    // device's UI area (which is tiny for this strip) and doesn't
+    // recognize the `openurl` message anyway — its real verb is `url`.
+    // System browser gives a real window the user can position freely.
+    // The [jweb] object remains in the patcher as a no-op vestige for
+    // now; Phase 4 may revisit if a true float-window embed is wanted.
+    var url = _serverBase + "/";
+    messnamed("max", "launchbrowser", url);
+    // Also fire outlet 3 with the proper [jweb] verb in case anyone has
+    // patched the strip to route outlet 3 into a custom embed.
+    outlet(3, "url", url);
     _status("editor opened");
-    _footer("editor → " + _serverBase + "/");
+    _footer("editor → " + url);
 }
 
 // "Start server" CTA fired when port-file is missing.

--- a/v0/src/m4l-devices/configurator-strip/tests/test_strip_builder.py
+++ b/v0/src/m4l-devices/configurator-strip/tests/test_strip_builder.py
@@ -131,27 +131,75 @@ def test_every_button_is_live_text_with_label_and_accent(spec, box_by_id):
         assert b["parameter_enable"] == 0
 
 
+DIALOG_VERBS = {"load-manifest", "export"}
+
+
 def test_every_button_has_tb_and_message_handler(spec, box_by_id, line_pairs):
     """Pitfall #17 — buttons need [t b] to convert label-symbol into a bang
-    before firing the JS handler-name message."""
+    before firing the JS handler.
+
+    Dialog-bearing verbs (load-manifest, export) route the bang through a
+    file picker first; see `test_dialog_bearing_buttons_have_file_picker`.
+    """
     for btn in spec["ui"]["buttons"]["items"]:
         verb = btn["verb"]
         handler = VERB_TO_HANDLER[verb]
 
         btn_box = _btn_box_id(btn["id"])
         tb_box = _btn_tb_id(btn["id"])
-        msg_box = _btn_msg_id(btn["id"])
 
         assert tb_box in box_by_id
         assert box_by_id[tb_box]["text"] == "t b"
+        # button → t b is shared by all verbs.
+        assert (btn_box, tb_box) in line_pairs
 
+        if verb in DIALOG_VERBS:
+            # Picker variants have no [message handler] box; their wiring is
+            # asserted in test_dialog_bearing_buttons_have_file_picker.
+            continue
+
+        msg_box = _btn_msg_id(btn["id"])
         assert msg_box in box_by_id
         assert box_by_id[msg_box]["text"] == handler
-
-        # Wiring: button → t b → message → JS.
-        assert (btn_box, tb_box) in line_pairs
+        # t b → message → JS for the standard path.
         assert (tb_box, msg_box) in line_pairs
         assert (msg_box, OBJ_JS) in line_pairs
+
+
+def test_dialog_bearing_buttons_have_file_picker(spec, box_by_id, line_pairs):
+    """Load Manifest and Export pop native file dialogs ([opendialog] /
+    [savedialog]) and pipe the chosen path into the JS via [prepend H].
+    Without the picker the user has to type an absolute path by hand.
+    """
+    items = {b["verb"]: b for b in spec["ui"]["buttons"]["items"]}
+
+    # ── load-manifest → [opendialog] → [prepend loadManifest] → JS ──────────
+    if "load-manifest" in items:
+        btn = items["load-manifest"]
+        tb_box = _btn_tb_id(btn["id"])
+        dlg_id = f"{_btn_msg_id(btn['id'])}-opendialog"
+        prep_id = f"{_btn_msg_id(btn['id'])}-prep"
+        assert dlg_id in box_by_id, "load-manifest missing [opendialog]"
+        assert box_by_id[dlg_id]["text"] == "opendialog"
+        assert prep_id in box_by_id, "load-manifest missing [prepend loadManifest]"
+        assert box_by_id[prep_id]["text"] == "prepend loadManifest"
+        assert (tb_box, dlg_id) in line_pairs
+        assert (dlg_id, prep_id) in line_pairs
+        assert (prep_id, OBJ_JS) in line_pairs
+
+    # ── export → [savedialog] → [prepend exportPpak] → JS ───────────────────
+    if "export" in items:
+        btn = items["export"]
+        tb_box = _btn_tb_id(btn["id"])
+        dlg_id = f"{_btn_msg_id(btn['id'])}-savedialog"
+        prep_id = f"{_btn_msg_id(btn['id'])}-prep"
+        assert dlg_id in box_by_id, "export missing [savedialog]"
+        assert box_by_id[dlg_id]["text"].startswith("savedialog")
+        assert prep_id in box_by_id, "export missing [prepend exportPpak]"
+        assert box_by_id[prep_id]["text"] == "prepend exportPpak"
+        assert (tb_box, dlg_id) in line_pairs
+        assert (dlg_id, prep_id) in line_pairs
+        assert (prep_id, OBJ_JS) in line_pairs
 
 
 # ── JS dispatcher object ────────────────────────────────────────────────────

--- a/v0/src/m4l-devices/configurator-strip/tests/test_strip_builder.py
+++ b/v0/src/m4l-devices/configurator-strip/tests/test_strip_builder.py
@@ -131,15 +131,15 @@ def test_every_button_is_live_text_with_label_and_accent(spec, box_by_id):
         assert b["parameter_enable"] == 0
 
 
-DIALOG_VERBS = {"load-manifest", "export"}
-
-
 def test_every_button_has_tb_and_message_handler(spec, box_by_id, line_pairs):
-    """Pitfall #17 — buttons need [t b] to convert label-symbol into a bang
-    before firing the JS handler.
+    """Pitfall #17 — every button needs [t b] to convert label-symbol into a
+    bang before firing the JS handler.
 
-    Dialog-bearing verbs (load-manifest, export) route the bang through a
-    file picker first; see `test_dialog_bearing_buttons_have_file_picker`.
+    All seven buttons now follow the same shape: button → [t b] → [message
+    handler] → [js]. Verbs that need a path argument (load-manifest, export)
+    call their JS handler with no args; the handler pops an osascript file
+    picker via [shell] and the chosen path routes back through the
+    shell-output chain — see test_picker_routing_from_shell_output.
     """
     for btn in spec["ui"]["buttons"]["items"]:
         verb = btn["verb"]
@@ -147,59 +147,66 @@ def test_every_button_has_tb_and_message_handler(spec, box_by_id, line_pairs):
 
         btn_box = _btn_box_id(btn["id"])
         tb_box = _btn_tb_id(btn["id"])
+        msg_box = _btn_msg_id(btn["id"])
 
         assert tb_box in box_by_id
         assert box_by_id[tb_box]["text"] == "t b"
-        # button → t b is shared by all verbs.
-        assert (btn_box, tb_box) in line_pairs
-
-        if verb in DIALOG_VERBS:
-            # Picker variants have no [message handler] box; their wiring is
-            # asserted in test_dialog_bearing_buttons_have_file_picker.
-            continue
-
-        msg_box = _btn_msg_id(btn["id"])
         assert msg_box in box_by_id
         assert box_by_id[msg_box]["text"] == handler
-        # t b → message → JS for the standard path.
+
+        assert (btn_box, tb_box) in line_pairs
         assert (tb_box, msg_box) in line_pairs
         assert (msg_box, OBJ_JS) in line_pairs
 
 
-def test_dialog_bearing_buttons_have_file_picker(spec, box_by_id, line_pairs):
-    """Load Manifest and Export pop native file dialogs ([opendialog] /
-    [savedialog]) and pipe the chosen path into the JS via [prepend H].
-    Without the picker the user has to type an absolute path by hand.
+def test_picker_routing_from_shell_output(spec, box_by_id, line_pairs):
+    """Shell stdout → [route PICKEDLOAD PICKEDEXPORT] → [prepend pickedX] → JS.
+
+    The osascript file pickers fired by loadManifest()/exportPpak() with no
+    args emit a single token (`PICKEDLOAD` or `PICKEDEXPORT`) when the user
+    completes the dialog. That token is what we route here back into JS so
+    the corresponding `pickedLoad()`/`pickedExport()` handler can read the
+    chosen path from the temp file and dispatch.
     """
-    items = {b["verb"]: b for b in spec["ui"]["buttons"]["items"]}
+    # [route PICKEDLOAD PICKEDEXPORT] present.
+    route_box = next(
+        (
+            box_by_id[bid]
+            for bid in box_by_id
+            if box_by_id[bid].get("text", "") == "route PICKEDLOAD PICKEDEXPORT"
+        ),
+        None,
+    )
+    assert route_box is not None, "shell-output [route PICKEDLOAD PICKEDEXPORT] missing"
+    route_id = route_box["id"]
 
-    # ── load-manifest → [opendialog] → [prepend loadManifest] → JS ──────────
-    if "load-manifest" in items:
-        btn = items["load-manifest"]
-        tb_box = _btn_tb_id(btn["id"])
-        dlg_id = f"{_btn_msg_id(btn['id'])}-opendialog"
-        prep_id = f"{_btn_msg_id(btn['id'])}-prep"
-        assert dlg_id in box_by_id, "load-manifest missing [opendialog]"
-        assert box_by_id[dlg_id]["text"] == "opendialog"
-        assert prep_id in box_by_id, "load-manifest missing [prepend loadManifest]"
-        assert box_by_id[prep_id]["text"] == "prepend loadManifest"
-        assert (tb_box, dlg_id) in line_pairs
-        assert (dlg_id, prep_id) in line_pairs
-        assert (prep_id, OBJ_JS) in line_pairs
+    # [prepend pickedLoad] and [prepend pickedExport] present.
+    prep_load = next(
+        (
+            bid
+            for bid in box_by_id
+            if box_by_id[bid].get("text", "") == "prepend pickedLoad"
+        ),
+        None,
+    )
+    prep_export = next(
+        (
+            bid
+            for bid in box_by_id
+            if box_by_id[bid].get("text", "") == "prepend pickedExport"
+        ),
+        None,
+    )
+    assert prep_load, "[prepend pickedLoad] missing"
+    assert prep_export, "[prepend pickedExport] missing"
 
-    # ── export → [savedialog] → [prepend exportPpak] → JS ───────────────────
-    if "export" in items:
-        btn = items["export"]
-        tb_box = _btn_tb_id(btn["id"])
-        dlg_id = f"{_btn_msg_id(btn['id'])}-savedialog"
-        prep_id = f"{_btn_msg_id(btn['id'])}-prep"
-        assert dlg_id in box_by_id, "export missing [savedialog]"
-        assert box_by_id[dlg_id]["text"].startswith("savedialog")
-        assert prep_id in box_by_id, "export missing [prepend exportPpak]"
-        assert box_by_id[prep_id]["text"] == "prepend exportPpak"
-        assert (tb_box, dlg_id) in line_pairs
-        assert (dlg_id, prep_id) in line_pairs
-        assert (prep_id, OBJ_JS) in line_pairs
+    # Wiring: shell → route → (prepend pickedLoad | prepend pickedExport) → JS.
+    shell_id = "obj-sf-configurator-shell"
+    assert (shell_id, route_id) in line_pairs
+    assert (route_id, prep_load) in line_pairs
+    assert (route_id, prep_export) in line_pairs
+    assert (prep_load, OBJ_JS) in line_pairs
+    assert (prep_export, OBJ_JS) in line_pairs
 
 
 # ── JS dispatcher object ────────────────────────────────────────────────────


### PR DESCRIPTION
Two on-device UX issues from the second smoke test:

**1. OPEN EDITOR opened in a new Chrome TAB, not a separate window.**

`messnamed("max", "launchbrowser", url)` delegates to the OS URL handler, which lands as a tab in the existing Chrome session.

Switched to shell `open -na "Google Chrome" --args --new-window --app=<url>`. Chrome **app-mode** opens a chromeless dedicated window (no tabs, no URL bar, no bookmarks) that lives apart from the regular Chrome session — looks native.

JS-only change. The `[jweb]` object stays in the patcher as a vestige.

**2. LOAD MANIFEST asked for an absolute path.**

The button banged the JS handler with no args, hitting the "pass an absolute path" early-return. No file picker existed.

Wired `[opendialog]` between LOAD MANIFESTs `[t b]` and the JS, with `[prepend loadManifest]` formatting the chosen path. Native macOS file picker.

Same fix preemptively applied to EXPORT via `[savedialog]` + `[prepend exportPpak]` (default suggested filename: `configurator-export.ppak`).

**Tests**
- Python: `test_dialog_bearing_buttons_have_file_picker` asserts the new wiring for both verbs. 18 strip-builder tests pass (was 17).
- JS: `openEditor` test rewritten to assert the shell-exec command shape (Chrome target, `--app=`, `--new-window`, URL present). 14/14 pass.

**On-device reload**
The patcher topology changed this time (unlike the JS-only #97 and #98). To pick up: **remove the strip from the track → drag the rebuilt `v0/build/ConfiguratorStrip.amxd` back onto the track**. (.amxd has been rebuilt in this PRs working tree at 24,608 bytes; JS already redeployed to the Max Package.)