### PR TITLE
feat(configurator): consolidated design + execution plan v1

### DIFF
--- a/docs/configurator/CURRENT_STATE_DUMP_2026-05-13.md
+++ b/docs/configurator/CURRENT_STATE_DUMP_2026-05-13.md
@@ -1,0 +1,606 @@
+# StemForge Configurator — Full State Dump (2026-05-13)
+
+> A self-contained snapshot of the configurator stack as of v0.2.0 + Phase 3 + the
+> 2026-05-13 on-device debugging session. Intended to be pasted into a fresh
+> design session for re-architecture discussion. **No project-tree access
+> required to follow this.**
+
+---
+
+## 1. Glossary — what every "thing" is
+
+The names have been slipping; locking them down here.
+
+| Name | What it is | File / location | Status |
+|---|---|---|---|
+| **StemForge.amxd** | The original, full-featured M4L device. Has its own UI: preset dropdown, manifest dropdown, FORGE / COMMIT / BOUNCE buttons, status text. Drives Live's LOM directly. **This is "the big device"** in my earlier shorthand. | `v0/build/StemForge.amxd`, JS in `v0/src/m4l-js/stemforge_loader.v0.js` | Works, with warts. User keeps it as-is. |
+| **ConfiguratorStrip.amxd** | The new Phase 3 M4L device, built fresh. Thin horizontal strip with 7 labelled buttons (LOAD / SLICE / RECOMPUTE / RE-ANCHOR / CURATE / EXPORT / OPEN EDITOR), connection-status dot, and a "Start Server" CTA. **This is "the strip"** in my shorthand. | `v0/build/ConfiguratorStrip.amxd`, JS in `v0/src/m4l-devices/configurator-strip/js/sf_configurator.js` | Only OPEN EDITOR works reliably. Other buttons fire HTTP via `[shell]` which silently no-ops in this M4L sandbox config. |
+| **Configurator Server** | Local Python FastAPI process. Holds an in-memory `ProjectSpec`. Exposes intent endpoints (`POST /intent/*`) and an SSE stream (`GET /state/stream`). Server-side native file picker. Bound `127.0.0.1` only. | `stemforge/configurator/` Python module. Entry: `stemforge-configurator` console script. Port file: `~/stemforge/.configurator_port` | Works. |
+| **Popup** (or "Web UI") | The browser-rendered configurator UI. React + TS + Vite + Tailwind + shadcn + Framer Motion. Loads from `http://127.0.0.1:<port>/` in a Chrome tab. Subscribes to server SSE; fires `/intent/*` via fetch. **This is "the popup"**. | `web/configurator/`, build output served by the Python server | Renders pad state. Load button works. Commit/Export buttons exist but the underlying server handlers don't actually drive Live or persist to disk. |
+| **CLI** | `stemforge` Click CLI. Headless deck-building. | `stemforge/cli.py` | Works. `stemforge deck-from-manifest` + `stemforge build-deck` are the proven .ppak production path. |
+| **sf-remote** | Tiny Python CLI that fires UDP/OSC messages at the running Max/Live instance. Existing infrastructure. | `tools/sf_remote.py` | Works. Big device listens via `[udpreceive 7420]`. |
+
+---
+
+## 2. Current physical architecture
+
+```
+                    ┌─────────────────────┐
+                    │   Live + M4L host   │
+                    │                     │
+   ┌───────────┐    │  ┌─────────────┐    │
+   │ sf-remote │────UDP→│ StemForge   │    │
+   │  (CLI)    │    │  │ .amxd       │←─── direct LOM ───→ Live tracks
+   └───────────┘    │  │ (legacy)    │    │              (A/B/C/D, etc.)
+                    │  └─────────────┘    │
+                    │                     │
+                    │  ┌─────────────┐    │
+                    │  │Configurator │    │
+                    │  │ Strip .amxd │── [shell] (broken) ──╳
+                    │  │ (new)       │    │
+                    │  └──────┬──────┘    │
+                    │         │           │
+                    │   messnamed launchbrowser
+                    │         │           │
+                    └─────────┼───────────┘
+                              ↓
+                       ┌────────────┐
+                       │   Chrome   │
+                       │  (Popup)   │←────┐
+                       └─────┬──────┘     │ SSE
+                             │ fetch      │
+                             ↓            │
+                    ┌────────────────────┴───┐
+                    │ Configurator Server    │
+                    │ (FastAPI, Python)      │
+                    │ Holds: ProjectSpec     │──── osascript ───→ native file dialogs
+                    │ Port: 7430-7440        │
+                    └────────────────────────┘
+```
+
+The big arrows that are broken or missing:
+
+- **Strip → Server (HTTP)**: dead. `[shell]` in this M4L sandbox config doesn't actually execute the curl commands the strip's JS emits. Confirmed by clicking RECOMPUTE — server logs no incoming POST. Only `messnamed("max", "launchbrowser", url)` works from the strip, which is how OPEN EDITOR launches Chrome.
+- **Server → Live LOM**: doesn't exist. Python FastAPI process has no way to drive Ableton's LOM. The Configurator Server is "headless" with respect to Live.
+- **Popup → Live**: same — only the server is reachable. The popup can't directly write to Live.
+- **StemForge.amxd ↔ Server**: no link. Both maintain their own state.
+
+---
+
+## 3. Current operation surface — three meanings of "commit", two of "load"
+
+### LOAD
+
+| Surface | What "load" does today |
+|---|---|
+| StemForge.amxd's FORGE/LOAD button | Reads selected manifest from Max `[Dict sf_manifest]`. If `layout_mode: production` OR `session_tracks` populated (added today), dispatches to `loadSong()` which creates tracks + clips in Live via LOM. |
+| Strip's LOAD button | Sends `POST /intent/load-manifest` via `[shell]` curl. Currently broken (shell doesn't fire). |
+| Popup's Load button | Sends `POST /intent/pick-manifest` to the server, which uses `osascript` (Python subprocess) to pop a native file dialog, then internally dispatches to `handle_load_manifest`. **Works.** State lives only in the server's in-memory `ProjectSpec`. **Does NOT touch Live tracks.** |
+| `sf-remote fire manifest-loader load <path>` | UDP message to the StemForge.amxd. |
+
+**Result:** "Load" in the popup and "Load" in StemForge.amxd populate two completely independent state stores. They don't share data.
+
+### COMMIT
+
+| Surface | What "commit" does today |
+|---|---|
+| StemForge.amxd's COMMIT button | Calls `commitOffsets()` with **no args** — Dict mode. Walks Live's A/B/C/D via LOM, builds `session_tracks`, writes into the in-memory Max `[Dict sf_manifest]`. **Does NOT touch the manifest file on disk.** |
+| `sf-remote fire forge commitOffsets <path>` | Same walker, but writes the file at `<path>` with an atomic rename. **This is the only path that persists to disk today.** |
+| Strip → no COMMIT button | (Was deliberately excluded from the 7-button surface.) |
+| Popup's Commit button | `POST /intent/commit`. Server-side handler reconciles its in-memory ProjectSpec. **Does NOT touch Live's LOM or the manifest file.** |
+
+**Result:** Three different "commit"s, only one of which (the sf-remote path) actually persists to disk. None of them keep the popup's state in sync with Live's state.
+
+### BOUNCE
+
+| Surface | What "bounce" does today |
+|---|---|
+| StemForge.amxd's BOUNCE button | Reads A/B/C/D Live tracks, exports each clip as a fresh WAV via track.freeze + clip.crop, captures per-clip `warp_bpm`, writes a brand-new deck-shape manifest at a chosen path. This is what built `breaks-n-beats1.ppak`. |
+| `sf-remote fire forge bounceTracks <path>` | UDP-fired equivalent. |
+| Strip / Popup | No bounce button. |
+
+### EXPORT (manifest → .ppak)
+
+| Surface | What "export" does today |
+|---|---|
+| CLI: `stemforge deck-from-manifest <manifest> --out deck.yaml` + `stemforge build-deck deck.yaml --out out.ppak` | The proven, working .ppak production path. Reads `session_tracks` from manifest, projects onto EP-133, writes `.ppak`. |
+| Popup's Export button | `POST /intent/export`. Server-side handler tries to run the same projection, but it requires `state.last_manifest_path` to be set (only set if you loaded via popup, AND the project must have valid session_tracks). Hasn't been smoke-tested end-to-end. |
+| Strip's EXPORT button | `POST /intent/export` via `[shell]` curl. Broken. |
+
+---
+
+## 4. Where state lives — multiple disconnected sources of truth
+
+| State | Where it lives | Updated by |
+|---|---|---|
+| Currently-loaded manifest content (legacy, in-Live editing) | Max `[Dict sf_manifest]` (in-memory in StemForge.amxd) | StemForge.amxd's FORGE button reading from disk |
+| Live tracks/clips state | Ableton itself (LOM) | User editing + StemForge.amxd's loader creating clips |
+| Configurator ProjectSpec (new) | Python server in-memory dict | Popup's Load → server's `/intent/load-manifest` |
+| Manifest file on disk | `~/stemforge/decks/<name>/curated/manifest.json` (or similar) | Only `sf-remote fire forge commitOffsets <path>` OR the BOUNCE flow with explicit path |
+| Audio hash cache | `~/stemforge/.audio_hash_cache.json` | Server-side at commit time |
+
+**No two of these stay in sync today.**
+
+---
+
+## 5. The user's actual workflow (what they want)
+
+Verse-swap deck for EP-133:
+
+1. **Source material**: hand-curated WAVs from previously-forged tracks. Already on disk under `~/stemforge/processed/<slug>/curated/manifest.json` for each source song.
+2. **Arrange in Live**: drop clips onto A/B/C/D session-view slots, manually choose what goes where. Trim, rearrange, taste-make.
+3. **Persist the arrangement** as a deck-shape manifest on disk (with `session_tracks`).
+4. **Produce a `.ppak`** from that manifest.
+5. **Iterate**: re-open the deck manifest later, tweak in Live, re-persist, re-build.
+
+This is the loop. Today only step 4 (.ppak production via CLI) and step 1 (sources on disk) are clean. Steps 2/3/5 require a mix of StemForge.amxd buttons and sf-remote terminal commands, with knowledge of which "commit" actually writes to disk.
+
+---
+
+## 6. Known gaps + sharp edges
+
+### 6.1 [shell] doesn't fire commands in the strip's M4L sandbox
+
+The strip's JS dispatches all HTTP via `outlet(4, "exec", "curl ...")` to a `[shell]` object. Confirmed by clicking RECOMPUTE — no incoming POST in the server log, no stdout in Max console. The same `[shell]` object works for `messnamed("max", "launchbrowser", url)` (OPEN EDITOR opens Chrome) because that bypasses `[shell]` entirely.
+
+Could be sandbox / permissions / Max version specific. Not debugged to root cause; we pivoted to the popup instead.
+
+### 6.2 COMMIT button only writes to in-memory Dict, not disk
+
+Big device's COMMIT button fires `commitOffsets` with no arg → in-memory mutation only. To persist, the user has to fire `sf-remote fire forge commitOffsets <path>` from terminal. Surprises everyone.
+
+Patch sketch: cache `_lastManifestPath` on load; default `commitOffsets()` to that path if no arg.
+
+### 6.3 No "load deck manifest" path until today's patch
+
+Deck-shape manifests (only `session_tracks`, no `stems[]`) hit the early-return in `loadFromDict` / `loadSong`. Patched today: `loadFromDict` now also dispatches to `loadSong` when `session_tracks` is populated; `loadSong` skips the stem-loading loop and goes straight to `_restoreSessionTracks`.
+
+### 6.4 Popup state and StemForge.amxd state don't share
+
+Click Load in the popup → server's `ProjectSpec` gets populated → popup re-renders. But nothing happens in Live. Click Forge in StemForge.amxd → Live tracks populated → popup unchanged.
+
+### 6.5 SSE typed-event mismatch (fixed today)
+
+Server emits `event: state\ndata: <json>` (standard SSE typed events). Frontend was using `onmessage` which only catches default unnamed events. Frontend also expected a `{type, payload}` wrapper that the server doesn't send. **Fixed today**: frontend now uses `addEventListener("state", ...)` etc. and parses `data` directly.
+
+### 6.6 Frontend types didn't match server Pydantic shape (fixed today)
+
+Frontend was reading `state.project_name`, `state.songs[0].scenes[0].groups[0]`, `pad.clip_id`, `group.group`, `pad.pad`. Server actually emits `state.name`, `state.songs[0].groups[0]` (no intermediate `scenes` layer), `pad.clip.path`, `group.group_id`, `pad.pad_id`. **Fixed today** by realigning the TS types to mirror Pydantic.
+
+### 6.7 Hand-curated deck manifests have no `stems[]` AND no `layout_mode`
+
+The breaks-n-beats1-style deck manifest is created by `bounceTracks`. It has `bpm`, `source_dir`, `session_tracks`, `notes` — that's it. No `layout_mode` field. The original loader required `layout_mode: production`. Today's patch adds the `session_tracks`-only branch so these manifests load.
+
+### 6.8 macOS + Chrome won't honor "new window" launches
+
+`open -na "Google Chrome" --args --new-window --app=<url>` silently drops the new-window request when Chrome is already running. AppleScript Tell-Chrome-to-make-new-window times out on AppleEvent permissions. Falls back to default browser → opens in an existing tab. Workaround: drag the tab out. Future fix: in-popup "Pop out" button using `window.open()`.
+
+### 6.9 The strip's status dot stays amber even when connected
+
+Cosmetic. `live.text` widget's `bgcolor` attribute doesn't re-paint on the second `bgcolor` message after the first sets it. Functional state is correct.
+
+---
+
+## 7. What the popup already does well
+
+- Server-side native file dialog via osascript (full GUI permission — sidesteps the M4L sandbox entirely)
+- Live SSE state subscription with reconnect semantics
+- Renders the loaded ProjectSpec as a polished 4-group × 12-pad grid (`PadCanvas`)
+- Tabular numeric fields, glass chrome, Inter font, Framer Motion micro-interactions (the snazzy aesthetic from Phase 3)
+- 11 vitest cases passing for the hook + intent + topbar layers
+
+---
+
+## 8. Open architectural questions for the design session
+
+1. **Who's the source of truth?** Three plausible answers:
+   - StemForge.amxd's Max Dict (legacy authority)
+   - Configurator server's ProjectSpec (new, but disconnected from Live)
+   - The manifest file on disk (everyone reads/writes it; risky concurrent-write surface)
+2. **How does Live's LOM get driven from a non-Max process?** The Python server can't access LOM. Options:
+   - UDP/OSC bridge (sf-remote already exists). Server fires UDP at the StemForge.amxd's verb handlers.
+   - Strip device becomes the LOM-side worker; popup talks to it via... what? `[shell]` doesn't work; would need UDP or a fresh transport.
+   - Keep LOM-touching strictly in the legacy StemForge.amxd; popup/strip just observe.
+3. **What's the canonical verb set?** Honest minimal: LOAD, COMMIT, BOUNCE, EXPORT. Each with a single sentence definition. Today there are 3+ meanings of LOAD/COMMIT — none of them aligned.
+4. **Where does file-on-disk I/O happen?** Today it's split across `commitOffsets <path>` (Max JS), `bounceTracks <path>` (Max JS), `handle_load_manifest` (Python), `deck-from-manifest` (Python CLI). A unified writer would simplify reasoning.
+5. **What's the strip device actually for?** If `[shell]` doesn't fire, the strip can't do operations. Three plausible answers:
+   - Drop the strip; the popup is the editor. Strip is a phase-4 polish item.
+   - Rewire the strip's transport over UDP (use sf_remote infrastructure). Then it can fire ops without `[shell]`.
+   - Strip becomes a thin "status + Open Editor" launcher only.
+6. **Does StemForge.amxd live on?** User said yes — they keep it with all its warts. But: does the new architecture observe its state? Or stay completely disjoint?
+7. **What's the failure mode for "two surfaces edit the same manifest file"?** If the popup and StemForge.amxd both think they own state, who wins on disk write? Need explicit ownership rule.
+
+---
+
+## 9. Today's deltas (uncommitted)
+
+In the working tree as of this dump, not yet committed:
+
+- `stemforge/configurator/intents.py` + `server.py`: added `/intent/pick-manifest` endpoint with server-side osascript dialog
+- `web/configurator/src/lib/{api,types}.ts`: added `pickManifest` HTTP client + realigned ProjectSpec/GroupSpec/PadSpec types to the Pydantic shape
+- `web/configurator/src/hooks/useProjectState.ts`: switched from `onmessage` to `addEventListener("state"/"log"/"progress"/"error", ...)`, dropped the `{type, payload}` wrapper expectation
+- `web/configurator/src/hooks/useIntent.ts`: added `usePickManifest` hook
+- `web/configurator/src/components/{LeftRail,PadCanvas,StatusBar,TopBar}.tsx`: aligned to new types
+- `web/configurator/src/test/mockEventSource.ts` + `useProjectState.test.ts`: support typed-event dispatch
+- `v0/src/m4l-js/stemforge_loader.v0.js` + deploy copies: `loadFromDict` dispatches deck-shape manifests to `loadSong`; `loadSong` skips per-stem loop when no `stems[]` and goes straight to `_restoreSessionTracks`
+- `v0/src/m4l-devices/configurator-strip/`: lots of debug instrumentation (shell-based `_post`, osascript file-picker plumbing, `[print SHELL_OUT]` patcher debug) — most of which is dead code now since `[shell]` doesn't fire
+
+---
+
+## 10. Outstanding PRs
+
+- **PR #99** open: `fix(configurator-strip): native file pickers + Chrome app-mode editor window` — title is misleading now; it's accumulated multiple pivots. Should likely be closed or split. Tracking the strip's now-dead [shell]-based file picker.
+- Today's working-tree changes are uncommitted entirely.
+
+---
+
+## 11. Where to push next — the user's ask
+
+> "Get everything aligned. New browser UI, new strip, all forge/bounce/commit/save/load logic, unified common interface and set of operations. Don't blow up the current StemForge device. Just get to a consistent workflow."
+
+This implies: design ONE set of verbs with ONE meaning each, decide ONE source of truth, route everything through it, deprecate-but-keep the legacy StemForge.amxd. Architecture choice should anchor on:
+
+- Who can drive Live's LOM (only Max [js]; FastAPI server can't).
+- Which transport actually works in the user's M4L sandbox: UDP/OSC ✓, `messnamed` ✓, `[shell]` ✗ (per the 2026-05-13 session).
+- What the user actually does in a session (loop in §5 above).
+
+---
+
+## 12. Detailed button-by-button inventory + UX flows
+
+This section enumerates every clickable / interactive surface across the three M4L devices, the popup, the CLI, and `sf-remote`. For each: its label, position, what it actually does, what state it touches, and where it sits in the user's mental workflow.
+
+### 12.1 StemForge.amxd (the legacy big device) — drawn via v8ui canvas, 820×149
+
+The device is laid out as three vertical zones:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ LEFT (x 0-716)              CENTER                  RIGHT (x 716-820)   │
+│ ┌─────────────────────┐                              ┌───────────────┐  │
+│ │ PRESET dropdown     │                              │ FORGE/CANCEL/ │  │
+│ │ "Pick preset…"      │                              │  DONE/RETRY   │  │
+│ └─────────────────────┘                              │  (primary)    │  │
+│ ┌─────────────────────┐                              ├───────────────┤  │
+│ │ SOURCE dropdown     │                              │ COMMIT        │  │
+│ │ "Pick source…"      │     (status text +           ├───────────────┤  │
+│ └─────────────────────┘      progress/phase area)    │ BOUNCE        │  │
+│                                                      ├───────────────┤  │
+│                                                      │ EXPORT        │  │
+│                                                      ├───────────────┤  │
+│                                                      │ LOAD │ ANCH   │  │
+│                                                      └───────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 12.1.1 PRESET dropdown (left, top)
+
+- **What it shows**: list of preset JSON files scanned from `presets/` and StemForge data dirs. Each preset describes a curation pipeline + UI palette + target-track layout. Examples: `production_idm`, `ambient_veil`, `brutalism`, `dub_echo`, `spectral_glitch`, `drums_only`.
+- **What clicking does**: writes selection into the Max `[Dict sf_preset]`. Updates the device's internal "preset chosen?" state to true.
+- **State affected**: `sf_preset` Dict (in-memory). Subsequent loads/commits read this when applying a pipeline's effect-chain templates.
+- **Workflow position**: Step 1 of source-loading. Required to unlock the primary action button (state machine demands both a preset AND a source).
+
+#### 12.1.2 SOURCE / MANIFEST dropdown (left, below preset)
+
+- **What it shows**: list of manifests auto-scanned from canonical paths (`~/stemforge/processed/<slug>/curated/manifest.json`, plus user-configured roots). Last two items are special: `"Browse manifest..."` (opens a native file dialog) and `"Browse audio..."` (opens a dialog to pick a raw audio file to forge).
+- **What clicking does**:
+  - Picking a manifest entry: writes manifest content into `[Dict sf_manifest]`. Status updates to `"manifestPath: <name> · <BPM> BPM · <N stems>"`.
+  - Picking "Browse manifest...": fires `[opendialog]` → file path → loads into the dict.
+  - Picking "Browse audio...": fires `[opendialog sound]` → audio path → ready to forge.
+- **State affected**: `sf_manifest` Dict.
+- **Workflow position**: Step 2 of source-loading. With both preset + source picked, the primary action button activates.
+
+#### 12.1.3 Primary action button (right column, top) — label cycles through FORGE / CANCEL / DONE / RETRY
+
+- **Label states**:
+  - **FORGE** (idle, ready): both preset + source picked, no operation running.
+    - If audio source: runs Demucs separation → produces stems → writes a fresh curated manifest → loads clips into Live tracks.
+    - If manifest source: dispatches `loadFromDict` → walks the manifest's `stems[]` (or `session_tracks` after today's patch) → creates clips on A/B/C/D session-view slots via LOM.
+  - **CANCEL**: operation in progress, click to abort.
+  - **DONE**: operation just completed, click to dismiss / return to idle.
+  - **RETRY**: operation failed, click to re-attempt with same params.
+- **State affected**: Live's LOM (tracks/clip slots), Max Dicts, and potentially filesystem (if forge writes stems).
+- **Workflow position**: The main "do the thing" button. Most of every session starts here.
+
+#### 12.1.4 COMMIT button (right column, below primary)
+
+- **Always visible**, no state-machine gating.
+- **What clicking does**: fires `commitOffsets` to the JS — **no path argument**. Walks Live's A/B/C/D session view + arrangement view, builds a `session_tracks` block, writes into the in-memory `[Dict sf_manifest]`.
+- **What it does NOT do today**: write the updated manifest back to the file on disk. The on-disk version is unchanged.
+- **State affected**: Max `[Dict sf_manifest]` only. Live state is unchanged.
+- **Workflow position**: User believes "commit = save my arrangement." Reality is "commit = update in-memory state that no one reads." Persisting to disk requires `sf-remote fire forge commitOffsets <path>` from terminal.
+
+#### 12.1.5 BOUNCE button (right column, below COMMIT)
+
+- **Always visible.**
+- **What clicking does**: triggers the bounce pipeline:
+  1. Pre-crop metadata capture: reads each A/B/C/D clip's `warp_markers` to compute slope = displayed `warp_bpm` (since `clip.warp_bpm` is read-only/unset).
+  2. Collapses each clip's loop region into its play region (`_collapseToLoopRegion`).
+  3. For each clip on A/B/C/D, calls `clip.call("crop")` to render the visible loop into a fresh WAV.
+  4. Writes a deck-shape manifest to a user-chosen path with `bpm`, `source_dir`, `session_tracks`, `notes`.
+  5. Each clip's `warp_bpm` is tagged into the bounced WAV's TNGE chunk + per-clip in the manifest.
+- **State affected**: filesystem (new WAVs + manifest), nothing in Live changes structurally (the cropped clips replace the prior clip content but stay in the same slot).
+- **Workflow position**: This is the "produce a deck" action. Was used to build `breaks-n-beats1.ppak`. The output manifest is fed to the CLI `deck-from-manifest` + `build-deck` for `.ppak` production.
+
+#### 12.1.6 EXPORT button (right column, below BOUNCE)
+
+- **Always visible.**
+- **What clicking does**: fires the **arrangement-view export** (EP-133 song mode). Walks arrangement-view clips on tracks A/B/C/D + scene markers, builds a song-mode `.ppak` (not the deck-mode kit). Uses `stemforge export-song` under the hood.
+- **State affected**: filesystem (new `.ppak`).
+- **Workflow position**: EP-133 song-mode export. **Different** from deck-mode `.ppak` (which goes via CLI `build-deck`). Not the verse-swap deck workflow.
+
+#### 12.1.7 LOAD button (right column, bottom-left half of split row)
+
+- **Always visible.**
+- **What clicking does**: fires `[opendialog]` to pick an arrangement-view chunk manifest (the `prechop_manifest.json` shape, not the curated/manifest.json shape). Then `sf_arrangement_loader.js` lays out the chunks in the arrangement view across A/B/C/D.
+- **State affected**: Live's arrangement view.
+- **Workflow position**: For arrangement-mode loading (laying out a chunked song in arrangement view for editing).
+
+#### 12.1.8 ANCH (anchor) button (right column, bottom-right half of split row)
+
+- **Always visible.**
+- **What clicking does**: reads Live's first cue_point (locator), back-computes the source-audio time, shells out to `stemforge re-anchor` CLI to re-cut the prechop chunks at that anchor, then reloads the arrangement.
+- **State affected**: filesystem (rewritten chunks), Live's arrangement view (reloaded).
+- **Workflow position**: For re-anchoring a pre-existing forge when the auto-detected downbeat was off.
+
+#### 12.1.9 Status text + phase-progress display (center area)
+
+- **Not a button**, but the device's main feedback surface. Shows things like:
+  - `"waiting - pick a preset and a source"`
+  - `"detected production manifest → song loader"`
+  - `"session_tracks restored: 46 clips (A=12 B=12 C=10 D=12)"`
+  - per-phase progress for FORGE operations
+- **State affected**: none (display only).
+- **Workflow position**: Primary user feedback channel. **Often the only signal that something worked or didn't.**
+
+### 12.2 ConfiguratorStrip.amxd — 820×100, 7 labelled rectangles
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ConfiguratorStrip                                                         │
+│  ┌──────┐ ┌──────┐ ┌──────────┐ ┌──────────┐ ┌──────┐ ┌──────┐ ┌──────────┐│
+│  │ LOAD │ │SLICE │ │RECOMPUTE │ │RE-ANCHOR │ │CURATE│ │EXPORT│ │OPEN      ││
+│  │      │ │      │ │          │ │          │ │      │ │      │ │EDITOR    ││
+│  └──────┘ └──────┘ └──────────┘ └──────────┘ └──────┘ └──────┘ └──────────┘│
+│  status:                                                          ●  edit │
+│  footer line — http://127.0.0.1:7430                              v0.1.0   │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+All 7 buttons go through the same per-button chain: `[live.text mode=1]` → `[t b]` → `[message <handler>]` → `[js sf_configurator]`. The JS handler is supposed to fire `outlet(4, "exec", "curl ...")` → `[shell]` → HTTP → server. **`[shell]` doesn't actually execute in this M4L sandbox config, so 6 of 7 buttons are dead.**
+
+#### 12.2.1 LOAD
+
+- **Intended**: fire `POST /intent/load-manifest` with an osascript-picked file path.
+- **Today**: clicks; JS function runs; emits the curl command to outlet 4; `[shell]` silently drops the command. No file dialog appears, no manifest loads. Status footer shows `"waiting for file pick…"` indefinitely.
+- **Workaround**: load via the popup's Load button instead.
+
+#### 12.2.2 SLICE
+
+- **Intended**: fire `POST /intent/slice`. (Server handler not yet implemented; currently a no-op endpoint.)
+- **Today**: dead. Same `[shell]` issue.
+
+#### 12.2.3 RECOMPUTE
+
+- **Intended**: fire `POST /intent/recompute`. Re-run curation / refresh available clips.
+- **Today**: dead. Confirmed by clicking and observing no incoming POST in server logs.
+
+#### 12.2.4 RE-ANCHOR
+
+- **Intended**: fire `POST /intent/re-anchor`. Re-cut prechop chunks at the current locator.
+- **Today**: dead. (Server-side handler also not yet implemented.)
+
+#### 12.2.5 CURATE
+
+- **Intended**: fire `POST /intent/curate`. Re-run curation pipeline.
+- **Today**: dead. (Server-side handler not yet implemented.)
+
+#### 12.2.6 EXPORT
+
+- **Intended**: fire osascript save-dialog for the `.ppak` output path, then `POST /intent/export` with that path. Server runs `deck-from-manifest` + `build-deck`.
+- **Today**: dead. (Server handler partially implemented but never reached.)
+
+#### 12.2.7 OPEN EDITOR — the one button that works
+
+- **Intended**: open the popup URL in the user's default browser.
+- **Today**: calls `messnamed("max", "launchbrowser", "http://127.0.0.1:<port>/")` which bypasses `[shell]` entirely and goes through Max's URL launcher. Opens in a new Chrome tab.
+- **Caveats**: macOS pops a permission dialog the first time ("Live wants to control Google Chrome") that's easy to miss behind Live's window. Tab opens in existing Chrome session, not a new window — drag the tab out for a dedicated window.
+
+#### 12.2.8 Status dot (right side, 14×14)
+
+- **Color states**: green `DOT_OK` (connected), amber `DOT_WARN` (checking), red `DOT_ERROR` (server not running).
+- **Today's quirk**: stays amber even when functionally connected because `live.text`'s `bgcolor` attribute message only takes effect on first write. Functional connection state (`_serverBase` set, intents fire — well, they would if `[shell]` worked) is correct underneath.
+
+#### 12.2.9 Status text (right side, beside dot)
+
+- Shows: `"checking…"`, `"connected"`, `"server down"`, or transient action text like `"editor opened"`, `"waiting for file pick…"`.
+
+#### 12.2.10 Footer text (full-width, below buttons)
+
+- Shows the server URL when connected, or last action result. Currently the most diagnostic surface on the strip.
+
+#### 12.2.11 Version stamp (right side, below dot)
+
+- Static text `v0.1.0` of the strip device build.
+
+#### 12.2.12 Implicit "Start Server" CTA
+
+- When `~/stemforge/.configurator_port` is missing, the strip's JS surfaces `"server not running — click Start Server"`. Clicking the status dot at that point fires a shell `exec stemforge-configurator &` to launch the Python server. (This CTA exists in JS but isn't visually distinct — folded into the dot.)
+
+### 12.3 Popup (Web UI) — Chrome tab at `http://127.0.0.1:<port>/`
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ ◯ StemForge          verse_swap_v1                  EP133 ● connected   │ ← TopBar
+│   CONFIGURATOR       loaded curated/manifest.json · 46 clips             │
+├──────────┬───────────────────────────────────────────────────────────────┤
+│OPERATIONS│  scene                                          4 groups  48  │
+│          │  ┌─────────────────────────────────────────────┐              │
+│ [Load    │  │ group A · VOCALS                            │              │
+│ manifest]│  │  ┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐         │ ← PadCanvas
+│          │  │  │A1││A2││A3││A4│ ...                                       │
+│ Commit   │  │  └──┘└──┘└──┘└──┘                                          │
+│          │  │ group B · VOCALS (ALT)                                     │
+│ Recompute│  │ group C · DRUMS                                            │
+│          │  │ group D · TEXTURE / IDM                                    │
+│ Export   │  │                                                            │
+│          │  └─────────────────────────────────────────────┘              │
+│LeftRail  │                                                               │
+├──────────┴───────────────────────────────────────────────────────────────┤
+│ 48.0 / 64.0 MB     A·VOCAL B·VOCAL C·DRUM D·TEXTURE     load · 842ms    │ ← StatusBar
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 12.3.1 TopBar — project header
+
+- **Project name** (or "no project loaded" placeholder). Reads `state.name` (after today's schema fix).
+- **Manifest microcopy** — `"loaded curated/manifest.json · 46 clips"`. Reads `state.manifest_path` and `state.clip_count`.
+- **Target chip** — fixed `"EP133"` for v1.
+- **Connection status** — pulsing dot + tooltip showing SSE state (idle/connecting/connected/disconnected/error).
+- **State affected**: none (display only).
+- **Workflow position**: At-a-glance "is the system alive?" + "what's loaded?"
+
+#### 12.3.2 LeftRail — operations panel
+
+Four buttons, top to bottom. Each is wired via TanStack Query mutation hooks that fire `POST /intent/*`.
+
+##### `Load manifest` (orange accent, always enabled)
+
+- **What clicking does (today)**: fires `POST /intent/pick-manifest` (no body). Server runs Python `subprocess.run(["osascript", "-e", "POSIX path of (choose file ...)"])`. Native macOS file dialog pops. On pick, server internally dispatches `handle_load_manifest(path)`. ProjectSpec updates. SSE state event fires. Popup re-renders.
+- **State affected**: Configurator server's in-memory ProjectSpec; persistent `last_manifest_path` stored. **Does NOT touch Live's LOM.**
+- **Workflow position**: "Show me a deck's structure" — the popup becomes a read-only view of the picked manifest's session_tracks block.
+
+##### `Commit` (disabled when no project)
+
+- **What clicking does (today)**: fires `POST /intent/commit` (no body). Server-side handler attempts to reconcile the in-memory ProjectSpec.
+- **What it DOESN'T do**: walk Live (the FastAPI process can't access LOM); write the manifest file to disk (no writer path implemented).
+- **State affected**: in-memory ProjectSpec; that's it.
+- **Workflow position**: Currently a stub. The user-facing intent ("snapshot Live") isn't actually wired.
+
+##### `Recompute` (disabled when no project)
+
+- Stub. `POST /intent/recompute` handler is mostly a no-op.
+
+##### `Export` (disabled when no project)
+
+- **What clicking does (today)**: fires `POST /intent/export` with `{target: "ep133", out_path: <user-prompted>}`. Server projects the in-memory ProjectSpec onto EP-133 shape and writes a `.ppak`. **Untested end-to-end against a real manifest.**
+- **State affected**: filesystem (new `.ppak`).
+- **Workflow position**: Should be the equivalent of running CLI `deck-from-manifest` + `build-deck`. Today the CLI path is the safer bet.
+
+#### 12.3.3 PadCanvas — main 4×12 grid
+
+- **48 pads** (4 group rows × 12 pads each). Each pad cell shows:
+  - Group letter + pad index (e.g. `A · 01`)
+  - Clip filename stem (if `clip.path` is non-empty)
+  - Play-mode chip (KEY / ONESHOT / LOOP)
+  - Subtle group-color edge cue (cyan A, violet B, red C, green D)
+- **No click interactions yet** — Phase 3 ships read-only. Hover shows tooltip; "click to assign — phase 4" on empty pads.
+- **State affected**: none (display only).
+- **Workflow position**: User's mental model of the deck. Currently the only place that shows "what's in this deck" without opening the manifest JSON.
+
+#### 12.3.4 StatusBar — bottom rollup
+
+- **Memory usage** (`48.0 / 64.0 MB`) — currently shows hardcoded cap (64 MB EP-133); used-bytes is server-supplied via `state.capacity.used_bytes`. (Server doesn't actually compute this yet, so it'll often be 0.)
+- **Per-group format chips** — `A·VOCAL B·VOCAL C·DRUM D·TEXTURE`. Reads `group.format_profile`.
+- **Last operation elapsed-time** — `"load manifest · 842ms"`. Reads `state.last_operation`.
+- **Live progress bar** — slides in when an SSE `progress` event fires for a long-running operation.
+- **State affected**: none.
+- **Workflow position**: "Will my deck fit?" + "did the last thing finish?"
+
+### 12.4 sf-remote — terminal CLI for firing UDP/OSC at the big device
+
+```bash
+uv run sf-remote fire <target> <verb> [<args>...]
+uv run sf-remote dump <dict-name>
+uv run sf-remote log [--follow]
+uv run sf-remote status
+uv run sf-remote setstate <canned-state-name>
+```
+
+#### Available `<target>`s (matched in `cmd_fire` allowlist)
+
+- `state` — fires into `sf_state_mgr`
+- `forge` — fires into `sf_forge`, the big device's orchestrator
+- `preset-loader` — fires into `sf_preset_loader`
+- `manifest-loader` — fires into `sf_manifest_loader`
+- `settings` — fires into `sf_settings`
+- `ui` — fires into `sf_ui`
+- `logger` — fires into `sf_logger`
+
+#### Key verbs the user actually fires today
+
+| Command | Effect |
+|---|---|
+| `sf-remote fire forge bounceTracks <manifest_path>` | Runs the BOUNCE pipeline (same as the BOUNCE button), writing the deck manifest to the given path |
+| `sf-remote fire forge commitOffsets <manifest_path>` | The disk-write variant of COMMIT. **This is the verb the COMMIT button SHOULD call but doesn't.** |
+| `sf-remote fire forge reload` | Tries to reload `stemforge_loader.v0.js`. PR #74 made this work via autowatch toggle. |
+| `sf-remote fire manifest-loader scanManifests` | Re-scan canonical manifest dirs |
+| `sf-remote fire manifest-loader load <path>` | Load a manifest by path (UDP-driven equivalent of the dropdown) |
+| `sf-remote fire forge startForge` | Equivalent to pressing the FORGE button |
+| `sf-remote dump sf_manifest` | Dump the current in-memory manifest dict |
+
+**Workflow position:** sf-remote is the "back door" for everything the device buttons should do but don't quite. Every workaround we hit involved sf-remote. The popup + strip both need to converge to NOT requiring sf-remote knowledge to do basic things.
+
+### 12.5 CLI (`stemforge` Click commands)
+
+Headless equivalents that compose with everything above.
+
+#### Marquee commands for the deck workflow
+
+| Command | What it does |
+|---|---|
+| `stemforge forge <audio>` | Full split → curate pipeline. Produces `~/stemforge/processed/<slug>/{stems.json, curated/manifest.json, prechop_manifest.json}`. |
+| `stemforge split <audio>` | Stems-only step. Produces `stems.json`. |
+| `stemforge deck-from-manifest <manifest> --out <deck.yaml>` | Reads `session_tracks` block from manifest, projects onto EP-133 deck.yaml format. |
+| `stemforge build-deck <deck.yaml> --out <out.ppak>` | Reads deck.yaml, writes `.ppak`. Final step of the verse-swap workflow. |
+| `stemforge export-song <manifest>` | Arrangement-view export (different from deck-mode). Uses `Ep133Projector.project_from_spec`. |
+| `stemforge re-anchor <slug>` | Re-cut prechop chunks at a new downbeat. |
+| `stemforge reslice-curated <slug>` | Re-cut curated bar loops at the current first downbeat. |
+
+#### Other commands (less central to the deck workflow)
+
+`analyze`, `clean-beats`, `create-templates`, `ep133-clear-pad`, `export`, `export-koala`, `generate-pipeline-json`, `list`, `route`.
+
+---
+
+## 13. The user's mental workflow — mapped to today's buttons
+
+Here's what an experienced user (you, Zak) does to build a new verse-swap deck today, mapping each step to the actual button/command they fire and what's broken:
+
+| # | What you want to do | Button / command you use today | Friction |
+|---|---|---|---|
+| 1 | Forge each source song from raw audio | `stemforge forge <audio>` (CLI) | Smooth — works via CLI |
+| 2 | Open the StemForge.als template in Live | (manual, in Ableton) | — |
+| 3 | Load the first source manifest into Live | StemForge.amxd: pick preset → pick source → click FORGE button (which functions as LOAD for an existing manifest) | Works but UX is muddled — "FORGE" means both "split audio" AND "load manifest" depending on source type |
+| 4 | Repeat for additional source songs | Same flow — clear the previous, load the next | Repeat |
+| 5 | Drag/rearrange clips across A/B/C/D | Live session view (drag) | Smooth |
+| 6 | Bounce the final arrangement to a deck manifest | `sf-remote fire forge bounceTracks <out-manifest-path>` (terminal) OR BOUNCE button in StemForge.amxd | Bounce button works but the OUTPUT path is hardcoded / depends on dialog; sf-remote path is reliable but requires terminal context |
+| 7 | Generate the .ppak | `stemforge deck-from-manifest <manifest> --out <yaml> && stemforge build-deck <yaml> --out <ppak>` (CLI) | Two-step CLI; could be one command |
+| 8 | Import on EP-133 | Drag-drop .ppak into Sample Tool → import as project | Smooth |
+| 9 | Want to tweak the deck later | (today, awkward): no clean re-open path. The big device's loader didn't accept deck-shape manifests until today's patch. Now it does, but COMMIT-button-doesn't-persist still bites. | The "iterate on an existing deck" loop is the most broken thing |
+
+The popup + strip are supposed to make steps 3, 6, 7, 9 cleaner. Today they don't.
+
+---
+
+## 14. What "consistent" should look like (architectural targets)
+
+If we were designing fresh, these are the invariants that would make the user's loop clean:
+
+1. **ONE verb set** — `LOAD`, `COMMIT`, `BOUNCE`, `EXPORT` — each defined once with one canonical implementation. Every UI surface (popup, strip, big device) calls into that one implementation.
+2. **ONE source of truth for the deck state** — likely the manifest file on disk (it's the artifact that crosses session boundaries). Live's LOM and the server's ProjectSpec are projections of the manifest; they read it on load, mutate it on commit.
+3. **ONE driver for LOM operations** — only Max [js] can drive LOM. So LOM-touching ops (load clips into tracks, walk Live, bounce) must originate from a Max device. Server fires UDP at the legacy device to drive LOM.
+4. **ONE failure mode** — operations succeed or surface a structured error. No "succeeds in Dict, fails on disk" silent-divergence.
+5. **The popup is the editor view**, the strip is a button panel, the big device is the LOM worker. None of them store independent state.
+
+---
+
+## 15. End of dump
+
+Take this to a fresh design session. The minimum questions to answer before any more code:
+
+1. Which surface owns "do the thing" vs "show the thing"?
+2. Where does the manifest file live in the lifecycle (read at load, written at commit, projected at export)?
+3. How does a non-Max process drive Live (or do we just refuse to try)?
+4. What's the strip's actual job — operations, or just a launcher?
+5. What gets deprecated — anything?

--- a/docs/configurator/EXECUTION_PLAN_v1.md
+++ b/docs/configurator/EXECUTION_PLAN_v1.md
@@ -1,0 +1,443 @@
+# Execution Plan — Configurator v1.0
+
+> Companion to `specs/CONSOLIDATED_DESIGN.md`. The spec describes the
+> destination; this document describes the path. Optimized for **maximum
+> parallelism**, **maximum autonomous execution**, and **maximum headless
+> testing** including Live-in-the-loop where unavoidable.
+
+---
+
+## Top-level shape
+
+```
+Phase 0:  Foundation  (sequential, ALL OTHER PHASES BLOCKED)
+  └── Pydantic schemas, TS-gen, max-stub.js, lom_snapshots fixtures, CI
+
+Phase 1:  Parallel migrations  (4 worktree agents simultaneously)
+  ├── Lane 1A: CLI file-shape migration
+  ├── Lane 1B: Server curation CRUD endpoints
+  ├── Lane 1C: Device picker + sniffer + LOAD-curation
+  └── Lane 1D: Popup UI restructure
+
+Phase 2:  COMMIT keystone  (sequential — depends on 1B + 1C)
+  └── End-to-end COMMIT + integration test (no Live needed)
+
+Phase 3:  Features  (3 worktree agents simultaneously)
+  ├── Lane 3A: Templates (.adg per-group)
+  ├── Lane 3B: BOUNCE refactor
+  └── Lane 3C: EXPORT via server
+
+Phase 4:  Polish  (2 worktree agents simultaneously)
+  ├── Lane 4A: Active-curation persistence
+  └── Lane 4B: Stale detection + strip deletion
+
+Phase 5:  Live-in-the-loop smoke suite  (sequential)
+  └── AppleScript harness + fixture .als + recorded LOM snapshots
+```
+
+**Estimated agent-runs**: 15. **Estimated PRs**: 22 (one per agent + the bookkeeping PRs in between).
+
+## The four testing layers
+
+Per spec §7. Every PR must contribute to one or more of these:
+
+| Layer | Surface | Speed | What it catches |
+|---|---|---|---|
+| **L1 unit** | pytest + vitest with no I/O | <1s per test | logic bugs |
+| **L2 integration (filesystem-only)** | pytest with pyfakefs, msw, fixture trees | <5s per test | wiring bugs, schema bugs |
+| **L3 device-JS via `max-stub.js` + `lom_snapshots`** | Node + stubbed Max globals + JSON-replayed LOM | <2s per test | LOM-walking + LOAD/COMMIT logic — **the historical pain killer** |
+| **L4 Live-in-the-loop smoke** | AppleScript-driven real Live + sf-remote assertions | 10-60s per test | wiring against real Max + LOM quirks |
+
+L1–L3 run on every PR. L4 runs gated on release / manually.
+
+## Phase 0 — Foundation
+
+**Goal**: lock down the contracts and build the test harness BEFORE any feature work. Every subsequent phase depends on this.
+
+This phase ships as **one PR** because the artifacts are tightly coupled.
+
+### Deliverables
+
+1. **Pydantic schemas** at `stemforge/configurator/schemas/`:
+   - `Curation` (curation file)
+   - `Pad`, `Group`, `Target`, `PadSource`, `ClipSettings`, `LastBounce`, `LastExport`
+   - `ForgeManifest` (auto-curation shape from spec §2.2)
+   - `ArrangementManifest` (arrangement-chunks shape from spec §2.2)
+   - `StemforgeState` (`.stemforge_state.json` from spec §2.4)
+   - All with `schema_version`/`curation_version` + frozen `model_config`
+2. **TS type generator** — `scripts/gen_typescript_types.py` that uses `datamodel-code-generator` (or hand-rolled JSON schema → TS) to write `web/configurator/src/lib/api-types.generated.ts`. Plus a CI step that diffs the regenerated output and fails if drifted.
+3. **`max-stub.js`** at `tools/test-harness/max-stub.js`:
+   - Stubs `Dict`, `LiveAPI`, `outlet`, `messnamed`, `post`, `arrayfromargs`, `Folder`, `File` (the minimum API surface the device JS touches today).
+   - Programmable: tests configure return values per LOM path.
+   - Records outlet emissions for assertion.
+   - Pre-seeds `lom_snapshot` JSON files (replay mode).
+4. **`lom_snapshots/`** library at `tests/fixtures/lom_snapshots/`:
+   - 5 starter snapshots: `empty-set.json`, `forge-loaded.json`, `staging-empty.json`, `staging-4-pads-stg-a.json`, `staging-full-46-pads.json`.
+   - Each is a JSON dump of LOM state at a specific moment (track list, clip slots, clip properties).
+   - Documented capture procedure (one-time, from real Live, via `sf-remote dump` plus a small capture script).
+5. **Fixture forges + curations** at `tests/fixtures/forges/` + `tests/fixtures/curations/`:
+   - 2 forge dirs with synthetic 1-second WAVs + valid manifests (auto-curation + arrangement).
+   - 4 curations: empty, partial, bounced, stale-reference.
+6. **CI workflows** at `.github/workflows/`:
+   - `ci-server.yml` — Python pytest + mypy + ruff
+   - `ci-popup.yml` — vitest + tsc + eslint
+   - `ci-cli.yml` — CliRunner tests
+   - `ci-device-js.yml` — Node vitest on device JS with max-stub
+   - `ci-types.yml` — Pydantic → TS regen + diff
+   - `ci-integration.yml` — pytest covering server ↔ CLI ↔ filesystem
+   - (`ci-smoke-live.yml` stub for Phase 5, not active yet)
+7. **Self-test of foundation**: 10+ tests proving every layer of harness actually works (mock LiveAPI returns the seeded path, stubbed Dict round-trips, schema parsing rejects malformed input, TS regen produces stable output).
+
+### Acceptance gates
+
+- All 7 CI workflows pass green.
+- `tests/fixtures/lom_snapshots/empty-set.json` loaded through `max-stub.js`, then `new LiveAPI("live_set").getcount("tracks")` returns the seeded value.
+- TS regeneration produces no diff against the committed file.
+- `Curation(**fixture).model_dump()` round-trips.
+
+---
+
+## Phase 1 — Parallel migrations (4 lanes)
+
+After Phase 0 lands, spawn 4 worktree-isolated agents in parallel. Each operates in disjoint file scope.
+
+### Lane 1A — CLI file-shape migration
+
+**Scope**: `stemforge/cli.py`, `stemforge/curator/*`, `stemforge/forge/*` — the Python source-pipeline side.
+
+**Inputs**: Phase 0 schemas.
+
+**Deliverables**:
+- `stemforge migrate-forge <slug>` command: takes an existing `~/stemforge/processed/<slug>/curated/manifest.json`, rewrites it as `auto_curation_manifest.json` with `schema_version: 1` and `manifest_hash`; extracts arrangement data into separate `arrangement_manifest.json`.
+- Both forge-writing code paths (`stemforge forge`, `stemforge curate-bars`, `stemforge re-anchor`, etc.) emit the new file shape.
+- `stemforge re-curate <slug>` new subcommand: re-runs auto-curation only (without re-running stem separation).
+- Compatibility shim in CLI to read both old and new shapes for one release.
+- Pydantic-validated reads of forge manifests.
+
+**Self-verification**: pytest CliRunner tests cover round-trip + migration of fixture forges.
+
+**PR scope**: ~600 lines. Title: `migrate(cli): forge file shape — split auto_curation + arrangement manifests`.
+
+### Lane 1B — Server curation CRUD
+
+**Scope**: `stemforge/configurator/{server,intents,state}.py` — replace the old ProjectSpec model with the new Curation model. Add the new endpoints from spec §4.3.
+
+**Inputs**: Phase 0 schemas + fixture curations.
+
+**Deliverables**:
+- `GET /curations` — scan `~/stemforge/curations/` directory.
+- `POST /curations` — create empty curation with target/groups.
+- `GET /curations/{name}` — return single curation.
+- `POST /curations/{name}/open` — set active (server-state mutation only at this phase; UDP-to-device wiring comes Phase 2).
+- `POST /curations/{name}/save-as` — file copy + active-switch.
+- `DELETE /curations/{name}`.
+- `PATCH /curations/{name}/template` — write template assignment.
+- `PATCH /curations/{name}/target`.
+- `POST /curations/{name}/commit` — accepts a device snapshot, validates, writes file atomically. **Server-side write path used by Phase 2's device walker.**
+- Atomic write helper: write `.tmp` + `rename`.
+- File-system lock for concurrent writers (simple flock).
+- SSE `state` event on every mutation.
+- Server-side `.stemforge_state.json` reader/writer (full impl deferred to Phase 4, but the file's existence is wired here so Phase 1A/C don't have to add their own state file).
+
+**Self-verification**:
+- Round-trip tests for every endpoint via FastAPI TestClient + pyfakefs.
+- Concurrent-write test (two simultaneous commits to same curation).
+- SSE broadcast test (subscribe, mutate, assert event arrives).
+
+**PR scope**: ~1500 lines. Title: `feat(server): curation CRUD endpoints + atomic write path`.
+
+### Lane 1C — Device picker + sniffer + LOAD-curation
+
+**Scope**: `v0/src/m4l-js/stemforge_loader.v0.js` + builder.
+
+**Inputs**: Phase 0 max-stub.js + lom_snapshots + schemas (TS types).
+
+**Deliverables**:
+- New `pickSource()` JS function — opens `[opendialog]`, sniffs the picked file's type (audio / forge_manifest / arrangement_manifest / curation), stores result in JS state.
+- Primary-button label switcher: `FORGE` / `LOAD FORGE` / `LOAD CURATION` based on picker state.
+- `loadCuration(yamlText)` JS function — parses curation YAML, creates `STG-A`..`STG-N` tracks per target (delete any pre-existing `STG-*` first), populates each pad slot via `loadClip()`, applies `clip_settings` (warp BPM, loop region).
+- Device patcher: replace the PRESET dropdown, SOURCE dropdown, and the LOAD/ANCH split-row with the new single `[Pick source…]` element and rearranged primary button.
+- Status text emits structured stages for L3 testability: `"sniffer: detected curation v1"`, `"staging: created STG-A through STG-D"`, `"staging: populated A·01 (vocal-bar4-8)"`, etc.
+
+**Self-verification**:
+- L3 device-JS tests via max-stub + lom_snapshots:
+  - Sniffer: given each fixture file type, returns correct routed type.
+  - loadCuration: given a fixture curation YAML and `empty-set` lom_snapshot, produces the expected sequence of LiveAPI calls.
+  - Track-rename / deletion idempotence: loading curation twice produces same final state.
+
+**PR scope**: ~1200 lines. Title: `feat(device): unified picker + LOAD-curation via staging tracks`.
+
+### Lane 1D — Popup UI restructure
+
+**Scope**: `web/configurator/src/` — replace the current LeftRail-centric layout with the three-panel layout from spec §3.2.
+
+**Inputs**: Phase 0 TS types + msw mocked server.
+
+**Deliverables**:
+- New panels: `ForgeList` (left rail), `ActiveCuration` (center), `CurationList` (right rail).
+- Top bar: active curation name + target chip + Save / Save-as / Close + connection.
+- Forge list panel: scan-driven, per-entry actions (Load/Unload/Re-anchor/Re-curate/Show in Finder).
+- Active curation panel: read-only grid view of pads, per-group template selector, label edit field, bounce/export status.
+- Curation list panel: per-entry Open / Duplicate / Rename / Delete.
+- All actions wire to the new server endpoints from Lane 1B.
+- Remove the old `LeftRail.tsx`'s drag-and-drop curation UI (kept only for the curation panel skeleton — content is replaced).
+- Stale-reference badge component (renders when curation's `referenced_forges.manifest_hash` ≠ current forge's hash).
+- "Pop out" button in TopBar that calls `window.open(location.href, "stemforge", "popup,width=1200,height=800")` for the macOS+Chrome new-window-resistant workaround (spec §6.8).
+
+**Self-verification**:
+- vitest + React Testing Library for each panel against msw-mocked server.
+- Snapshot tests for each panel's empty / populated / stale states.
+
+**PR scope**: ~2000 lines. Title: `feat(popup): three-panel restructure — forges / curation / curations`.
+
+### Phase 1 merge order
+
+1. Lane 1A first (CLI file shapes — everyone else's fixtures may depend).
+2. Lane 1B + 1C + 1D in any order (independent file scopes).
+
+---
+
+## Phase 2 — COMMIT keystone (sequential)
+
+**Goal**: per spec §11, this is "the keystone fix. Once this works, the architecture's promise holds." Built sequentially because it integrates Phase 1B + 1C end-to-end.
+
+This phase ships as **one PR**, possibly with helper PRs along the way.
+
+### Deliverables
+
+1. Device JS `commit()` function rewritten:
+   - Walks `STG-*` tracks (count from active curation's `target.groups`).
+   - For each clip slot, snapshots clip state into the Pad shape from spec §2.3.
+   - Sends UDP `commit <serialized-snapshot>` to server.
+2. Server `POST /curations/{name}/commit` handler:
+   - Receives device snapshot.
+   - Resolves `(forge_slug, clip_id)` for each pad's audio path (reverse-lookup against forge manifests).
+   - Writes curation file atomically.
+   - Broadcasts SSE.
+3. UDP receiver added to device's `[udpreceive 7420]` route table.
+4. End-to-end L3 integration test:
+   - Fixture: `lom_snapshots/staging-4-pads-stg-a.json`.
+   - Stub device → fixture filesystem → assert curation file content matches expected.
+   - **This test is the architecture's correctness check. Block merge on it.**
+5. The legacy `commitOffsets()` Dict-only path is removed.
+
+### Self-verification
+
+- L3 tests for the walker against multiple LOM-snapshot fixtures (empty, partial, full).
+- L2 tests for the server handler against fixture snapshots.
+- Integration test that runs the walker + handler end-to-end and verifies file contents.
+
+### PR scope
+
+~800 lines. Title: `feat: COMMIT end-to-end — device walker → server write path`.
+
+---
+
+## Phase 3 — Features (3 lanes parallel)
+
+After Phase 2 lands, spawn 3 worktree agents.
+
+### Lane 3A — Templates (.adg per-group)
+
+**Scope**: server, device JS, popup (template selector wiring).
+
+**Deliverables**:
+- Server endpoint: `GET /templates` scans `~/stemforge/templates/*.adg`.
+- Server endpoint: `PATCH /curations/{name}/template` writes assignment + fires UDP to device.
+- Device JS handles `template-changed <group> <template-name>` UDP message:
+  - Loads `<template-name>.adg` onto the `STG-<group>` track via `LiveAPI("live_set tracks N device 0").call("apply_param")` or whatever the LOM verb is for loading a rack onto a track.
+- Popup template selector dropdown wired to the PATCH endpoint.
+- L3 tests for the device JS template-load handler.
+- L2 tests for the server endpoint.
+
+**PR scope**: ~600 lines.
+
+### Lane 3B — BOUNCE refactor
+
+**Scope**: device JS bounce, server-side bounce-spec construction, integration tests.
+
+**Deliverables**:
+- Device JS `bounce()` reads from active curation's `curated_layout` (not from walking A/B/C/D directly).
+- For each pad with `source`: solo group track, trigger clip, freeze-and-crop via existing helpers, write WAV to `~/stemforge/bounced/<curation-name>/<pad-id>.wav`.
+- Update curation's `last_bounce` block via server.
+- Server endpoint: `POST /curations/{name}/trigger-bounce` fires UDP at device.
+- L3 tests for the bounce-spec construction (which slots, in which order, with which templates baked).
+- The actual WAV rendering still requires Live (deferred to Phase 5 smoke); but the CONTROL of the bounce is testable.
+
+**PR scope**: ~700 lines.
+
+### Lane 3C — EXPORT via server
+
+**Scope**: server endpoint, CLI wiring.
+
+**Deliverables**:
+- Server endpoint `POST /curations/{name}/export` body `{out_path, target_format}`.
+- Server runs `stemforge export <curation-name> --target ep133 --out <path>` subprocess.
+- Server updates `last_export` block.
+- Popup "Export to .ppak…" button uses osascript save-dialog (existing pattern from PR #99 era) to pick the out_path, then fires the endpoint.
+- L2 tests for the server-side wiring (mocked subprocess).
+
+**PR scope**: ~400 lines.
+
+---
+
+## Phase 4 — Polish (2 lanes parallel)
+
+### Lane 4A — Active-curation persistence
+
+**Scope**: server `.stemforge_state.json` read/write, device sends current `.als` path on boot.
+
+**Deliverables**:
+- Server reads `.stemforge_state.json` at startup; writes on every active-curation change.
+- Device JS sends `als-opened <path>` UDP on `loadbang`.
+- Server responds with `set-active-curation <name>` if it knows one for that `.als`.
+- L2 tests for the state file round-trip.
+- L3 tests for the device-side bootstrap message.
+
+**PR scope**: ~350 lines.
+
+### Lane 4B — Stale detection + strip deletion
+
+**Scope**: server stale-check, popup stale badge, delete strip device.
+
+**Deliverables**:
+- Server computes `referenced_forges[i].manifest_hash` vs current forge's `manifest_hash` at every state broadcast.
+- Marks pads as stale in the broadcast.
+- Popup renders stale badge.
+- Popup `Refresh from forge` button → server endpoint that re-derives pad refs.
+- **Delete** `v0/src/m4l-devices/configurator-strip/` and `v0/build/ConfiguratorStrip.amxd`.
+- Move "Open Editor" button into `StemForge.amxd`'s footer (the spec's §3.1 layout).
+- Close PR #99 with a comment pointing at this PR.
+
+**PR scope**: ~600 lines.
+
+---
+
+## Phase 5 — Live-in-the-loop smoke suite (sequential)
+
+**Goal**: build the L4 layer so we can verify Phase 1–4 actually works on real Live without manual clicking.
+
+### Deliverables
+
+1. `tools/test-harness/live-runner.sh`:
+   - Uses AppleScript to open Live + load a fixture `.als`.
+   - Waits for the device's `[udpreceive]` to come up (heartbeat).
+   - Runs a series of `sf-remote fire ...` commands against the live device.
+   - Captures `sf-remote dump` state at each checkpoint.
+   - Asserts captured state matches expected.
+   - Reports pass/fail.
+2. Fixture `.als` files at `tests/fixtures/als/`:
+   - `empty-staging.als` — fresh template, just the strip + device.
+   - `loaded-forge-stg-empty.als` — a forge loaded, no staging populated.
+   - `curation-active-stg-populated.als` — active curation, staging populated.
+3. **5–10 smoke tests** scripted via the runner:
+   - Smoke 1: open empty .als → device boots → `sf-remote dump` shows no active curation.
+   - Smoke 2: load fixture forge → assert FORGE/* tracks created with correct clip count.
+   - Smoke 3: create curation → assert staging tracks created with correct count for target.
+   - Smoke 4: COMMIT → assert curation file written with correct content.
+   - Smoke 5: load curation from disk → assert staging populated correctly.
+   - Smoke 6: switch active curation → assert staging repopulated.
+   - Smoke 7: re-anchor → assert forge manifests updated + tracks reloaded.
+   - Smoke 8: bounce → assert bounce dir populated with correct # of WAVs.
+   - Smoke 9: export → assert `.ppak` produced.
+   - Smoke 10: stale detection → mutate forge, assert popup state shows stale.
+4. `.github/workflows/ci-smoke-live.yml`:
+   - Triggered manually (`workflow_dispatch`).
+   - Runs on a self-hosted runner with Live + StemForge installed.
+   - Executes `live-runner.sh`.
+   - Reports per-test pass/fail.
+5. README at `tests/fixtures/als/README.md`:
+   - How to record new `.als` fixtures.
+   - How to capture LOM snapshots for L3 tests.
+
+**PR scope**: ~1500 lines (mostly the runner script + smoke test definitions; fixtures are binary).
+
+---
+
+## Per-phase parallelism plan (for agent dispatch)
+
+| Phase | Sequential / Parallel | # Agents | Wait gate |
+|---|---|---|---|
+| 0 | sequential | 1 | — |
+| 1 | parallel (4 lanes) | 4 | after Phase 0 lands |
+| 2 | sequential | 1 | after Phase 1A + 1B + 1C land |
+| 3 | parallel (3 lanes) | 3 | after Phase 2 lands |
+| 4 | parallel (2 lanes) | 2 | after Phase 3 lands |
+| 5 | sequential | 1 | after Phase 4 lands |
+
+Total **12 parallel-or-sequential agent runs** across the whole plan (plus phase-prep coordination by the main orchestrator).
+
+---
+
+## Self-verification at every step
+
+**Every agent's deliverable must include**:
+
+1. ✅ Tests at the highest applicable layer (L1/L2/L3) — block PR merge on green.
+2. ✅ Self-consistency: schemas → TS regen → no drift. CI enforces.
+3. ✅ Acceptance summary in the PR description listing which tests cover which behaviors.
+4. ✅ A small `INTEGRATION.md` note in the PR if the agent expects another phase to touch related code.
+
+**No agent merges without**:
+- All L1/L2/L3 CI workflows green.
+- At least 5 new tests per lane (Phase 1) or 3 per lane (Phases 3-4).
+- Coverage of at least one negative-control case per major code path.
+
+**Phase-level merge gate**:
+- All PRs in the phase merged.
+- A 5-minute integration smoke runs end-to-end via the harness against the new code (without Live for Phases 0–4; with Live for Phase 5).
+
+---
+
+## What the orchestrator (main session) does
+
+- Spawns each phase's agents with self-contained briefs.
+- Verifies CI green on each PR before approving for merge.
+- Maintains the cross-phase invariants:
+  - Schemas are the source of truth — anyone editing them coordinates with the TS regen.
+  - lom_snapshot fixtures are versioned; agents extend, never break, the existing snapshots.
+  - The `Curation` Pydantic shape never silently drifts.
+- Between phases: drives the merge of in-flight PRs (re-targeting, rebase conflicts).
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Pydantic ↔ TS drift in real time | `ci-types.yml` regenerates and diffs on every PR. |
+| Phase 1 agents stepping on each other's tests | Disjoint test directories; CI enforces no cross-import. |
+| Phase 2 COMMIT path needs Live to verify | L3 max-stub + lom_snapshots replays Live state; Phase 5 final verification. |
+| lom_snapshots get stale as Live versions change | Versioned by Live major; capture script in Phase 0 deliverable. |
+| AppleScript Live driver unreliable on different macOS | Live-runner has graceful fallback; smoke tests degrade to "skipped" rather than "failed" on environment issues. |
+| Strip deletion breaks something nobody noticed | Phase 4B keeps the `Open Editor` button moved to the main device; smoke test 1 catches regression. |
+
+---
+
+## File-by-file ownership across phases
+
+To prevent agent collisions, here's who owns what:
+
+| Path | Phase / Lane owner |
+|---|---|
+| `stemforge/configurator/schemas/` | Phase 0 (created), Phase 1B + 3A (extend) |
+| `stemforge/configurator/server.py` | Phase 1B, Phase 2, Phase 3A/B/C, Phase 4A/B |
+| `stemforge/configurator/intents.py` | same |
+| `stemforge/cli.py` | Phase 1A, Phase 3C |
+| `v0/src/m4l-js/stemforge_loader.v0.js` | Phase 1C, Phase 2, Phase 3A/B, Phase 4A/B |
+| `v0/src/m4l-js/stemforge_loader.v0.js` (deploy copy) | always mirrored |
+| `web/configurator/src/lib/api-types.generated.ts` | Phase 0 (generated), regenerated on schema changes |
+| `web/configurator/src/components/` | Phase 1D, Phase 3A/B/C, Phase 4B |
+| `tools/test-harness/max-stub.js` | Phase 0 (created), all subsequent (extended) |
+| `tests/fixtures/lom_snapshots/` | Phase 0 (seeded), all subsequent (extended) |
+| `tests/fixtures/als/` | Phase 5 |
+| `.github/workflows/ci-*.yml` | Phase 0 (created); Phase 5 (activates smoke) |
+| `v0/src/m4l-devices/configurator-strip/` | Phase 4B (deleted) |
+
+Phases with same-file ownership are SEQUENTIAL; phases with disjoint ownership run in PARALLEL.
+
+---
+
+## Phase 0 starts now
+
+Spawning the Phase 0 worktree agent immediately after this plan commits. Phases 1+ launch on Phase 0 merge.

--- a/specs/CONSOLIDATED_DESIGN.md
+++ b/specs/CONSOLIDATED_DESIGN.md
@@ -1,0 +1,855 @@
+# StemForge Configurator — Design Spec v1.0
+
+> Supersedes `CURRENT_STATE_DUMP_2026-05-13.md`. Authored 2026-05-13 after a
+> design conversation that unwound the multi-source-of-truth mess into a clean
+> three-noun model. The goal of this document is to be implementable: a fresh
+> Claude Code session should be able to take this and build/refactor toward it
+> without further design negotiation.
+
+---
+
+## 0. TL;DR for the impatient
+
+- **Three nouns**: `forge` (source material on disk), `curation` (the persistable curated artifact), `staging` (the in-Live editing surface).
+- **One Max device** drives Live. **One web popup** orchestrates and inspects. `ConfiguratorStrip.amxd` is **deleted**.
+- **Five verbs**: `FORGE`, `LOAD`, `COMMIT`, `BOUNCE`, `RE-ANCHOR`. Each has one meaning, one owner, one writer.
+- **Staging tracks** (`STG-A`..`STG-N`, count determined by target device) are the **only** clip-backed connection between Live and the curation. The popup never sees Live's clip state directly. Live never sees the popup's curation directly. Both project through the curation file on disk.
+- **Curations are documents**: named, persistable, scoped to one curation pass. The popup browses them; the device's COMMIT writes them.
+- **No drag-and-drop curation in the popup**. Curation happens in Live (drag from forge tracks to staging). The popup edits curation *metadata* (target, templates, name) and triggers operations.
+- **Testing**: aggressive automation. Most of the system is testable headlessly — the curation file is the contract, the device's COMMIT/LOAD/BOUNCE can be exercised via UDP without human clicking, and the popup is React + a typed API. The Live-in-the-loop dependency is isolated to one well-defined boundary.
+
+---
+
+## 1. Concepts and vocabulary
+
+### 1.1 Forge
+
+A **forge** is the output of running the StemForge pipeline on a single audio file. It produces a set of files on disk under `~/stemforge/processed/<slug>/`:
+
+- `arrangement_manifest.json` — describes the arrangement-view chunks (longer, song-position-anchored sections of the source).
+- `auto_curation_manifest.json` — describes the auto-curated short clips (loops, hits, snippets) suitable for pad assignment.
+- `stems/` — the raw separated stems (drum, bass, vocal, other).
+- `curated_audio/` — short WAV files referenced by `auto_curation_manifest.json`.
+- `arrangement_chunks/` — WAV files referenced by `arrangement_manifest.json`.
+
+A forge has a **slug** (e.g. `breaks-n-beats-1`) which is its identifier across the system. Forges live independently on disk; the system discovers them by scanning `~/stemforge/processed/`.
+
+### 1.2 Curation
+
+A **curation** is a named, persistable artifact representing one curation pass: which clips go in which pads, which config templates apply per group, what target device, when it was last bounced/exported. Curations live at `~/stemforge/curations/<name>.yaml`.
+
+A curation is the unit of work the user iterates on. Examples: `verse_swap_v1`, `live_set_oct_2026`, `breaks-n-beats-deck`. A curation references one or more forges by slug; it does not embed clip audio (which lives in the referenced forges' `curated_audio/` or `arrangement_chunks/`).
+
+Curations have a `type`: `deck` for hardware-export-shaped curations (target device pad grid) and `arrangement` reserved for v2 (scene-based curations for Flow B). **v1 implements `deck` only**; the `type` field exists in the schema for forward compatibility.
+
+### 1.3 Staging
+
+**Staging tracks** are a set of specially-named Live tracks (`STG-A`, `STG-B`, ...) whose contents reflect the active curation's `curated_layout`. The number and identity of staging tracks is determined by the curation's target device:
+
+- EP-133 → 4 staging tracks (`STG-A` through `STG-D`)
+- (Future targets) → different counts and naming
+
+Staging tracks are the **only** path for clip-level data to flow between Live and the curation:
+
+- **Curation → staging** happens on `LOAD curation` (one-shot population from disk).
+- **Staging → curation** happens on `COMMIT` (the device walks staging and writes to the active curation file).
+
+Non-staging tracks in Live (e.g. `FORGE/<slug>/*` source tracks, user-added audition tracks) are **invisible to the curation**. Edits there don't affect the curation; they exist for the user to audition and assemble material before deciding what to commit.
+
+### 1.4 Active curation
+
+At any moment, there is at most one **active curation** in the system. The active curation is:
+
+- The curation whose `curated_layout` is currently mirrored in staging.
+- The destination of the next `COMMIT`.
+- Persisted server-side (not in the `.als`), keyed by Live's project file path, so it survives Live restarts.
+
+If no curation is active, `COMMIT` is an error and the popup prompts the user to create or open one.
+
+### 1.5 Global workspace vs local workspace (vocabulary only)
+
+These are descriptive terms, not data structures:
+
+- **Global workspace** = everything StemForge knows about on disk: all forges, all curations, all templates. The popup is a window into the global workspace.
+- **Local workspace** = the subset currently materialized in Live: forge tracks that have been loaded, staging tracks for the active curation. Lives in the `.als` file.
+
+The system has no "workspace" file. The global workspace is just "what's under `~/stemforge/`." The local workspace is just "what's in the current `.als`."
+
+### 1.6 Config template
+
+A **config template** is a Live device rack (`.adg` file) stored under `~/stemforge/templates/<name>.adg`. Templates are authored by the user in Ableton (Save Device Group). Templates apply **per-group**, not per-pad, in v1.
+
+When a template is assigned to a curation group (e.g. group `A` → template `dry-direct`), the device loads the corresponding `.adg` onto the `STG-A` staging track. `BOUNCE` renders staging through Live, so the template's effect chain is baked into bounced audio.
+
+Templates also apply to `FORGE/<slug>/*` source tracks at forge-load time, using the forge's `default_template` field (or a system default if unset).
+
+---
+
+## 2. Data model
+
+### 2.1 Filesystem layout
+
+```
+~/stemforge/
+  processed/                      # one subdir per forge, scanned for the catalog
+    <forge-slug>/
+      arrangement_manifest.json
+      auto_curation_manifest.json
+      stems/
+        drum.wav
+        bass.wav
+        vocal.wav
+        other.wav
+      curated_audio/
+        <clip-id>.wav             # referenced by auto_curation_manifest
+      arrangement_chunks/
+        <chunk-id>.wav            # referenced by arrangement_manifest
+
+  curations/                      # one file per curation
+    <curation-name>.yaml
+
+  templates/                      # Ableton device racks
+    <template-name>.adg
+
+  bounced/                        # one subdir per curation, regenerated by BOUNCE
+    <curation-name>/
+      <pad-id>.wav
+      bounce_manifest.json
+
+  exports/                        # one file per export
+    <curation-name>.ppak
+
+  .stemforge_state.json           # server-side runtime state (active curation per .als)
+  .configurator_port              # port file (unchanged from current)
+```
+
+### 2.2 Forge manifest schemas
+
+**`auto_curation_manifest.json`**:
+
+```json
+{
+  "schema_version": 1,
+  "forge_slug": "breaks-n-beats-1",
+  "source_audio": "/path/to/original.wav",
+  "bpm": 138.0,
+  "first_downbeat_sec": 0.142,
+  "manifest_hash": "<sha256 of clips array>",
+  "default_template": "dry-direct",
+  "clips": [
+    {
+      "clip_id": "drum-bar4-8",
+      "audio_path": "curated_audio/drum-bar4-8.wav",
+      "stem": "drum",
+      "source_bar_range": [4, 8],
+      "duration_bars": 4,
+      "tags": ["loop", "tight"]
+    }
+  ]
+}
+```
+
+**`arrangement_manifest.json`**:
+
+```json
+{
+  "schema_version": 1,
+  "forge_slug": "breaks-n-beats-1",
+  "source_audio": "/path/to/original.wav",
+  "bpm": 138.0,
+  "first_downbeat_sec": 0.142,
+  "manifest_hash": "<sha256 of chunks array>",
+  "chunks": [
+    {
+      "chunk_id": "drum-section-1",
+      "audio_path": "arrangement_chunks/drum-section-1.wav",
+      "stem": "drum",
+      "source_position_sec": 0.142,
+      "duration_sec": 14.2,
+      "bar_position": 0,
+      "duration_bars": 8
+    }
+  ]
+}
+```
+
+The `manifest_hash` field is the SHA-256 of the canonicalized clips/chunks array. It's the stale-reference detection mechanism for curations: a curation stores the manifest_hash it was last committed against; if the forge's hash has changed, the popup surfaces "this curation references a forge that has been modified."
+
+**Critical**: re-running auto-curation rewrites `auto_curation_manifest.json` but **never touches `curations/*.yaml`**. The stale-detection at the curation side is how the system stays safe across re-curations.
+
+### 2.3 Curation file schema
+
+```yaml
+curation_version: 1
+name: verse_swap_v1
+type: deck                          # deck | arrangement (v2)
+created_at: 2026-05-10T14:22:00Z
+modified_at: 2026-05-13T09:14:00Z
+
+target:
+  device: ep133
+  groups: 4
+  pads_per_group: 12
+
+referenced_forges:                  # derived from pad sources at COMMIT time
+  - slug: breaks-n-beats-1
+    manifest_hash: "abc123..."      # auto_curation_manifest hash at last commit
+  - slug: dub-vault-3
+    manifest_hash: "def456..."
+
+groups:
+  A:
+    label: "Vocals"
+    template: "dry-direct"
+    pads:
+      - pad_id: A01
+        source:
+          forge: breaks-n-beats-1
+          clip_id: "vocal-bar12-16"
+          audio_path: "curated_audio/vocal-bar12-16.wav"  # cached resolved path
+        clip_settings:
+          warp_bpm: 138.0           # captured from Live at commit
+          loop_start_bar: 0
+          loop_end_bar: 4
+      - pad_id: A02
+        source:
+          forge: dub-vault-3
+          clip_id: "vocal-alt-bar4"
+          audio_path: "curated_audio/vocal-alt-bar4.wav"
+      - { pad_id: A03 }             # empty pad
+      # ... 12 total pads, empty ones are objects with just pad_id
+  B:
+    label: "Drums"
+    template: "tight-compressed"
+    pads: [...]
+  C:
+    label: "FX"
+    template: null                  # no template = dry passthrough
+    pads: [...]
+  D:
+    label: "Bass"
+    template: "warm-saturated"
+    pads: [...]
+
+last_bounce:
+  bounced_at: 2026-05-13T09:30:00Z
+  manifest_path: "bounced/verse_swap_v1/bounce_manifest.json"
+  pad_audio_hashes:                 # for diff detection on next bounce
+    A01: "sha256..."
+    A02: "sha256..."
+
+last_export:
+  exported_at: 2026-05-13T09:35:00Z
+  target_format: ppak
+  output_path: "exports/verse_swap_v1.ppak"
+```
+
+**Schema rules**:
+
+- Empty pads are present in the list as `{ pad_id: X }` with no `source`. Don't omit them — the pad ordering and identity is preserved.
+- `audio_path` in the `source` block is denormalized (also derivable from forge + clip_id) for resilience: if the forge moves on disk, the recorded path may still resolve. Always recompute it from the forge manifest at LOAD time for safety.
+- `clip_settings` captures Live-side clip state at COMMIT (warp BPM, loop region, etc) so that on next LOAD the staging clip is restored faithfully.
+- `referenced_forges` is computed at COMMIT from the union of pad sources.
+
+### 2.4 Server-side runtime state
+
+`~/stemforge/.stemforge_state.json`:
+
+```json
+{
+  "schema_version": 1,
+  "active_curation_by_als": {
+    "/Users/zak/Music/Ableton/Verse Swap.als": "verse_swap_v1",
+    "/Users/zak/Music/Ableton/Mashup Lab.als": "breaks-n-beats-deck"
+  },
+  "last_known_port": 7430,
+  "last_seen_at": "2026-05-13T09:14:00Z"
+}
+```
+
+This is the **only** persistent runtime state outside of curation files. It's small, server-owned, and survives Live restarts so the popup can re-attach to "the right curation" when Live reopens a known `.als`.
+
+---
+
+## 3. Surfaces and their roles
+
+### 3.1 StemForge.amxd (the one Max device)
+
+**Physical layout** (820×149, unchanged dimensions):
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  LEFT (x 0-716)              CENTER                  RIGHT (x 716-820)  │
+│  ┌─────────────────────┐                            ┌───────────────┐   │
+│  │ [ Pick source… ]    │     (status text +         │ FORGE / LOAD  │   │
+│  │ <picked path/type>  │      progress / phase)     │  (label varies)   │
+│  └─────────────────────┘                            ├───────────────┤   │
+│                                                     │ COMMIT        │   │
+│                                                     ├───────────────┤   │
+│                                                     │ BOUNCE        │   │
+│                                                     ├───────────────┤   │
+│                                                     │ RE-ANCHOR     │   │
+│                                                     └───────────────┘   │
+│  [ Open Editor ]    ● connected · http://127.0.0.1:7430 · v1.0          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Buttons** — only these. No PRESET dropdown, no SOURCE dropdown, no separate LOAD/ANCH split-row, no EXPORT button:
+
+| Slot | Label | Enabled when | What it does |
+|------|-------|--------------|--------------|
+| Picker | `Pick source…` | always | Opens native file dialog (`[opendialog]`). Accepts audio (`.wav .aiff .mp3 .flac`) or text (`.json .yaml`). Sniffs the picked file: audio → `picked.type = "audio"`. JSON → peek shape: `arrangement_manifest` / `auto_curation_manifest` / forge directory → `"forge_manifest"`. YAML → if `curation_version` present → `"curation"`. Status text updates: `"audio: my-track.wav — ready to FORGE"` or similar. |
+| Primary | `FORGE` (audio) / `LOAD FORGE` (forge manifest) / `LOAD CURATION` (curation) | source picked, no op running | Audio: runs forge pipeline via CLI subprocess. Forge manifest: creates `FORGE/<slug>/*` tracks, loads auto-curation into session view and arrangement chunks into arrangement view, applies default template. Curation: creates/recreates staging tracks per target, populates from `curated_layout`, applies templates per group, sets active curation. |
+| COMMIT | (fixed) | active curation set, staging tracks present | Walks `STG-*` tracks, snapshots each slot's clip (source resolution, `clip_settings`), writes to active curation's YAML file via the server. |
+| BOUNCE | (fixed) | active curation set, staging populated | Renders each staging slot's clip through Live (track freeze + crop, baking the group's template chain), writes WAVs to `~/stemforge/bounced/<curation>/`, updates curation's `last_bounce`. |
+| RE-ANCHOR | (fixed) | a forge is the "active forge" (last loaded, or selected in popup) | Reads first Live locator → fires CLI `stemforge re-anchor <slug>` → reloads the forge's tracks in Live. Updates `arrangement_manifest.json` and `auto_curation_manifest.json` (new manifest_hash). |
+
+**Footer**:
+
+- `[ Open Editor ]` button — fires `messnamed("max", "launchbrowser", server_url)`. The only [shell]-free way that's proven to work.
+- Connection dot — green when server reachable, red when not. Fix the bgcolor re-paint bug from §6.9 of the dump by using a `[live.text]` with a single dynamic color rather than re-issuing bgcolor.
+- Version stamp.
+
+**What this device does NOT have**:
+
+- No PRESET dropdown. Presets-as-pipeline-configs are CLI args at FORGE time; presets-as-effect-chains are config templates.
+- No SOURCE dropdown. The picker replaces it.
+- No EXPORT button. Export lives in the popup (target-specific, output-path-specific — popup territory).
+- No separate LOAD button distinct from FORGE. One primary action button whose label/behavior switches based on picker state.
+- No ANCH button distinct from RE-ANCHOR. There's one re-anchor verb.
+
+### 3.2 The popup (web UI)
+
+**Purpose**: inspector for the global workspace + orchestrator for curation lifecycle. Not a clip editor.
+
+**Top bar**:
+
+- Active curation name (or "no curation active")
+- Target device chip
+- Save / Save as / Close active curation
+- Connection status (SSE state)
+
+**Left rail — Forges**:
+
+- List of all forges discovered under `~/stemforge/processed/` (scan-based).
+- Each forge: name, BPM, source path, clip counts (auto-curation + arrangement chunks), "loaded in Live" indicator if currently materialized, "stale" indicator if manifest_hash has changed since active curation last referenced it.
+- Per-forge actions: `Load into Live`, `Unload from Live`, `Re-anchor`, `Re-curate`, `Show in Finder`.
+- `Add forge…` button (file picker → calls server which dispatches device LOAD-forge).
+
+**Center — Active curation**:
+
+- If no active curation: empty state with "New curation…" and "Open curation…" buttons.
+- If active: read-only grid view of `curated_layout` (target-shaped). Each pad shows clip name, source forge, bar range, "stale" badge if forge has changed.
+- Per-group: template selector (dropdown of available templates), label field (editable), "load template to STG-X" indicator showing which template is currently applied in Live.
+- Below grid: bounce status, export status, action buttons (Trigger BOUNCE in Live, Export to .ppak…).
+
+**Right rail — Curations**:
+
+- List of all curations under `~/stemforge/curations/`.
+- Each: name, target, modified_at, last bounce/export timestamps, "active" badge if it's the active curation.
+- Per-curation actions: `Open as active`, `Duplicate`, `Rename`, `Delete`.
+
+**No drag-and-drop curation UI.** No clip browser as a drop source. Pad assignments are not editable in the popup. They are display-only, reflecting the state of the active curation as last committed.
+
+### 3.3 CLI
+
+Unchanged in scope from current state. Verbs:
+
+- `stemforge forge <audio>` — produces `processed/<slug>/{arrangement_manifest, auto_curation_manifest}.json` + audio outputs.
+- `stemforge re-anchor <slug> --downbeat-sec <s>` — re-cut a forge's chunks at a new downbeat.
+- `stemforge re-curate <slug> [--params...]` — re-run auto-curation only.
+- `stemforge bounce <curation-name>` — headless bounce. **Not** the same as the device's BOUNCE button (which requires Live). This is a degraded fallback: it renders pad audio from the source forge through a Python approximation of the template (or just dry, in v1). Useful for CI tests; user-facing BOUNCE goes through the device.
+- `stemforge export <curation-name> --target ep133 --out <path>.ppak` — builds the `.ppak` from the curation's last bounce.
+
+The server proxies these for the popup.
+
+### 3.4 sf-remote
+
+Unchanged in role: UDP transport for firing verbs at the legacy device. Still exists as the "back door" for debugging and as the transport the server uses to drive the device.
+
+---
+
+## 4. Verbs, ownership, transports
+
+### 4.1 The verb table
+
+| Verb | Owner (writer) | Transport | Trigger surfaces |
+|------|---------------|-----------|------------------|
+| FORGE | CLI subprocess | direct invocation by device JS | device (FORGE button), popup (Add forge…) |
+| LOAD forge | Device Max JS (LOM) | device → LOM | device (LOAD FORGE), popup (Load into Live) |
+| LOAD curation | Device Max JS (LOM) + server (active curation state) | device → LOM + server | device (LOAD CURATION), popup (Open as active) |
+| COMMIT | Device Max JS (walks LOM, writes via server) | device → server → file | device (COMMIT) — only |
+| BOUNCE | Device Max JS (track freeze + crop) | device → LOM + server (writes bounce manifest) | device (BOUNCE), popup (Trigger BOUNCE in Live → UDP → device button) |
+| RE-ANCHOR | CLI subprocess | device → CLI | device (RE-ANCHOR), popup (Re-anchor) |
+| EXPORT | CLI subprocess | server → CLI | popup (Export to .ppak…) — only |
+| Unload forge | Device Max JS | device ← UDP from server | popup (Unload from Live) |
+| Save as | Server (file copy + rename) | popup → server | popup |
+| Switch active curation | Server + LOAD curation cascade | popup → server → UDP → device | popup |
+
+**Rules enforced by this table**:
+
+1. **Curation files are written by exactly one path**: device COMMIT → server → file. Server proxies the write; device originates it.
+2. **Forge manifests are written by exactly one path**: CLI (forge, re-curate, re-anchor) → file.
+3. **Live's LOM is touched by exactly one process**: the Max device. Everything else fires UDP at it.
+4. **The popup never writes curation files directly**. It fires intents at the device which then COMMITs. The two exceptions are *metadata* edits (template assignment, group labels, target change) which the server writes directly because they don't require walking Live — but the server still writes through a single guarded path that all writers share (locking, atomic rename).
+
+### 4.2 Transports — what works, what doesn't
+
+From the 2026-05-13 debugging session:
+
+- ✅ UDP (`[udpreceive]`): works. Server fires UDP at port 7420 to trigger device verb handlers.
+- ✅ `messnamed("max", "launchbrowser", url)`: works. Footer's Open Editor uses this.
+- ✅ Server-side `osascript`: works. Native file dialogs from the server (used for popup's Add forge…, etc).
+- ❌ `[shell]` in M4L sandbox: does not fire `exec` commands. **Don't use it for anything.**
+- ✅ SSE (`event: state\ndata: <json>`): works once frontend uses `addEventListener("state", ...)` (the fix from §6.5 of the dump).
+
+The single transport rule: **device ⟷ server uses UDP and SSE**. UDP is server-to-device (intent firing). SSE is server-to-popup (state push). HTTP is popup-to-server (intents from UI). `[shell]` is dead.
+
+### 4.3 Server intents (popup → server HTTP, server → device UDP)
+
+The popup talks to the server via HTTP. The server, on receipt, may write to disk and/or fire UDP at the device. SSE pushes state updates back to the popup. Endpoint catalog:
+
+| Endpoint | Method | Body | Effect |
+|----------|--------|------|--------|
+| `/forges` | GET | — | Scan `~/stemforge/processed/`, return forge index. |
+| `/forges/{slug}/load` | POST | — | UDP → device: `forge load <slug>`. |
+| `/forges/{slug}/unload` | POST | — | UDP → device: `forge unload <slug>`. |
+| `/forges/{slug}/re-anchor` | POST | `{downbeat_sec}` | CLI `re-anchor`, then UDP → device: reload. |
+| `/forges/{slug}/re-curate` | POST | `{params}` | CLI `re-curate`, then UDP → device: reload if loaded. |
+| `/curations` | GET | — | Scan `~/stemforge/curations/`. |
+| `/curations` | POST | `{name, target}` | Create empty curation file. UDP → device: create staging, set active. |
+| `/curations/{name}/open` | POST | — | Set active. UDP → device: populate staging from curation. |
+| `/curations/{name}/save-as` | POST | `{new_name}` | Copy file. Set new as active. |
+| `/curations/{name}` | DELETE | — | Delete file (if not active). |
+| `/curations/{name}/template` | PATCH | `{group, template_name}` | Update curation file. UDP → device: load template rack on group's staging track. |
+| `/curations/{name}/target` | PATCH | `{device, groups, pads_per_group}` | Update curation file. UDP → device: recreate staging tracks for new target. |
+| `/curations/{name}/export` | POST | `{out_path, target_format}` | CLI `export` against curation's last bounce. |
+| `/curations/{name}/trigger-bounce` | POST | — | UDP → device: fire BOUNCE button. |
+| `/state/stream` | GET (SSE) | — | Server-sent events for state changes. |
+
+The device-side UDP receiver is `[udpreceive 7420]` in the existing infrastructure. Add handlers for the new verbs that aren't already covered.
+
+---
+
+## 5. Workflows — walked step-by-step
+
+### 5.1 First-time forge from raw audio
+
+1. User clicks `Pick source…` on the device. Picks `~/Music/raw/my-track.wav`.
+2. Device status: `"audio: my-track.wav — ready to FORGE"`. Primary button label changes to `FORGE`.
+3. User clicks `FORGE`.
+4. Device JS spawns CLI subprocess: `stemforge forge ~/Music/raw/my-track.wav`. Phase updates stream to status.
+5. CLI completes. Writes `~/stemforge/processed/my-track/{arrangement_manifest, auto_curation_manifest}.json` + audio outputs.
+6. Status: `"forged: my-track (138 BPM, 47 clips, 12 arrangement chunks). Click LOAD to bring into Live, or open the editor."`
+7. **Nothing is in Live yet.** The user can now use the popup or the device to load it.
+
+### 5.2 Loading a forge into Live
+
+1. User clicks `Pick source…`, picks the forge manifest. Device sniffs → curation type `forge_manifest`, primary becomes `LOAD FORGE`.
+2. User clicks `LOAD FORGE`.
+3. Device JS creates Live tracks: `FORGE/my-track/drum`, `.../bass`, `.../vocal`, `.../other`.
+4. Each track gets the forge's `default_template` (or system default) loaded as an effect rack.
+5. Session view slots on each track populated from `auto_curation_manifest.clips` (filtered by stem).
+6. Arrangement view populated from `arrangement_manifest.chunks` (filtered by stem).
+7. Status: `"loaded forge my-track (4 tracks, 47 session clips, 12 arrangement chunks)"`.
+
+Alternative trigger: popup's `Load into Live` button on the forge entry. Fires `/forges/my-track/load` → server UDP → device runs the same code path.
+
+### 5.3 Creating and committing a curation
+
+1. User has forge `my-track` loaded. Wants to start a new curation.
+2. In popup, clicks `New curation…`. Names it `verse_swap_v1`, target = EP-133.
+3. Server creates `~/stemforge/curations/verse_swap_v1.yaml` with empty layout. Sets as active. UDP → device: create `STG-A`..`STG-D` tracks, empty.
+4. User drags clips in Live from `FORGE/my-track/drum` session slot 5 onto `STG-B` slot 3. Trims to taste, sets warp BPM.
+5. Repeats for other pads across `STG-A`..`STG-D`.
+6. User clicks `COMMIT` on device.
+7. Device JS walks `STG-*` tracks. For each clip in each slot, resolves: which forge does this audio path belong to? Which clip_id? What's the slot's bar range and warp state?
+8. Builds a pad list per group. Sends `commit` UDP to server (or HTTP POST — see §6.1) with serialized layout.
+9. Server writes to `verse_swap_v1.yaml` atomically (write-tmp + rename). Updates `referenced_forges` from new pad sources. Recomputes `modified_at`.
+10. SSE pushes new state to popup. Popup grid view updates.
+
+### 5.4 Iterating: load curation, add a new forge, save-as
+
+This is the workflow Zak described:
+
+1. User opens Live (fresh `.als` or existing). Popup is open.
+2. Popup: clicks `verse_swap_v1` in curations list, `Open as active`.
+3. Server marks active. UDP → device: create staging tracks if absent, populate pads from `verse_swap_v1.curated_layout`, apply per-group templates.
+4. User auditions in Live. Decides they want to pull from a new source.
+5. Popup: clicks `Add forge…` (or device picker). Picks `~/stemforge/processed/dub-vault-3/auto_curation_manifest.json`.
+6. UDP → device LOAD-forge: creates `FORGE/dub-vault-3/*` tracks alongside existing staging.
+7. User drags a clip from `FORGE/dub-vault-3/vocal` session slot 7 onto `STG-A` slot 9 (overwriting whatever was there).
+8. User has two options now:
+   - **Commit to v1**: click COMMIT. `verse_swap_v1.yaml` updates. Pad A·09 now references `dub-vault-3` instead of whatever was there before.
+   - **Save as v2**: in popup, click `Save as…`, name it `verse_swap_v2`. Server copies the curation file and switches active. Next COMMIT writes to v2; v1 is preserved.
+
+### 5.5 Bouncing and exporting
+
+1. Active curation `verse_swap_v1` is loaded, staging is populated, user is satisfied with how it sounds in Live.
+2. User clicks `BOUNCE` on device (or `Trigger BOUNCE in Live` in popup, which fires UDP at the device to press its own BOUNCE button).
+3. Device JS for each staging track:
+   - Solos the track.
+   - For each clip slot containing a pad:
+     - Triggers the clip.
+     - Uses Live's track freeze + clip crop to render the pad's audio with the group's template chain baked in.
+     - Writes the rendered WAV to `~/stemforge/bounced/verse_swap_v1/<pad-id>.wav`.
+     - Records SHA-256 of the WAV.
+   - Un-solos the track.
+4. Writes `bounced/verse_swap_v1/bounce_manifest.json` with all pad paths and hashes.
+5. Updates `verse_swap_v1.yaml.last_bounce` via server.
+6. SSE pushes state. Popup shows "Bounced 2 minutes ago — 48 pads — Export?"
+7. User clicks `Export to .ppak…` in popup. Native save dialog (osascript). Picks output path.
+8. Server runs `stemforge export verse_swap_v1 --target ep133 --out <path>.ppak`. Reads `bounce_manifest.json`, projects onto EP-133 deck format, writes `.ppak`.
+9. Updates `verse_swap_v1.yaml.last_export`.
+10. Popup shows export success with path. User drags `.ppak` to EP-133 Sample Tool.
+
+### 5.6 Re-anchoring an existing forge
+
+1. User has forge `my-track` loaded. Notices the downbeat is off.
+2. In Live, drops a locator at the true downbeat.
+3. Clicks `RE-ANCHOR` on device (or in popup on the forge entry).
+4. Device reads first Live locator's time.
+5. Fires CLI: `stemforge re-anchor my-track --downbeat-sec 0.247`.
+6. CLI rewrites the forge's manifests and audio chunks (new `first_downbeat_sec`, new clip start positions, new `manifest_hash`).
+7. Device JS reloads `FORGE/my-track/*` tracks from the rewritten manifests.
+8. **If the active curation references `my-track`**: popup shows a "forge re-anchored — curation may have stale pad refs" warning. User can `Refresh from forge` (re-derives clip refs against new manifest) or ignore.
+
+### 5.7 Switching active curations mid-session
+
+1. Active is `verse_swap_v1`, staging is populated.
+2. User wants to work on `live_set_oct_2026` for a bit.
+3. Popup: clicks `live_set_oct_2026`, `Open as active`.
+4. Popup warns: "Current active curation has uncommitted staging changes. Commit before switching, or switch (changes will be lost)?"
+   - **Commit**: COMMIT runs first. Then switch.
+   - **Switch (discard)**: staging is repopulated from `live_set_oct_2026.curated_layout`, current Live state is overwritten.
+5. After switch, `live_set_oct_2026` is active. Staging mirrors its layout. `verse_swap_v1` is on disk unchanged.
+
+For v1, "uncommitted changes" detection can be approximate (compare current staging snapshot hash to last-committed snapshot hash). False positives are OK; false negatives must be impossible (always warn if in doubt).
+
+---
+
+## 6. Pre-emption — issues from current state, fixed by design
+
+This section explicitly addresses each of the §6 "Known gaps + sharp edges" entries from the current state dump.
+
+### 6.1 [shell] doesn't fire commands in the M4L sandbox
+
+**Resolution**: `[shell]` is not used anywhere in the new design. All device-side HTTP-style operations go through UDP to the server, which then does whatever I/O it needs to. Server uses `osascript` for native dialogs (works); CLI subprocesses (work); file writes (work). Device uses UDP receive and `messnamed launchbrowser` only.
+
+**Test enforcement**: a CI lint rule that fails if any `[shell]` object appears in a `.amxd` patch file. Greppable.
+
+### 6.2 COMMIT writes only to in-memory Dict, not disk
+
+**Resolution**: in the new design, COMMIT *always* writes to disk via the server. The device's COMMIT button fires UDP → server, server writes the curation file atomically (tmp + rename), server pushes SSE update. No in-memory-only path exists. The bug class is eliminated because no surface offers an in-memory-only COMMIT.
+
+**Test enforcement**: integration test that fires COMMIT via UDP with a fixture Live state, then asserts the curation file on disk matches expected. No Live required — see §7.
+
+### 6.3 No "load deck manifest" path
+
+**Resolution**: there are no longer two manifest shapes ("production" vs "deck") competing. The schemas in §2 are explicit and versioned. Curation files have `curation_version: 1`; forge manifests have `schema_version: 1`. Device's LOAD branches on the sniffed file type, not on heuristic content shape. The legacy "session_tracks" terminology is replaced by `curated_layout.groups[*].pads`.
+
+**Migration note**: existing `breaks-n-beats1.ppak`-style deck manifests need a migration script. See §8.
+
+### 6.4 Popup state and StemForge.amxd state don't share
+
+**Resolution**: the popup and device share state through the curation file on disk + SSE updates from the server. Neither holds independent authoritative state. The server's in-memory `ProjectSpec` is replaced by a thin cache over the active curation file; on any mutation it writes through to disk and re-reads.
+
+### 6.5 SSE typed-event mismatch
+
+**Resolution**: keep the §6.5 fix. Frontend uses `addEventListener("state", ...)` etc. Server emits typed events. Document this in the API spec.
+
+### 6.6 Frontend types don't match server Pydantic shape
+
+**Resolution**: in v1, the Pydantic shapes for `Curation`, `ForgeManifest`, `Pad`, etc. are defined in `stemforge/configurator/schemas.py` and a TypeScript client is **generated from them** via `datamodel-codegen` or similar (or hand-mirrored with a CI check that diffs them). Manual type drift is eliminated.
+
+**Test enforcement**: CI step that regenerates the TS types and fails the build if the regenerated output differs from the committed file.
+
+### 6.7 Hand-curated deck manifests have no schema fields
+
+**Resolution**: all curation files have `curation_version`, `type`, `target`, etc. as required fields. Old files get migrated (§8). The device's LOAD verb rejects files without `curation_version` with a clear error.
+
+### 6.8 macOS + Chrome won't honor "new window" launches
+
+**Resolution**: keep the current workaround (open in default browser; user drags tab out). Add a "Pop out" button inside the popup that calls `window.open(location.href, "stemforge", "popup,width=1200,height=800")`. The popup itself becomes responsible for the new-window-ness, sidestepping the OS-level launcher issue.
+
+### 6.9 Strip's status dot stays amber
+
+**Resolution**: strip is deleted. Footer status dot on the main device uses a different rendering approach: `[live.text]` with `mode 1` (toggle-style) and a JS-set color via `setattr bgcolor <r> <g> <b>` issued exactly once per state change, not as a continuous stream. If the bgcolor-resets-once bug recurs on the main device, an alternative is using `[lcd]` or a custom drawn rect via `js` and `mgraphics`.
+
+**Test enforcement**: visual smoke test exists but isn't blocking. Manual eyeball during release.
+
+---
+
+## 7. Testing strategy — automate aggressively
+
+> The historical pain has been "loops with Zak loading and clicking in Ableton." Designing this away is a primary goal of v1.
+
+### 7.1 The testability surface
+
+The system has four boundaries, in decreasing order of testability:
+
+1. **CLI** — pure Python subprocesses with file I/O. **100% headless testable**.
+2. **Server** — FastAPI process with file I/O and UDP out. **100% headless testable** with UDP mocked or captured.
+3. **Popup** — React + TS, fetches from server. **100% headless testable** with vitest + msw mocks.
+4. **Device Max JS** — runs inside M4L, touches LOM. **Partially headless testable** (see §7.5).
+
+The strategy: make boundaries 1-3 cover as much of the design as possible. Push functionality *out* of the device JS where it can live in the server or CLI. Treat the device as a thin LOM-touching shim that delegates everything else.
+
+### 7.2 What lives where (for testability)
+
+| Logic | Lives in | Why |
+|-------|----------|-----|
+| Curation file schema validation | Pydantic / Python | Testable in isolation. |
+| Curation file write (atomic, locked) | Server | Testable with tmp dirs. |
+| Forge discovery / scanning | Server | Testable with fixture filesystems. |
+| Pad source resolution (forge + clip_id → audio_path) | Server | Pure function over manifest. Highly testable. |
+| Template-to-rack mapping | Server | Just a registry lookup; pure. |
+| Bounce target spec construction | Server | Returns "render these slots through these templates"; the device just executes. |
+| Export pipeline | CLI | Pure file-in / file-out. |
+| UDP message envelope construction | Server | Pure function. |
+| **LOM walking (COMMIT) and clip creation (LOAD)** | **Device JS** | **Cannot be lifted out**. But: the device JS should be a thin walker that emits a structured snapshot to the server, which then validates and writes. |
+
+The result: the device JS becomes much simpler than it is today (it's currently doing schema work, file I/O, and orchestration). It becomes "given this UDP intent, walk this part of LOM and report back" or "given this curation snapshot from the server, create these clips on these tracks." The decisions live in the server, which is testable.
+
+### 7.3 Test pyramid
+
+**Unit tests** (vitest + pytest):
+
+- Curation schema parsing (Pydantic) — happy path + every malformed field.
+- Server endpoint handlers with mocked filesystem (`pyfakefs`) and mocked UDP out (capture sent bytes).
+- Frontend hooks and components with msw-mocked server.
+- CLI commands with `click.testing.CliRunner` over tmpdirs.
+
+**Integration tests** (pytest, no Live):
+
+- End-to-end via the server: create curation → mock device commit (server-side fixture function that simulates what device would send) → assert curation file contents.
+- Forge scan against a fixture `~/stemforge/processed/` tree.
+- Stale-reference detection: load a curation referencing forge X, mutate X's manifest_hash, assert popup state shows stale.
+- Switch active curation: verify UDP message envelope sent by server, verify `.stemforge_state.json` updates.
+
+**Device-JS unit tests** (Node + Max stubs):
+
+- Mock `LiveAPI` and `Dict` objects.
+- Test the COMMIT walker: given a stubbed `STG-*` track with clips at specific slots, produce the snapshot object the server expects.
+- Test the LOAD curation: given a curation snapshot, produce the sequence of LOM calls (assert the call log).
+- Test the picker sniffer: given various file paths, return the correct routed type.
+
+**Live-in-the-loop tests** (manual or semi-automated):
+
+- A small suite of "smoke tests" that require Live open with a fixture `.als`. Run once per release.
+- Each test is scripted via `sf-remote`: load fixture forge → COMMIT → assert curation file. Or: load curation → assert STG-* track count + clip slot contents (via a `sf-remote dump` of LOM state).
+- These tests fire from a CI runner that has Live installed (a dedicated mac mini, ideally). The runner triggers Live to open a fixture `.als` via AppleScript, then runs the sf-remote sequence, then asserts.
+
+### 7.4 Fixture infrastructure
+
+Build a fixture library under `tests/fixtures/`:
+
+- `tests/fixtures/forges/` — pre-baked forge directories (small synthetic audio, complete manifests).
+- `tests/fixtures/curations/` — sample curation files at various states (empty, partial, bounced, exported, stale).
+- `tests/fixtures/als/` — minimal Live project files with known track configurations.
+- `tests/fixtures/lom_snapshots/` — captured JSON snapshots of LOM state at specific moments (what `sf-remote dump` would return after a specific setup). Tests use these instead of live LOM.
+
+The LOM snapshot library is the key new piece. Today the only way to know what LOM looks like in a given state is to ask Live. By capturing snapshots once and replaying them, the device JS becomes testable without Live running.
+
+### 7.5 Mocking Max JS environment for tests
+
+Stand up a `max-stub.js` module under `tools/test-harness/` that exposes the same API as Max's JS environment: `Dict`, `LiveAPI`, `outlet`, `messnamed`, etc. Each implemented as a programmable mock that test code can configure ("when `LiveAPI.get_path('live_set tracks 0 clip_slots 5 clip')` is called, return this captured clip object").
+
+Then the device JS imports unchanged in Node, and tests drive it directly:
+
+```js
+// tests/device-js/commit.test.js
+import { stubMax } from '../tools/test-harness/max-stub.js';
+import lomSnapshot from '../fixtures/lom_snapshots/four-pads-on-stg-a.json' assert { type: 'json' };
+import { commitOffsets } from '../../v0/src/m4l-js/stemforge_loader.v0.js';
+
+test('COMMIT produces expected pad snapshot for 4-pad STG-A state', () => {
+  stubMax(lomSnapshot);
+  const sentMessages = [];
+  stubMax.captureOutletMessages(sentMessages);
+  commitOffsets();
+  expect(sentMessages).toContainEqual({
+    udpTo: 'server', verb: 'commit',
+    payload: expect.objectContaining({
+      groups: { A: { pads: expect.arrayContaining([
+        { pad_id: 'A01', source: { /* ... */ } }
+      ])}}
+    })
+  });
+});
+```
+
+This is the breakthrough for the historical Live-in-the-loop pain. Once `max-stub.js` covers the LOM API surface the device JS actually uses, device JS development moves entirely into the test loop.
+
+### 7.6 What still requires Live
+
+A short, well-defined list:
+
+- **BOUNCE rendering** — actual audio comes out of Live; this is the whole point. Cannot be mocked. But: the *control* of the bounce (which slots to render, what template each gets) is server-side and testable. The unmockable part is Live's audio engine.
+- **Template-rack loading on tracks** — Max API `loadbang` style operations that depend on Live actually parsing the `.adg` file. Stubbable for unit tests; live for integration.
+- **The visual M4L UI** — pixel-level rendering of the device. Manual smoke test.
+
+Everything else has a path to headless testing. The current "load + click in Ableton" loop should drop from "every change" to "once per release for the smoke suite."
+
+### 7.7 CI structure
+
+```
+.github/workflows/
+  ci-server.yml        # pytest, mypy, ruff on Python
+  ci-popup.yml         # vitest, tsc, eslint on web/configurator/
+  ci-cli.yml           # pytest CliRunner tests
+  ci-device-js.yml     # vitest + max-stub on v0/src/m4l-js/
+  ci-integration.yml   # pytest covering server ↔ CLI ↔ filesystem
+  ci-types.yml         # regenerate TS types from Pydantic, diff against committed
+  ci-smoke-live.yml    # gated, manual trigger, runs on the live-equipped runner
+```
+
+All of `ci-server` / `ci-popup` / `ci-cli` / `ci-device-js` / `ci-integration` / `ci-types` run on every PR. `ci-smoke-live` runs on release branches or manually.
+
+---
+
+## 8. Migration from current state
+
+Ordered checklist. Each step should leave the system in a working state (the user can still build a `.ppak` after each step).
+
+### Step 1 — Pre-work, no behavior changes
+
+- [ ] Rename `~/stemforge/processed/<slug>/curated/manifest.json` → `auto_curation_manifest.json`. Add a compatibility shim in CLI / device that reads both paths for a release.
+- [ ] Add `arrangement_manifest.json` as a separate file (today, arrangement data is embedded in the same file or computed on the fly — extract it).
+- [ ] Add `schema_version` and `manifest_hash` fields to both manifests. Backfill hash from existing data.
+- [ ] Write a `stemforge migrate` CLI command that does the above for an existing forge.
+
+### Step 2 — Curation file schema and write path
+
+- [ ] Define Pydantic models for `Curation`, `Group`, `Pad`, `Target`, etc.
+- [ ] Add server endpoint `POST /curations` (create empty).
+- [ ] Add server endpoint `POST /curations/{name}/commit` (receives device snapshot, writes file).
+- [ ] Generate TS types from Pydantic.
+- [ ] Tests: round-trip parse → write → re-parse for fixture curation files.
+
+### Step 3 — Device's new picker + LOAD-curation behavior
+
+- [ ] Add the unified `Pick source…` button, replacing PRESET and SOURCE dropdowns.
+- [ ] Implement file-type sniffer in device JS.
+- [ ] Primary button label switches based on picked type.
+- [ ] LOAD-curation code path: device receives curation YAML (via UDP or by reading file), creates `STG-*` tracks, populates pads.
+- [ ] Tests: `max-stub.js` + lom_snapshots fixture; verify staging track creation for EP-133 target.
+
+### Step 4 — COMMIT writes through server
+
+- [ ] Device COMMIT walks staging tracks (not A/B/C/D as before).
+- [ ] Device serializes snapshot, sends UDP `commit` to server.
+- [ ] Server validates, writes curation file atomically.
+- [ ] Device's old in-memory-only COMMIT path is removed.
+- [ ] Tests: stub device → server → fixture-fs → assert file contents.
+
+### Step 5 — Popup as orchestrator
+
+- [ ] Remove the popup's current drag-and-drop curation UI (LeftRail's Commit/Recompute/Export). Replace with the panels in §3.2.
+- [ ] Implement curations list with Open/Save-as/Delete.
+- [ ] Implement forges list with Load/Unload/Re-anchor.
+- [ ] Wire popup → server endpoints from §4.3.
+- [ ] Tests: vitest + msw for each panel.
+
+### Step 6 — Templates
+
+- [ ] Define template directory and `.adg` discovery.
+- [ ] Add template assignment per group in curation file.
+- [ ] Device JS loads `.adg` onto `STG-*` track on template change UDP.
+- [ ] Popup template selector wired up.
+- [ ] Tests: curation parse with templates; UDP envelope verification.
+
+### Step 7 — BOUNCE refactor
+
+- [ ] BOUNCE reads from active curation's `curated_layout`, not from walking A/B/C/D.
+- [ ] Output goes to `~/stemforge/bounced/<curation-name>/`.
+- [ ] Updates curation's `last_bounce`.
+- [ ] Tests: server-side spec construction; device-side stubbed render call sequence.
+
+### Step 8 — EXPORT via server
+
+- [ ] Popup's Export button calls `POST /curations/{name}/export`.
+- [ ] Server runs CLI `stemforge export`.
+- [ ] Updates curation's `last_export`.
+- [ ] Device's EXPORT button is removed (already absent in the new design, just confirming).
+
+### Step 9 — Delete the strip
+
+- [ ] Remove `v0/src/m4l-devices/configurator-strip/` entirely.
+- [ ] Remove `v0/build/ConfiguratorStrip.amxd`.
+- [ ] Close PR #99 (or merge minimally if anything in it is salvageable for the main device's footer).
+- [ ] Move "Open Editor" button into StemForge.amxd's footer.
+
+### Step 10 — Active curation persistence
+
+- [ ] Implement `.stemforge_state.json` server-side.
+- [ ] On Live `.als` open, device pings server with `.als` path; server returns last-known active curation.
+- [ ] Tests: state file read/write round-trip; `.als` path keying.
+
+### Step 11 — Stale-reference detection
+
+- [ ] On forge re-anchor / re-curate, server updates the forge's manifest_hash.
+- [ ] Popup compares active curation's referenced_forges hashes vs current forge hashes; surfaces stale badges.
+- [ ] "Refresh from forge" button re-derives pad refs.
+
+### Step 12 — Smoke test suite
+
+- [ ] Build the `tests/fixtures/lom_snapshots/` library.
+- [ ] Build the `max-stub.js` test harness.
+- [ ] Set up CI workflows from §7.7.
+- [ ] Wire up live-runner CI (longer-term).
+
+---
+
+## 9. Things explicitly deferred to v2
+
+These are mentioned to prevent scope creep in v1 implementation. Each has a "we will not block on this" tag.
+
+- **`type: "arrangement"` curations** — scene-based curations for Flow B (mashup/performance). v1 ships `type: "deck"` only. The schema reserves the field.
+- **Per-pad templates** — v1 is per-group only.
+- **Targets other than EP-133** — schema supports `target.device` as a string, but only `ep133` is wired through. MPC / OP-1 / etc. require pad-grid spec work that's out of scope.
+- **Variable pads-per-group** — schema has `pads_per_group`, v1 hardcodes 12 (EP-133 default).
+- **Popup drag-and-drop from clip browser** — explicitly rejected per design conversation. Curation happens in Live.
+- **Multi-curation simultaneous editing** — one active curation at a time. Switching is supported; concurrent isn't.
+- **Workspace files / project files at a level above curations** — the global workspace is just the filesystem; no project file groups multiple curations together. Could add later.
+- **In-Live editing of forge metadata** — re-anchor and re-curate are operations, but the user can't edit forge tags or BPM directly. Forge metadata is CLI-owned.
+- **The auto-create-on-startup of staging tracks** — if a Live `.als` opens with no `STG-*` tracks and no active curation, the device does nothing. Staging is created when a curation becomes active. (If this is annoying in practice we can revisit.)
+- **Conflict resolution on concurrent writes** — assume one user, one Live, one popup. If the user edits the curation file by hand while Live is running, last-writer-wins. (Realistic for one-human workflow.)
+
+---
+
+## 10. Glossary recap
+
+| Term | Definition |
+|------|------------|
+| **Forge** | A processed audio source on disk. Slug-identified. Has arrangement and auto-curation manifests. |
+| **Curation** | A named, persistable artifact representing one curation pass. `.yaml` file under `~/stemforge/curations/`. |
+| **Active curation** | The currently-open curation. There is at most one. Persisted server-side keyed by `.als` path. |
+| **Staging** | Live tracks `STG-A`..`STG-N` whose contents mirror the active curation's `curated_layout`. Count determined by target device. |
+| **Pad** | A single slot in a curation's `curated_layout`. Has a `pad_id` like `A01`, a `source` (forge + clip_id), and `clip_settings`. |
+| **Group** | A row of pads in a curation. Has a label, a template, and pads. EP-133 has 4 groups. |
+| **Template** | A Live device rack (`.adg`) applied per-group. Baked into bounced audio. |
+| **Target** | The device the curation is being built for. EP-133 in v1. |
+| **Global workspace** | Descriptive: everything under `~/stemforge/`. Not a data structure. |
+| **Local workspace** | Descriptive: what's currently in Live's `.als`. Not a data structure. |
+
+---
+
+## 11. Build order suggestion
+
+For a fresh Claude Code session, I'd recommend tackling the migration steps in this order:
+
+1. **Steps 1-2** together: get the file shapes right, lock in schemas, generate types. This is foundational and unblocks everything else.
+2. **Step 4** (COMMIT writes through server) — the keystone fix. Once this works, the architecture's promise holds.
+3. **Step 3** (picker + LOAD-curation) — the device's new entry point.
+4. **Step 5** (popup as orchestrator) in parallel — the popup work doesn't depend on Steps 3-4 strictly.
+5. **Steps 6-8** (templates, BOUNCE, EXPORT) as features layer on.
+6. **Step 9** (delete the strip) — cleanup, do it before Step 10 so there's nothing to keep alive in parallel.
+7. **Steps 10-11** (state persistence, stale detection) — polish.
+8. **Step 12** (testing infrastructure) — woven in as you go, not at the end. Specifically: don't implement Step 4 without the COMMIT test harness in place first. Don't implement Step 3 without the picker sniffer unit tests. Etc.
+
+The biggest payoff from doing testing first: Step 4 alone has historically been the source of half the dump's pain. With a server-side commit endpoint that's testable with a fixture device snapshot, you can iterate on the COMMIT logic without Live open. That's the change that buys back the most time.
+
+---
+
+*End of spec. Drop into a Claude Code session with `SPEC.md` filename and start at Step 1.*

--- a/v0/src/m4l-js/stemforge_loader.v0.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.js
@@ -562,8 +562,19 @@ function loadFromDict() {
 
     status("loaded manifest from dict: " + dictName);
 
+    // Production manifest (curated with a pipeline that sets layout_mode).
     if (mf.layout_mode === "production") {
         status("detected production manifest → song loader");
+        loadSong();
+        return;
+    }
+
+    // Deck-shape manifest: only `session_tracks` populated, no `stems[]`
+    // (e.g. breaks-n-beats1-style hand-curated decks). loadSong handles
+    // this shape since the 2026-05-13 patch — it skips per-stem loading
+    // and goes straight to _restoreSessionTracks.
+    if (_sessionTracksHasContent(mf.session_tracks)) {
+        status("detected deck manifest (session_tracks only) → song loader");
         loadSong();
         return;
     }
@@ -1028,7 +1039,24 @@ function loadSong() {
     catch (e) { status("loadSong: parse error: " + e); return; }
 
     var stemData = mf.stems;
-    if (!stemData) { status("manifest has no stems"); return; }
+    var hasSessionTracks = _sessionTracksHasContent(mf.session_tracks);
+
+    // Two valid manifest shapes:
+    //   - SOURCE shape: `stems[]` populated, no session_tracks. The
+    //     loader duplicates per-stem template tracks + drops curated
+    //     bars, then _restoreSessionTracks is a no-op (auto-populate
+    //     drum hits instead).
+    //   - DECK shape: `session_tracks` populated, no stems[]. The user
+    //     has previously committed an A/B/C/D arrangement. We skip the
+    //     per-stem loop and go straight to _restoreSessionTracks, which
+    //     drops clips at the saved slots from `file` paths alone.
+    //
+    // The original code required `stems[]`, which made it impossible to
+    // re-load a deck-shape manifest (e.g. breaks-n-beats1) for editing.
+    if (!stemData && !hasSessionTracks) {
+        status("manifest has neither stems[] nor session_tracks");
+        return;
+    }
 
     var songName = mf.track || "stemforge";
     var loaded = 0;
@@ -1039,6 +1067,13 @@ function loadSong() {
     }
 
     ensureScenes(16);
+
+    // Deck-shape: no stems to load → straight to session_tracks restore.
+    if (!stemData) {
+        _restoreSessionTracks(mf, {});
+        outlet(1, "bang");
+        return;
+    }
 
     // Priority chain: sf_preset dict → manifest embedding → hardcoded fallback
     var pipelineConfig = null;

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
@@ -562,8 +562,19 @@ function loadFromDict() {
 
     status("loaded manifest from dict: " + dictName);
 
+    // Production manifest (curated with a pipeline that sets layout_mode).
     if (mf.layout_mode === "production") {
         status("detected production manifest → song loader");
+        loadSong();
+        return;
+    }
+
+    // Deck-shape manifest: only `session_tracks` populated, no `stems[]`
+    // (e.g. breaks-n-beats1-style hand-curated decks). loadSong handles
+    // this shape since the 2026-05-13 patch — it skips per-stem loading
+    // and goes straight to _restoreSessionTracks.
+    if (_sessionTracksHasContent(mf.session_tracks)) {
+        status("detected deck manifest (session_tracks only) → song loader");
         loadSong();
         return;
     }
@@ -1028,7 +1039,24 @@ function loadSong() {
     catch (e) { status("loadSong: parse error: " + e); return; }
 
     var stemData = mf.stems;
-    if (!stemData) { status("manifest has no stems"); return; }
+    var hasSessionTracks = _sessionTracksHasContent(mf.session_tracks);
+
+    // Two valid manifest shapes:
+    //   - SOURCE shape: `stems[]` populated, no session_tracks. The
+    //     loader duplicates per-stem template tracks + drops curated
+    //     bars, then _restoreSessionTracks is a no-op (auto-populate
+    //     drum hits instead).
+    //   - DECK shape: `session_tracks` populated, no stems[]. The user
+    //     has previously committed an A/B/C/D arrangement. We skip the
+    //     per-stem loop and go straight to _restoreSessionTracks, which
+    //     drops clips at the saved slots from `file` paths alone.
+    //
+    // The original code required `stems[]`, which made it impossible to
+    // re-load a deck-shape manifest (e.g. breaks-n-beats1) for editing.
+    if (!stemData && !hasSessionTracks) {
+        status("manifest has neither stems[] nor session_tracks");
+        return;
+    }
 
     var songName = mf.track || "stemforge";
     var loaded = 0;
@@ -1039,6 +1067,13 @@ function loadSong() {
     }
 
     ensureScenes(16);
+
+    // Deck-shape: no stems to load → straight to session_tracks restore.
+    if (!stemData) {
+        _restoreSessionTracks(mf, {});
+        outlet(1, "bang");
+        return;
+    }
 
     // Priority chain: sf_preset dict → manifest embedding → hardcoded fallback
     var pipelineConfig = null;


### PR DESCRIPTION
## Summary

Lands three companion docs that drive the next round of Configurator work:

- **`specs/CONSOLIDATED_DESIGN.md`** — the destination. Three nouns (forge / curation / staging), five verbs, file layout, endpoint catalog, 12-step migration, 4-layer testing strategy.
- **`docs/configurator/CURRENT_STATE_DUMP_2026-05-13.md`** — the historical "from" state (button-by-button inventory, 9 known gaps, the 3 meanings of COMMIT and 2 of LOAD).
- **`docs/configurator/EXECUTION_PLAN_v1.md`** — the path. Five phases optimized for parallel + autonomous execution: Phase 0 foundation → Phase 1 four-lane parallel migration → Phase 2 COMMIT keystone → Phase 3 three-lane features → Phase 4 two-lane polish → Phase 5 Live-in-the-loop smoke. File-ownership matrix prevents agent collisions; 4 testing layers (L1 unit / L2 integration / L3 device-JS via `max-stub.js` + LOM snapshots / L4 AppleScript runner) keep most work headless.

Also ships a small loader fix:

- **`fix(m4l-js)`** — the existing big device now accepts deck-shape manifests (`session_tracks` populated, no `stems[]`). Validated on-device 2026-05-12 by re-loading a breaks-n-beats1 deck.

## Test plan

- [x] Loader patch validated on-device by user 2026-05-12 ("reforge worked")
- [ ] Spec / plan rendered cleanly on GitHub (Mermaid + tables intact)
- [ ] Foundations PR (Phase 0) opens against this branch once approved

After merge, Phase 0 worktree agent spawns immediately and PRs schema / harness / CI scaffolding back into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)