### PR TITLE
migrate(cli): forge file shape — split auto_curation + arrangement manifests

### DIFF
--- a/stemforge/cli.py
+++ b/stemforge/cli.py
@@ -899,6 +899,39 @@ def re_anchor(
             else:
                 console.print("  curated/manifest.json + bar WAVs updated.")
 
+    # ── New-shape configurator manifests (Phase 1A) ──
+    # When curated/ exists, project it into the new two-file shape so the
+    # configurator + popup consumers see the post-anchor bpm + clips.
+    if curated_manifest_path.exists():
+        try:
+            from .forge import (
+                build_empty_arrangement,
+                build_from_curated_dict,
+                write_arrangement,
+                write_auto_curation,
+            )
+
+            _curated_dict = json.loads(curated_manifest_path.read_text())
+            _fm = build_from_curated_dict(
+                slug=track_name,
+                forge_dir=track_dir,
+                curated=_curated_dict,
+                bpm=float(bpm),
+                first_downbeat_sec=float(first_downbeat),
+            )
+            write_auto_curation(track_dir, _fm)
+            _am = build_empty_arrangement(
+                slug=track_name,
+                source_audio=str(source_file),
+                bpm=float(bpm),
+                first_downbeat_sec=float(first_downbeat),
+            )
+            write_arrangement(track_dir, _am)
+        except Exception as exc:  # noqa: BLE001 — non-fatal during re-anchor
+            console.print(
+                f"  [yellow]configurator manifests not refreshed: {exc}[/yellow]"
+            )
+
     console.print()
     console.print(Rule("[bold green]Re-anchored[/bold green]"))
     console.print(f"  BPM: [cyan]{bpm}[/cyan]  first_downbeat: [cyan]{first_downbeat}s[/cyan]")
@@ -908,6 +941,9 @@ def re_anchor(
             console.print("  curated/ rebuilt with fresh diversity picks at new anchor.")
         else:
             console.print("  curated/ re-sliced at new anchor.")
+        console.print(
+            "  auto_curation_manifest.json + arrangement_manifest.json refreshed."
+        )
     if keep_old:
         console.print("  [dim]Old chunks preserved at <stem>_prechop.bak/.[/dim]")
 
@@ -953,7 +989,255 @@ def reslice_curated(track_dir):
     if result.returncode != 0:
         console.print(f"[red]reslice exited {result.returncode}[/red]")
         sys.exit(1)
+
+    # Refresh the new-shape configurator manifests (Phase 1A) so the popup
+    # sees the post-reslice clip set with a fresh manifest_hash.
+    try:
+        from .forge import (
+            build_empty_arrangement,
+            build_from_curated_dict,
+            write_arrangement,
+            write_auto_curation,
+        )
+
+        _stems = json.loads(stems_json.read_text())
+        _curated_dict = json.loads(curated.read_text())
+        _bpm = float(_curated_dict.get("bpm") or _stems.get("bpm") or 120.0)
+        _dn = float((_stems.get("tempo") or {}).get("first_downbeat_sec") or 0.0)
+        _slug = _stems.get("track_name") or track_dir.name
+        _fm = build_from_curated_dict(
+            slug=_slug,
+            forge_dir=track_dir,
+            curated=_curated_dict,
+            bpm=_bpm,
+            first_downbeat_sec=_dn,
+        )
+        write_auto_curation(track_dir, _fm)
+        _src = _stems.get("source_file") or str(track_dir)
+        write_arrangement(
+            track_dir,
+            build_empty_arrangement(
+                slug=_slug,
+                source_audio=_src,
+                bpm=_bpm,
+                first_downbeat_sec=_dn,
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[yellow]configurator manifests not refreshed: {exc}[/yellow]")
+
     console.print(Rule("[bold green]Resliced[/bold green]"))
+
+
+# ── Configurator v1 (Phase 1A) — forge file-shape commands ──────────────────
+
+
+def _resolve_forge_dir(slug_or_path: str | Path) -> tuple[str, Path]:
+    """Resolve a slug/path arg into (slug, forge_dir).
+
+    Accepts either a bare slug (`my_track`) → resolves under PROCESSED_DIR,
+    or an explicit path (`./processed/my_track`) → uses the basename as
+    the slug. Raises ClickException when the dir is missing.
+    """
+    p = Path(slug_or_path)
+    if p.exists() and p.is_dir():
+        return p.name, p
+    # Treat as slug under PROCESSED_DIR
+    forge_dir = PROCESSED_DIR / str(slug_or_path)
+    if not forge_dir.exists():
+        raise click.ClickException(
+            f"forge `{slug_or_path}` not found "
+            f"(looked for path `{p}` and slug under `{PROCESSED_DIR}`)"
+        )
+    return forge_dir.name, forge_dir
+
+
+@cli.command("migrate-forge")
+@click.argument("slug")
+@with_audit("migrate-forge")
+def migrate_forge(slug):
+    """
+    Migrate a forge's legacy ``curated/manifest.json`` to the new file shape.
+
+    Reads ``~/stemforge/processed/<slug>/curated/manifest.json`` and writes
+    two sibling files at the forge root:
+
+      - ``auto_curation_manifest.json`` (ForgeManifest with manifest_hash)
+      - ``arrangement_manifest.json`` (ArrangementManifest, chunks may be
+        empty when the legacy file lacked arrangement data)
+
+    Both writes are atomic (.tmp + os.replace). The legacy file is left in
+    place for one release for compat; a follow-up cleanup will drop it.
+
+    Argument can be either a forge slug (`my_track`) or an explicit
+    forge-dir path (`./processed/my_track`).
+    """
+    from .forge import (
+        ForgeManifestError,
+        legacy_manifest_exists,
+        migrate_legacy,
+        new_manifest_exists,
+    )
+
+    slug, forge_dir = _resolve_forge_dir(slug)
+
+    if new_manifest_exists(forge_dir) and not legacy_manifest_exists(forge_dir):
+        console.print(
+            f"[yellow]forge `{slug}` already on new shape; nothing to migrate.[/yellow]"
+        )
+        return
+    if not legacy_manifest_exists(forge_dir):
+        raise click.ClickException(
+            f"forge `{slug}` has no curated/manifest.json to migrate "
+            f"(forge dir: {forge_dir})"
+        )
+
+    try:
+        fm_path, am_path = migrate_legacy(slug, forge_dir)
+    except ForgeManifestError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(Rule(f"[bold cyan]migrate-forge[/bold cyan] — {slug}"))
+    console.print(f"  wrote {fm_path.relative_to(forge_dir)}")
+    console.print(f"  wrote {am_path.relative_to(forge_dir)}")
+    console.print(
+        "  [dim]legacy curated/manifest.json left in place for one-release compat[/dim]"
+    )
+
+
+@cli.command("re-curate")
+@click.argument("slug")
+@click.option(
+    "--strategy",
+    "-s",
+    default=None,
+    type=click.Choice(["max-diversity", "rhythm-taxonomy", "sectional"]),
+    help="Override curation strategy. Default: re-use whatever the legacy manifest recorded.",
+)
+@click.option(
+    "--n-bars",
+    "-n",
+    default=None,
+    type=int,
+    help="Override the number of bars curated. Default: re-use legacy manifest value.",
+)
+@with_audit("re-curate")
+def re_curate(slug, strategy, n_bars):
+    """
+    Re-run auto-curation only — no stem separation.
+
+    Reads existing stems from ``~/stemforge/processed/<slug>/`` (drums.wav,
+    bass.wav, etc. already on disk from a prior ``stemforge forge`` or
+    ``split``), runs the curator across the existing bar-slices, and
+    writes a fresh ``auto_curation_manifest.json`` with a new
+    ``manifest_hash``.
+
+    Phase 4B's stale-detection hangs off this hash mutating: rerun this
+    command after editing the curation pipeline YAML to force every
+    curation that references this forge to surface a "stale" badge.
+    """
+    from .forge import (
+        ForgeManifestError,
+        build_empty_arrangement,
+        build_from_curated_dict,
+        write_arrangement,
+        write_auto_curation,
+    )
+
+    slug, forge_dir = _resolve_forge_dir(slug)
+
+    stems_json = forge_dir / "stems.json"
+    if not stems_json.exists():
+        raise click.ClickException(
+            f"forge `{slug}` has no stems.json at {stems_json} — run `stemforge split` first."
+        )
+
+    script = Path(__file__).resolve().parents[1] / "v0/src/stemforge_curate_bars.py"
+    if not script.exists():
+        raise click.ClickException(f"curate script not found at {script}")
+
+    # Replay strategy/n_bars from the existing manifest unless overridden.
+    legacy_path = forge_dir / "curated" / "manifest.json"
+    legacy_data: dict = {}
+    if legacy_path.exists():
+        try:
+            legacy_data = json.loads(legacy_path.read_text())
+        except json.JSONDecodeError:
+            legacy_data = {}
+
+    replay_strategy = strategy or legacy_data.get("strategy") or "max-diversity"
+    replay_n_bars = (
+        n_bars
+        if n_bars is not None
+        else int(legacy_data.get("n_bars") or 16)
+    )
+    replay_time_sig = int(legacy_data.get("time_signature_numerator") or 4)
+
+    console.print(Rule(f"[bold cyan]re-curate[/bold cyan] — {slug}"))
+    console.print(
+        f"  strategy=[cyan]{replay_strategy}[/cyan] "
+        f"n_bars=[cyan]{replay_n_bars}[/cyan] time_sig=[cyan]{replay_time_sig}[/cyan]"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--stems-dir",
+            str(forge_dir),
+            "--strategy",
+            replay_strategy,
+            "--n-bars",
+            str(replay_n_bars),
+            "--time-sig",
+            str(replay_time_sig),
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(
+            f"v0/src/stemforge_curate_bars.py exited {result.returncode}"
+        )
+
+    if not legacy_path.exists():
+        raise click.ClickException(
+            f"curate script ran but no {legacy_path} appeared — cannot project new shape."
+        )
+
+    try:
+        curated_dict = json.loads(legacy_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"re-curate wrote a malformed legacy manifest: {exc}"
+        ) from exc
+
+    stems_data = json.loads(stems_json.read_text())
+    bpm_val = float(curated_dict.get("bpm") or stems_data.get("bpm") or 120.0)
+    dn_val = float((stems_data.get("tempo") or {}).get("first_downbeat_sec") or 0.0)
+    source_audio = curated_dict.get("source_audio") or stems_data.get("source_file") or ""
+
+    try:
+        fm = build_from_curated_dict(
+            slug=slug,
+            forge_dir=forge_dir,
+            curated=curated_dict,
+            bpm=bpm_val,
+            first_downbeat_sec=dn_val,
+        )
+        fm_path = write_auto_curation(forge_dir, fm)
+        am = build_empty_arrangement(
+            slug=slug,
+            source_audio=source_audio,
+            bpm=bpm_val,
+            first_downbeat_sec=dn_val,
+        )
+        am_path = write_arrangement(forge_dir, am)
+    except ForgeManifestError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(f"  wrote {fm_path.relative_to(forge_dir)}")
+    console.print(f"  wrote {am_path.relative_to(forge_dir)}")
+    console.print(f"  manifest_hash=[green]{fm.manifest_hash[:16]}..[/green]")
 
 
 @cli.command("list")
@@ -1365,10 +1649,49 @@ def forge(audio_file, analysis, model, strategy, n_bars, time_sig, output, curat
             )
             sys.exit(1)
         manifest_path = track_out / "curated" / "manifest.json"
+
+        # ── 3.5 Mirror to new-shape configurator manifests (Phase 1A) ──
+        # The v0 production curator writes the legacy single-file manifest;
+        # we read it back and project into the new two-file shape so
+        # downstream configurator consumers see the same data.
+        from .forge import (
+            build_empty_arrangement,
+            build_from_curated_dict,
+            write_arrangement,
+            write_auto_curation,
+        )
+
+        _curated_dict: dict = {}
+        try:
+            _curated_dict = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            _curated_dict = {}
+        _bpm_for_forge = (
+            _curated_dict.get("bpm") if isinstance(_curated_dict.get("bpm"), (int, float)) else None
+        )
+        _fm = build_from_curated_dict(
+            slug=track_name,
+            forge_dir=track_out,
+            curated=_curated_dict,
+            bpm=_bpm_for_forge,
+            first_downbeat_sec=float(_curated_dict.get("first_downbeat_sec", 0.0) or 0.0),
+        )
+        _fm_path = write_auto_curation(track_out, _fm)
+        _am = build_empty_arrangement(
+            slug=track_name,
+            source_audio=str(audio_file),
+            bpm=_fm.bpm,
+            first_downbeat_sec=_fm.first_downbeat_sec,
+        )
+        _am_path = write_arrangement(track_out, _am)
+
         emit(
             "complete",
             output_dir=str(manifest_path.parent),
             manifest=str(manifest_path),
+            auto_curation_manifest=str(_fm_path),
+            arrangement_manifest=str(_am_path),
+            manifest_hash=_fm.manifest_hash,
             bars=n_bars,
             mode="production",
         )
@@ -1497,6 +1820,40 @@ def forge(audio_file, analysis, model, strategy, n_bars, time_sig, output, curat
     manifest_path = curated_root / "manifest.json"
     manifest_path.write_text(json.dumps(curated_manifest, indent=2))
 
+    # ── 3.5 Emit new-shape configurator manifests (Phase 1A) ──
+    # `auto_curation_manifest.json` + `arrangement_manifest.json` live at the
+    # forge root next to `stems.json`. The legacy `curated/manifest.json` is
+    # left in place for one release for backward compatibility with existing
+    # exporters/readers; the compat shim in `stemforge.forge.manifest_io`
+    # accepts both shapes.
+    from .forge import (
+        build_empty_arrangement,
+        build_from_curated_dict,
+        write_arrangement,
+        write_auto_curation,
+    )
+
+    _forge_dn = (
+        float(reconciled_for_forge.first_downbeat_sec)
+        if reconciled_for_forge is not None and reconciled_for_forge.first_downbeat_sec is not None
+        else 0.0
+    )
+    _fm = build_from_curated_dict(
+        slug=track_name,
+        forge_dir=track_out,
+        curated=curated_manifest,
+        bpm=detected_bpm,
+        first_downbeat_sec=_forge_dn,
+    )
+    _fm_path = write_auto_curation(track_out, _fm)
+    _am = build_empty_arrangement(
+        slug=track_name,
+        source_audio=str(audio_file),
+        bpm=_fm.bpm,
+        first_downbeat_sec=_forge_dn,
+    )
+    _am_path = write_arrangement(track_out, _am)
+
     # ── 4. Emit per-sample sidecars + a BatchManifest (manifest-spec) ──
     # Producer-side rotation: drums→A, bass→B, vocals→C, other→D, with
     # bottom-up pad layout per BAR_INDEX_TO_LABEL. Consumers (ep133-ppak's
@@ -1557,6 +1914,9 @@ def forge(audio_file, analysis, model, strategy, n_bars, time_sig, output, curat
         "complete",
         output_dir=str(curated_root),
         manifest=str(manifest_path),
+        auto_curation_manifest=str(_fm_path),
+        arrangement_manifest=str(_am_path),
+        manifest_hash=_fm.manifest_hash,
         batch_manifest=str(batch_path),
         sidecars=len(batch_samples),
         bars=len(selected_indices),

--- a/stemforge/cli.py
+++ b/stemforge/cli.py
@@ -928,9 +928,7 @@ def re_anchor(
             )
             write_arrangement(track_dir, _am)
         except Exception as exc:  # noqa: BLE001 — non-fatal during re-anchor
-            console.print(
-                f"  [yellow]configurator manifests not refreshed: {exc}[/yellow]"
-            )
+            console.print(f"  [yellow]configurator manifests not refreshed: {exc}[/yellow]")
 
     console.print()
     console.print(Rule("[bold green]Re-anchored[/bold green]"))
@@ -941,9 +939,7 @@ def re_anchor(
             console.print("  curated/ rebuilt with fresh diversity picks at new anchor.")
         else:
             console.print("  curated/ re-sliced at new anchor.")
-        console.print(
-            "  auto_curation_manifest.json + arrangement_manifest.json refreshed."
-        )
+        console.print("  auto_curation_manifest.json + arrangement_manifest.json refreshed.")
     if keep_old:
         console.print("  [dim]Old chunks preserved at <stem>_prechop.bak/.[/dim]")
 
@@ -1082,14 +1078,11 @@ def migrate_forge(slug):
     slug, forge_dir = _resolve_forge_dir(slug)
 
     if new_manifest_exists(forge_dir) and not legacy_manifest_exists(forge_dir):
-        console.print(
-            f"[yellow]forge `{slug}` already on new shape; nothing to migrate.[/yellow]"
-        )
+        console.print(f"[yellow]forge `{slug}` already on new shape; nothing to migrate.[/yellow]")
         return
     if not legacy_manifest_exists(forge_dir):
         raise click.ClickException(
-            f"forge `{slug}` has no curated/manifest.json to migrate "
-            f"(forge dir: {forge_dir})"
+            f"forge `{slug}` has no curated/manifest.json to migrate (forge dir: {forge_dir})"
         )
 
     try:
@@ -1100,9 +1093,7 @@ def migrate_forge(slug):
     console.print(Rule(f"[bold cyan]migrate-forge[/bold cyan] — {slug}"))
     console.print(f"  wrote {fm_path.relative_to(forge_dir)}")
     console.print(f"  wrote {am_path.relative_to(forge_dir)}")
-    console.print(
-        "  [dim]legacy curated/manifest.json left in place for one-release compat[/dim]"
-    )
+    console.print("  [dim]legacy curated/manifest.json left in place for one-release compat[/dim]")
 
 
 @cli.command("re-curate")
@@ -1166,11 +1157,7 @@ def re_curate(slug, strategy, n_bars):
             legacy_data = {}
 
     replay_strategy = strategy or legacy_data.get("strategy") or "max-diversity"
-    replay_n_bars = (
-        n_bars
-        if n_bars is not None
-        else int(legacy_data.get("n_bars") or 16)
-    )
+    replay_n_bars = n_bars if n_bars is not None else int(legacy_data.get("n_bars") or 16)
     replay_time_sig = int(legacy_data.get("time_signature_numerator") or 4)
 
     console.print(Rule(f"[bold cyan]re-curate[/bold cyan] — {slug}"))
@@ -1195,9 +1182,7 @@ def re_curate(slug, strategy, n_bars):
         check=False,
     )
     if result.returncode != 0:
-        raise click.ClickException(
-            f"v0/src/stemforge_curate_bars.py exited {result.returncode}"
-        )
+        raise click.ClickException(f"v0/src/stemforge_curate_bars.py exited {result.returncode}")
 
     if not legacy_path.exists():
         raise click.ClickException(
@@ -1207,9 +1192,7 @@ def re_curate(slug, strategy, n_bars):
     try:
         curated_dict = json.loads(legacy_path.read_text())
     except json.JSONDecodeError as exc:
-        raise click.ClickException(
-            f"re-curate wrote a malformed legacy manifest: {exc}"
-        ) from exc
+        raise click.ClickException(f"re-curate wrote a malformed legacy manifest: {exc}") from exc
 
     stems_data = json.loads(stems_json.read_text())
     bpm_val = float(curated_dict.get("bpm") or stems_data.get("bpm") or 120.0)

--- a/stemforge/configurator/schemas/__init__.py
+++ b/stemforge/configurator/schemas/__init__.py
@@ -33,7 +33,13 @@ from .curation import (
     ReferencedForge,
     Target,
 )
-from .forge import ArrangementChunk, ArrangementManifest, ForgeClip, ForgeManifest
+from .forge import (
+    ArrangementChunk,
+    ArrangementManifest,
+    ForgeClip,
+    ForgeManifest,
+    compute_manifest_hash,
+)
 
 # Phase 1B/2 intent-wire schemas (previously stemforge/configurator/schemas.py).
 # Re-exported here so existing imports
@@ -65,6 +71,7 @@ __all__ = [
     "Curation",
     "ForgeClip",
     "ForgeManifest",
+    "compute_manifest_hash",
     "Group",
     "LastBounce",
     "LastExport",

--- a/stemforge/configurator/schemas/forge.py
+++ b/stemforge/configurator/schemas/forge.py
@@ -16,7 +16,9 @@ re-curations.
 
 from __future__ import annotations
 
-from typing import Literal
+import hashlib
+import json
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -83,3 +85,27 @@ class ArrangementManifest(BaseModel):
     first_downbeat_sec: float = Field(..., ge=0.0)
     manifest_hash: str = Field(..., description="SHA-256 of canonical chunks array")
     chunks: list[ArrangementChunk] = Field(default_factory=list)
+
+
+# ── manifest_hash helpers ────────────────────────────────────────────────────
+
+
+def _canonical_json(payload: Any) -> str:
+    """Canonical JSON for hashing: sorted keys, no whitespace, UTF-8 safe."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_manifest_hash(items: list[dict[str, Any]]) -> str:
+    """SHA-256 of the canonical JSON of a clips/chunks array.
+
+    Per spec §2.2 the ``manifest_hash`` field is the hash of the
+    ``clips`` array (auto-curation) or ``chunks`` array (arrangement),
+    not the whole manifest dict. ``items`` should be the
+    ``model_dump(mode="json")`` form of the list — each entry a dict
+    with primitive-only values.
+
+    The function is pure: callers compute the hash, then set
+    ``manifest_hash`` on the manifest before serializing it.
+    """
+    canon = _canonical_json(items)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()

--- a/stemforge/forge/__init__.py
+++ b/stemforge/forge/__init__.py
@@ -1,0 +1,42 @@
+"""Forge file-shape I/O (Phase 1A, ``feat/configurator-1a-cli-migration``).
+
+The configurator v1 (spec §2.2) splits a forge's on-disk surface into two
+sibling files instead of the single legacy ``curated/manifest.json``:
+
+- ``auto_curation_manifest.json`` — the auto-curated deck (clips array,
+  ``schema_version``, ``manifest_hash``).
+- ``arrangement_manifest.json`` — arrangement-view chunks (chunks array,
+  ``schema_version``, ``manifest_hash``).
+
+``manifest_io.load_forge`` is the single entry point for reading either
+shape; it auto-detects and converts legacy → new for one release before
+the legacy ``manifest.json`` is dropped in a follow-up cleanup.
+"""
+
+from .manifest_io import (
+    LegacyForgeError,
+    ForgeManifestError,
+    load_forge,
+    load_arrangement,
+    write_auto_curation,
+    write_arrangement,
+    migrate_legacy,
+    legacy_manifest_exists,
+    new_manifest_exists,
+    build_from_curated_dict,
+    build_empty_arrangement,
+)
+
+__all__ = [
+    "LegacyForgeError",
+    "ForgeManifestError",
+    "load_forge",
+    "load_arrangement",
+    "write_auto_curation",
+    "write_arrangement",
+    "migrate_legacy",
+    "legacy_manifest_exists",
+    "new_manifest_exists",
+    "build_from_curated_dict",
+    "build_empty_arrangement",
+]

--- a/stemforge/forge/manifest_io.py
+++ b/stemforge/forge/manifest_io.py
@@ -1,0 +1,492 @@
+"""Atomic readers + writers for the configurator v1 forge file shape.
+
+Spec: `specs/CONSOLIDATED_DESIGN.md` §2.2.
+
+The legacy shape was a single ``curated/manifest.json`` dict embedding both
+auto-curation and arrangement data. The new shape lives at the forge root
+(`~/stemforge/processed/<slug>/`) as two sibling files:
+
+- ``auto_curation_manifest.json`` — `ForgeManifest` (clips array + bpm +
+  `first_downbeat_sec` + `manifest_hash`)
+- ``arrangement_manifest.json`` — `ArrangementManifest` (chunks array +
+  bpm + `first_downbeat_sec` + `manifest_hash`)
+
+This module provides a compat shim that reads either shape so the rest of
+the CLI doesn't have to care. New writers always emit the new shape;
+``migrate_legacy`` converts old-only forges in place (leaving the legacy
+file in place for one release for safety).
+
+All writes go through a ``.tmp + os.replace`` atomic dance so a crash mid-
+write can't leave a partial file behind.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import click
+from pydantic import ValidationError
+
+from stemforge.configurator.schemas import (
+    ArrangementChunk,
+    ArrangementManifest,
+    ForgeClip,
+    ForgeManifest,
+    compute_manifest_hash,
+)
+
+
+# ── Filenames (single source of truth) ───────────────────────────────────────
+
+AUTO_CURATION_FILENAME = "auto_curation_manifest.json"
+ARRANGEMENT_FILENAME = "arrangement_manifest.json"
+LEGACY_FILENAME = "manifest.json"
+LEGACY_PARENT = "curated"
+
+
+class ForgeManifestError(click.ClickException):
+    """Raised when a forge directory's manifest can't be read/parsed.
+
+    Subclass of ``ClickException`` so the CLI surfaces a clean one-line
+    error instead of a stacktrace.
+    """
+
+
+class LegacyForgeError(ForgeManifestError):
+    """Raised when only the legacy ``curated/manifest.json`` exists and the
+    caller asked for new-shape semantics without opting into migration.
+    """
+
+
+# ── Path helpers ─────────────────────────────────────────────────────────────
+
+
+def _auto_curation_path(forge_dir: Path) -> Path:
+    return forge_dir / AUTO_CURATION_FILENAME
+
+
+def _arrangement_path(forge_dir: Path) -> Path:
+    return forge_dir / ARRANGEMENT_FILENAME
+
+
+def _legacy_path(forge_dir: Path) -> Path:
+    return forge_dir / LEGACY_PARENT / LEGACY_FILENAME
+
+
+def new_manifest_exists(forge_dir: Path) -> bool:
+    """True when the new-shape ``auto_curation_manifest.json`` is present."""
+    return _auto_curation_path(forge_dir).exists()
+
+
+def legacy_manifest_exists(forge_dir: Path) -> bool:
+    """True when only the legacy ``curated/manifest.json`` is present."""
+    return _legacy_path(forge_dir).exists()
+
+
+# ── Atomic write ─────────────────────────────────────────────────────────────
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON to ``path`` atomically via ``.tmp`` + ``os.replace``.
+
+    The temp file lives in the same directory so the rename is a true
+    in-filesystem atomic move (cross-device renames would degrade to copy).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    os.replace(tmp, path)
+
+
+# ── Writers (Pydantic-validated) ─────────────────────────────────────────────
+
+
+def write_auto_curation(forge_dir: Path, manifest: ForgeManifest) -> Path:
+    """Write the auto-curation manifest atomically.
+
+    ``manifest_hash`` is recomputed from the canonical clips array and
+    overwrites whatever the caller put on ``manifest.manifest_hash`` —
+    this is the load-bearing invariant for stale detection.
+    """
+    clip_dicts = [c.model_dump(mode="json") for c in manifest.clips]
+    manifest = manifest.model_copy(update={"manifest_hash": compute_manifest_hash(clip_dicts)})
+    out = _auto_curation_path(forge_dir)
+    _atomic_write_json(out, manifest.model_dump(mode="json"))
+    return out
+
+
+def write_arrangement(forge_dir: Path, manifest: ArrangementManifest) -> Path:
+    """Write the arrangement manifest atomically (hash recomputed from chunks)."""
+    chunk_dicts = [c.model_dump(mode="json") for c in manifest.chunks]
+    manifest = manifest.model_copy(update={"manifest_hash": compute_manifest_hash(chunk_dicts)})
+    out = _arrangement_path(forge_dir)
+    _atomic_write_json(out, manifest.model_dump(mode="json"))
+    return out
+
+
+# ── Readers ──────────────────────────────────────────────────────────────────
+
+
+def _parse_forge_manifest(slug: str, path: Path) -> ForgeManifest:
+    """Parse a new-shape ``auto_curation_manifest.json`` with clean errors."""
+    try:
+        raw = path.read_text()
+    except OSError as e:
+        raise ForgeManifestError(f"forge `{slug}` manifest unreadable: {e}") from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed manifest: invalid JSON ({e.msg} at line {e.lineno})"
+        ) from e
+    try:
+        return ForgeManifest(**data)
+    except ValidationError as e:
+        # First error is enough — give the user the actionable detail
+        first = e.errors()[0]
+        loc = ".".join(str(p) for p in first.get("loc", ())) or "<root>"
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed manifest: {loc}: {first.get('msg', 'invalid')}"
+        ) from e
+
+
+def _parse_arrangement_manifest(slug: str, path: Path) -> ArrangementManifest:
+    try:
+        raw = path.read_text()
+    except OSError as e:
+        raise ForgeManifestError(f"forge `{slug}` arrangement unreadable: {e}") from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed arrangement: invalid JSON ({e.msg} at line {e.lineno})"
+        ) from e
+    try:
+        return ArrangementManifest(**data)
+    except ValidationError as e:
+        first = e.errors()[0]
+        loc = ".".join(str(p) for p in first.get("loc", ())) or "<root>"
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed arrangement: {loc}: {first.get('msg', 'invalid')}"
+        ) from e
+
+
+def load_forge(slug: str, forge_dir: Path | None = None) -> ForgeManifest:
+    """Read a forge's auto-curation manifest, auto-detecting shape.
+
+    - New shape (`auto_curation_manifest.json` present): parse + return.
+    - Legacy-only (`curated/manifest.json` present): convert in-memory and
+      return — the caller gets a `ForgeManifest`, the on-disk legacy file
+      is left untouched. Run ``stemforge migrate-forge`` to make it
+      permanent.
+
+    Both paths return Pydantic-validated models.
+    """
+    if forge_dir is None:
+        from stemforge.config import PROCESSED_DIR
+
+        forge_dir = PROCESSED_DIR / slug
+    forge_dir = Path(forge_dir)
+
+    new_path = _auto_curation_path(forge_dir)
+    if new_path.exists():
+        return _parse_forge_manifest(slug, new_path)
+
+    legacy_path = _legacy_path(forge_dir)
+    if legacy_path.exists():
+        return _legacy_to_forge_manifest(slug, legacy_path)
+
+    raise ForgeManifestError(
+        f"forge `{slug}` has no manifest "
+        f"(expected {AUTO_CURATION_FILENAME} or {LEGACY_PARENT}/{LEGACY_FILENAME} "
+        f"under {forge_dir})"
+    )
+
+
+def load_arrangement(slug: str, forge_dir: Path | None = None) -> ArrangementManifest | None:
+    """Read a forge's arrangement manifest. Returns None when absent.
+
+    Legacy forges did not separate arrangement data; if the new file is
+    absent the caller can derive arrangement chunks from prechop output or
+    skip the arrangement view entirely. Returning None instead of raising
+    keeps the device-side flow tolerant for compat.
+    """
+    if forge_dir is None:
+        from stemforge.config import PROCESSED_DIR
+
+        forge_dir = PROCESSED_DIR / slug
+    forge_dir = Path(forge_dir)
+
+    new_path = _arrangement_path(forge_dir)
+    if not new_path.exists():
+        return None
+    return _parse_arrangement_manifest(slug, new_path)
+
+
+# ── Legacy → new conversion ──────────────────────────────────────────────────
+
+
+_LEGACY_STEM_ALIAS = {
+    "drums": "drum",
+    "drum": "drum",
+    "bass": "bass",
+    "vocals": "vocal",
+    "vocal": "vocal",
+    "other": "other",
+}
+
+
+def _stem_label(legacy_name: str) -> str:
+    """Map legacy stem keys (``drums``, ``vocals``) onto the new Literal
+    set the forge schema accepts (``drum``, ``vocal``). Unknown stems are
+    bucketed into ``other`` rather than rejected — legacy forges may have
+    extra stems (guitar, piano) we don't want to lose silently.
+    """
+    return _LEGACY_STEM_ALIAS.get(legacy_name, "other")
+
+
+def _legacy_clip_id(stem_label: str, position: int, n_bars: int) -> str:
+    """Build a stable clip_id from legacy `position` + n_bars/position math."""
+    start = (position - 1) * n_bars
+    end = position * n_bars
+    return f"{stem_label}-bar{start}-{end}"
+
+
+def _read_legacy(legacy_path: Path, slug: str) -> dict[str, Any]:
+    try:
+        raw = legacy_path.read_text()
+    except OSError as e:
+        raise ForgeManifestError(f"forge `{slug}` legacy manifest unreadable: {e}") from e
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed legacy manifest: invalid JSON "
+            f"({e.msg} at line {e.lineno})"
+        ) from e
+
+
+def _legacy_to_forge_manifest(slug: str, legacy_path: Path) -> ForgeManifest:
+    """In-memory conversion of legacy → ForgeManifest. Does not write."""
+    data = _read_legacy(legacy_path, slug)
+    forge_slug, source_audio, bpm, n_bars, clips = _legacy_extract(data, slug)
+    return ForgeManifest(
+        schema_version=1,
+        forge_slug=forge_slug,
+        source_audio=source_audio,
+        bpm=bpm,
+        first_downbeat_sec=float(data.get("first_downbeat_sec", 0.0) or 0.0),
+        manifest_hash=compute_manifest_hash([c.model_dump(mode="json") for c in clips]),
+        default_template=data.get("default_template"),
+        clips=clips,
+    )
+
+
+def _legacy_to_arrangement_manifest(
+    slug: str,
+    legacy_path: Path,
+) -> ArrangementManifest:
+    """Extract arrangement chunks from a legacy manifest, or build an empty
+    arrangement manifest when the legacy file has no arrangement data.
+
+    Legacy v0/v1 single-file manifests rarely carried arrangement chunks
+    inline; arrangement data lived in a sibling ``prechop_manifest.json``.
+    For migration we emit an arrangement manifest with the same
+    bpm/source_audio metadata so downstream readers don't crash, even if
+    chunks is empty. A follow-up `re-anchor` or fresh `forge` run will
+    populate chunks from prechop output.
+    """
+    data = _read_legacy(legacy_path, slug)
+    forge_slug, source_audio, bpm, _n_bars, _clips = _legacy_extract(data, slug)
+    chunks: list[ArrangementChunk] = []
+    # Legacy "arrangement" inline shape (rare): {"arrangement": [{...}, ...]}
+    for raw in data.get("arrangement", []) or []:
+        try:
+            chunks.append(
+                ArrangementChunk(
+                    chunk_id=str(raw["chunk_id"]),
+                    audio_path=str(raw["audio_path"]),
+                    stem=_stem_label(str(raw.get("stem", "other"))),  # type: ignore[arg-type]
+                    source_position_sec=float(raw.get("source_position_sec", 0.0)),
+                    duration_sec=float(raw["duration_sec"]),
+                    bar_position=int(raw.get("bar_position", 0)),
+                    duration_bars=int(raw.get("duration_bars", 0)),
+                )
+            )
+        except (KeyError, ValueError, TypeError):
+            # Skip malformed inline rows rather than killing the whole migration.
+            continue
+    chunk_dicts = [c.model_dump(mode="json") for c in chunks]
+    return ArrangementManifest(
+        schema_version=1,
+        forge_slug=forge_slug,
+        source_audio=source_audio,
+        bpm=bpm,
+        first_downbeat_sec=float(data.get("first_downbeat_sec", 0.0) or 0.0),
+        manifest_hash=compute_manifest_hash(chunk_dicts),
+        chunks=chunks,
+    )
+
+
+def _legacy_extract(
+    data: dict[str, Any],
+    slug: str,
+) -> tuple[str, str, float, int, list[ForgeClip]]:
+    """Pull the four invariants + clips list out of a legacy manifest dict.
+
+    Returns (forge_slug, source_audio, bpm, n_bars, clips).
+    """
+    forge_slug = data.get("forge_slug") or data.get("track") or slug
+    source_audio = (
+        data.get("source_audio")
+        or data.get("source_file")
+        or data.get("source_dir")
+        or ""
+    )
+    bpm = data.get("bpm")
+    if bpm is None or float(bpm) <= 0:
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed legacy manifest: missing or non-positive bpm"
+        )
+    bpm = float(bpm)
+    n_bars = int(data.get("n_bars", 1)) or 1
+
+    clips: list[ForgeClip] = []
+    stems_dict = data.get("stems")
+    if not isinstance(stems_dict, dict):
+        raise ForgeManifestError(
+            f"forge `{slug}` has malformed legacy manifest: missing or non-object stems"
+        )
+    for stem_name, entries in stems_dict.items():
+        # v2 production shape: stems[stem_name] is a dict with `loops`, `oneshots`, etc.
+        if isinstance(entries, dict):
+            entries = entries.get("loops") or []
+        if not isinstance(entries, list):
+            continue
+        stem_label = _stem_label(stem_name)
+        for entry in entries:
+            if not isinstance(entry, dict) or "file" not in entry:
+                continue
+            position = int(entry.get("position", entry.get("rank", len(clips) + 1)))
+            duration_bars = int(entry.get("duration_bars", n_bars))
+            start_bar = (position - 1) * duration_bars
+            end_bar = start_bar + duration_bars
+            audio_path = str(entry["file"])
+            # Strip leading "curated/" so audio_path is relative to the
+            # forge root, matching the new-shape fixtures.
+            if audio_path.startswith("curated/"):
+                audio_path = audio_path[len("curated/") :]
+                # New-shape lives audio under `curated_audio/`; we map
+                # `curated/<stem>/<file>` → `curated_audio/<stem>-bar*-*.wav`
+                # by clip_id below. Preserve the original path on disk;
+                # we only rewrite when there's a deterministic mapping.
+                audio_path = f"curated_audio/{Path(audio_path).name}"
+            clip_id = entry.get("clip_id") or _legacy_clip_id(
+                stem_label, position, duration_bars
+            )
+            try:
+                clips.append(
+                    ForgeClip(
+                        clip_id=str(clip_id),
+                        audio_path=audio_path,
+                        stem=stem_label,  # type: ignore[arg-type]
+                        source_bar_range=(start_bar, end_bar),
+                        duration_bars=duration_bars,
+                        tags=list(entry.get("tags", []) or []),
+                    )
+                )
+            except ValidationError:
+                continue
+    return forge_slug, source_audio, bpm, n_bars, clips
+
+
+def build_from_curated_dict(
+    slug: str,
+    forge_dir: Path,
+    curated: dict[str, Any],
+    *,
+    bpm: float | None = None,
+    first_downbeat_sec: float = 0.0,
+    default_template: str | None = None,
+) -> ForgeManifest:
+    """Build a ``ForgeManifest`` from an in-memory legacy ``curated``
+    dict (the same dict shape ``stemforge forge`` writes to
+    ``curated/manifest.json``).
+
+    Used by writers that want to emit the new-shape file alongside the
+    legacy one during the compat window. ``bpm`` overrides the dict's bpm
+    field (handy when the bpm landed elsewhere in the pipeline). Other
+    invariants — source_audio, n_bars, stems — are pulled from ``curated``.
+
+    Returns an in-memory ``ForgeManifest``; the caller writes it with
+    ``write_auto_curation`` to get the atomic on-disk file.
+    """
+    merged = dict(curated)
+    if bpm is not None:
+        merged["bpm"] = bpm
+    if "bpm" not in merged or merged["bpm"] in (None, 0):
+        # Legacy forges sometimes omit bpm at the top of `curated_manifest`
+        # because it lives in stems.json. Synthesize a non-zero placeholder
+        # only when the caller didn't supply one — the schema rejects 0.
+        merged["bpm"] = 120.0
+    forge_slug, source_audio, bpm_val, _n_bars, clips = _legacy_extract(merged, slug)
+    return ForgeManifest(
+        schema_version=1,
+        forge_slug=forge_slug,
+        source_audio=source_audio,
+        bpm=bpm_val,
+        first_downbeat_sec=float(first_downbeat_sec or 0.0),
+        manifest_hash=compute_manifest_hash([c.model_dump(mode="json") for c in clips]),
+        default_template=default_template,
+        clips=clips,
+    )
+
+
+def build_empty_arrangement(
+    slug: str,
+    *,
+    source_audio: str,
+    bpm: float,
+    first_downbeat_sec: float = 0.0,
+) -> ArrangementManifest:
+    """Build a zero-chunk arrangement manifest with the forge's invariants.
+
+    Used when the writer hasn't computed arrangement chunks yet (forge
+    command without prechop, e.g.). The file's existence is what unblocks
+    downstream Phase 1B/1C/1D consumers that load both manifests; an empty
+    chunks list is a valid, well-formed manifest.
+    """
+    return ArrangementManifest(
+        schema_version=1,
+        forge_slug=slug,
+        source_audio=source_audio,
+        bpm=bpm,
+        first_downbeat_sec=float(first_downbeat_sec or 0.0),
+        manifest_hash=compute_manifest_hash([]),
+        chunks=[],
+    )
+
+
+def migrate_legacy(slug: str, forge_dir: Path) -> tuple[Path, Path]:
+    """Convert a legacy ``curated/manifest.json`` into the new two-file shape.
+
+    Atomic per file. Leaves the legacy file in place for one release for
+    backward compatibility — a follow-up cleanup will delete it.
+
+    Returns (auto_curation_path, arrangement_path).
+    """
+    legacy_path = _legacy_path(forge_dir)
+    if not legacy_path.exists():
+        raise ForgeManifestError(
+            f"forge `{slug}` has no legacy manifest at {legacy_path}; nothing to migrate"
+        )
+
+    forge_manifest = _legacy_to_forge_manifest(slug, legacy_path)
+    arrangement_manifest = _legacy_to_arrangement_manifest(slug, legacy_path)
+
+    fm_path = write_auto_curation(forge_dir, forge_manifest)
+    am_path = write_arrangement(forge_dir, arrangement_manifest)
+    return fm_path, am_path

--- a/stemforge/forge/manifest_io.py
+++ b/stemforge/forge/manifest_io.py
@@ -341,10 +341,7 @@ def _legacy_extract(
     """
     forge_slug = data.get("forge_slug") or data.get("track") or slug
     source_audio = (
-        data.get("source_audio")
-        or data.get("source_file")
-        or data.get("source_dir")
-        or ""
+        data.get("source_audio") or data.get("source_file") or data.get("source_dir") or ""
     )
     bpm = data.get("bpm")
     if bpm is None or float(bpm) <= 0:
@@ -370,7 +367,7 @@ def _legacy_extract(
         for entry in entries:
             if not isinstance(entry, dict) or "file" not in entry:
                 continue
-            position = int(entry.get("position", entry.get("rank", len(clips) + 1)))
+            position = int(entry.get("position") or entry.get("rank") or (len(clips) + 1))
             duration_bars = int(entry.get("duration_bars", n_bars))
             start_bar = (position - 1) * duration_bars
             end_bar = start_bar + duration_bars
@@ -384,9 +381,7 @@ def _legacy_extract(
                 # by clip_id below. Preserve the original path on disk;
                 # we only rewrite when there's a deterministic mapping.
                 audio_path = f"curated_audio/{Path(audio_path).name}"
-            clip_id = entry.get("clip_id") or _legacy_clip_id(
-                stem_label, position, duration_bars
-            )
+            clip_id = entry.get("clip_id") or _legacy_clip_id(stem_label, position, duration_bars)
             try:
                 clips.append(
                     ForgeClip(

--- a/tests/test_cli_forge_migration.py
+++ b/tests/test_cli_forge_migration.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from stemforge.cli import cli

--- a/tests/test_cli_forge_migration.py
+++ b/tests/test_cli_forge_migration.py
@@ -1,0 +1,242 @@
+"""CliRunner tests for Phase 1A configurator CLI commands.
+
+- `stemforge migrate-forge <slug>` round-trip + error handling.
+- `stemforge re-curate <slug>` produces fresh manifest_hash when params
+  change (stems unchanged).
+- `stemforge forge --help` advertises the new flags / behavior.
+- `stemforge migrate-forge --help` smoke.
+
+`re-curate` shells out to `v0/src/stemforge_curate_bars.py` (which depends
+on librosa + the full split output) — for the CLI-level fast test we
+patch the subprocess call and pre-stage a synthetic legacy manifest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from stemforge.cli import cli
+from stemforge.configurator.schemas import ForgeManifest, compute_manifest_hash
+from stemforge.forge.manifest_io import (
+    ARRANGEMENT_FILENAME,
+    AUTO_CURATION_FILENAME,
+)
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "forges"
+
+
+def _seed_legacy_forge(forge_root: Path, *, source_fixture: str = "sample-forge") -> Path:
+    """Stage a legacy forge dir under ``forge_root/<slug>/`` derived from a
+    Phase 0 new-shape fixture. Returns the forge dir (containing
+    ``curated/manifest.json``).
+    """
+    fixture_new = json.loads(
+        (FIXTURES / source_fixture / "auto_curation_manifest.json").read_text()
+    )
+    forge_dir = forge_root / source_fixture
+    (forge_dir / "curated").mkdir(parents=True)
+    # Build legacy manifest mirror of the new shape's clips.
+    LABEL_TO_LEGACY = {"drum": "drums", "bass": "bass", "vocal": "vocals", "other": "other"}
+    stems: dict[str, list] = {}
+    for clip in fixture_new["clips"]:
+        legacy_stem = LABEL_TO_LEGACY[clip["stem"]]
+        stems.setdefault(legacy_stem, []).append(
+            {
+                "position": len(stems.get(legacy_stem, [])) + 1,
+                "clip_id": clip["clip_id"],
+                "file": clip["audio_path"],
+                "duration_bars": clip["duration_bars"],
+            }
+        )
+    legacy = {
+        "track": fixture_new["forge_slug"],
+        "source_audio": fixture_new["source_audio"],
+        "strategy": "max-diversity",
+        "n_bars": fixture_new["clips"][0]["duration_bars"],
+        "bpm": fixture_new["bpm"],
+        "first_downbeat_sec": fixture_new["first_downbeat_sec"],
+        "time_signature_numerator": 4,
+        "stems": stems,
+    }
+    (forge_dir / "curated" / "manifest.json").write_text(json.dumps(legacy))
+    # Also drop a minimal stems.json so re-curate can find it.
+    (forge_dir / "stems.json").write_text(
+        json.dumps(
+            {
+                "track_name": fixture_new["forge_slug"],
+                "source_file": fixture_new["source_audio"],
+                "backend": "demucs",
+                "bpm": fixture_new["bpm"],
+                "beat_count": 0,
+                "stems": [],
+                "pipeline": "default",
+                "processed_at": "2026-05-13T00:00:00",
+            }
+        )
+    )
+    return forge_dir
+
+
+# ── migrate-forge ────────────────────────────────────────────────────────────
+
+
+def test_migrate_forge_help_loads():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["migrate-forge", "--help"])
+    assert result.exit_code == 0
+    assert "auto_curation_manifest" in result.output
+    assert "arrangement_manifest" in result.output
+
+
+def test_migrate_forge_round_trip_against_breaks_n_beats_fixture(tmp_path: Path):
+    """End-to-end: stage a legacy curated/manifest.json built from the
+    breaks-n-beats-deck fixture, run `stemforge migrate-forge <path>`,
+    assert both new-shape files exist with valid content and matching
+    manifest_hash. The legacy file is preserved (compat window).
+    """
+    forge_dir = _seed_legacy_forge(tmp_path, source_fixture="breaks-n-beats-deck")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["migrate-forge", str(forge_dir)])
+    assert result.exit_code == 0, result.output
+
+    fm_path = forge_dir / AUTO_CURATION_FILENAME
+    am_path = forge_dir / ARRANGEMENT_FILENAME
+    assert fm_path.exists()
+    assert am_path.exists()
+    # Legacy left in place for one-release compat
+    assert (forge_dir / "curated" / "manifest.json").exists()
+
+    new_fm = json.loads(fm_path.read_text())
+    fixture_fm = json.loads(
+        (FIXTURES / "breaks-n-beats-deck" / "auto_curation_manifest.json").read_text()
+    )
+    assert new_fm["forge_slug"] == "breaks-n-beats-deck"
+    assert new_fm["bpm"] == fixture_fm["bpm"]
+    assert new_fm["first_downbeat_sec"] == fixture_fm["first_downbeat_sec"]
+    assert new_fm["schema_version"] == 1
+    assert len(new_fm["clips"]) == len(fixture_fm["clips"])
+    # manifest_hash is canonical hash of clips
+    assert new_fm["manifest_hash"] == compute_manifest_hash(new_fm["clips"])
+    # Round-trip through Pydantic
+    ForgeManifest(**new_fm)
+
+
+def test_migrate_forge_idempotent_already_migrated(tmp_path: Path):
+    """Running migrate-forge twice is a no-op the second time."""
+    forge_dir = _seed_legacy_forge(tmp_path)
+    runner = CliRunner()
+    r1 = runner.invoke(cli, ["migrate-forge", str(forge_dir)])
+    assert r1.exit_code == 0, r1.output
+    # Drop the legacy file to simulate post-cleanup state
+    (forge_dir / "curated" / "manifest.json").unlink()
+    r2 = runner.invoke(cli, ["migrate-forge", str(forge_dir)])
+    assert r2.exit_code == 0, r2.output
+    assert "already on new shape" in r2.output
+
+
+def test_migrate_forge_missing_legacy_clean_error(tmp_path: Path):
+    """No legacy manifest → ClickException with a clean message, not stacktrace."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["migrate-forge", str(empty_dir)])
+    assert result.exit_code != 0
+    assert (
+        "no curated/manifest.json" in result.output.lower() or "no curated" in result.output.lower()
+    )
+
+
+def test_migrate_forge_corrupt_legacy_clean_error(tmp_path: Path):
+    forge_dir = tmp_path / "broken"
+    (forge_dir / "curated").mkdir(parents=True)
+    (forge_dir / "curated" / "manifest.json").write_text("{ not json")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["migrate-forge", str(forge_dir)])
+    assert result.exit_code != 0
+    assert "malformed" in result.output.lower() or "invalid" in result.output.lower()
+
+
+# ── re-curate ────────────────────────────────────────────────────────────────
+
+
+def test_re_curate_help_loads():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["re-curate", "--help"])
+    assert result.exit_code == 0
+    assert "Re-run auto-curation" in result.output
+    assert "stale" in result.output.lower()
+
+
+def test_re_curate_missing_stems_clean_error(tmp_path: Path):
+    forge_dir = tmp_path / "noforge"
+    forge_dir.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["re-curate", str(forge_dir)])
+    assert result.exit_code != 0
+    assert "stems.json" in result.output
+
+
+def test_re_curate_produces_fresh_manifest_hash_when_params_change(tmp_path: Path, monkeypatch):
+    """Stems are unchanged but the curator's strategy changes → new
+    auto_curation_manifest.json must have a different manifest_hash.
+
+    We stub out the subprocess call to the v0 curate script (which would
+    otherwise require librosa + real audio) and instead emit a synthetic
+    legacy manifest whose contents differ when the strategy differs. The
+    point of the test is: re-curate REWRITES the new-shape file and
+    refreshes the hash from the (potentially new) clips.
+    """
+    forge_dir = _seed_legacy_forge(tmp_path, source_fixture="sample-forge")
+
+    # Initial state: write the new shape directly so we have a baseline hash.
+    runner = CliRunner()
+    initial = runner.invoke(cli, ["migrate-forge", str(forge_dir)])
+    assert initial.exit_code == 0, initial.output
+    baseline_fm = json.loads((forge_dir / AUTO_CURATION_FILENAME).read_text())
+
+    # Patch subprocess.run inside the cli module to simulate the curate
+    # script overwriting the legacy file with a different clip set.
+    import stemforge.cli as cli_mod
+
+    fake_legacy = json.loads((forge_dir / "curated" / "manifest.json").read_text())
+    # Mutate: change a clip's file path so the resulting hash is different.
+    first_stem = next(iter(fake_legacy["stems"].keys()))
+    fake_legacy["stems"][first_stem][0]["file"] = "curated_audio/MUTATED.wav"
+    fake_legacy["strategy"] = "rhythm-taxonomy"
+    fake_legacy["bpm"] = baseline_fm["bpm"]  # keep bpm stable
+
+    class _FakeResult:
+        returncode = 0
+
+    def _fake_run(*args, **kwargs):
+        (forge_dir / "curated" / "manifest.json").write_text(json.dumps(fake_legacy))
+        return _FakeResult()
+
+    monkeypatch.setattr(cli_mod.subprocess, "run", _fake_run)
+
+    result = runner.invoke(cli, ["re-curate", str(forge_dir), "--strategy", "rhythm-taxonomy"])
+    assert result.exit_code == 0, result.output
+
+    refreshed_fm = json.loads((forge_dir / AUTO_CURATION_FILENAME).read_text())
+    assert refreshed_fm["manifest_hash"] != baseline_fm["manifest_hash"], (
+        "re-curate must produce a new manifest_hash when clips change"
+    )
+    # Schema invariants preserved
+    assert refreshed_fm["schema_version"] == 1
+    assert refreshed_fm["forge_slug"] == baseline_fm["forge_slug"]
+
+
+# ── Sentinel: forge --help still loads + lists new subcommands in group help
+
+
+def test_cli_group_help_lists_migrate_forge_and_re_curate():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "migrate-forge" in result.output
+    assert "re-curate" in result.output

--- a/tests/test_curator_new_shape_emission.py
+++ b/tests/test_curator_new_shape_emission.py
@@ -1,0 +1,84 @@
+"""Sentinel tests: every forge writer in stemforge/cli.py emits the new
+two-file shape (auto_curation_manifest.json + arrangement_manifest.json)
+alongside the legacy curated/manifest.json.
+
+These are static / wiring tests because the heavy commands (forge,
+re-anchor, reslice-curated) require Demucs + real audio and are marked
+@pytest.mark.live for the integration suite. The sentinels lock the
+call-site wiring in place so future refactors can't silently drop the
+new-shape emission.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+CLI_PATH = Path(__file__).resolve().parent.parent / "stemforge" / "cli.py"
+
+
+def test_forge_command_imports_new_writers():
+    """The forge command imports both write_auto_curation and write_arrangement."""
+    src = CLI_PATH.read_text()
+    # Two import sites: inline path + --curation production path
+    assert src.count("write_auto_curation") >= 2, (
+        "forge must call write_auto_curation in both inline and --curation branches"
+    )
+    assert src.count("write_arrangement") >= 2, (
+        "forge must call write_arrangement in both inline and --curation branches"
+    )
+
+
+def test_re_anchor_emits_new_shape_when_curated_exists():
+    """re-anchor refreshes auto_curation_manifest.json + arrangement_manifest.json."""
+    src = CLI_PATH.read_text()
+    # Re-anchor body contains the new-shape writer calls.
+    # Locate the re-anchor function and assert the writers appear within it.
+    match = re.search(
+        r"def re_anchor\(.*?\n(.+?)\n@cli\.command",
+        src,
+        re.DOTALL,
+    )
+    assert match, "re_anchor function body not found"
+    body = match.group(1)
+    assert "write_auto_curation" in body, (
+        "re-anchor must call write_auto_curation when curated/ exists"
+    )
+    assert "write_arrangement" in body, "re-anchor must call write_arrangement when curated/ exists"
+
+
+def test_reslice_curated_emits_new_shape():
+    """reslice-curated refreshes the new-shape manifests after reslicing."""
+    src = CLI_PATH.read_text()
+    match = re.search(
+        r"def reslice_curated\(.*?\n(.+?)\n@cli\.command",
+        src,
+        re.DOTALL,
+    )
+    assert match, "reslice_curated function body not found"
+    body = match.group(1)
+    assert "write_auto_curation" in body
+    assert "write_arrangement" in body
+
+
+def test_migrate_forge_subcommand_registered():
+    """stemforge migrate-forge is a registered subcommand."""
+    src = CLI_PATH.read_text()
+    assert '@cli.command("migrate-forge")' in src
+
+
+def test_re_curate_subcommand_registered():
+    """stemforge re-curate is a registered subcommand."""
+    src = CLI_PATH.read_text()
+    assert '@cli.command("re-curate")' in src
+
+
+def test_forge_emits_manifest_hash_in_complete_event():
+    """The forge command's 'complete' event includes manifest_hash so M4L
+    can store the reference for stale detection."""
+    src = CLI_PATH.read_text()
+    # The legacy inline path's complete event must carry the new fields.
+    # Look for "complete" event emit with manifest_hash.
+    assert "manifest_hash=_fm.manifest_hash" in src, (
+        "forge's 'complete' event must publish manifest_hash for stale-detection wiring"
+    )

--- a/tests/test_forge_manifest_io.py
+++ b/tests/test_forge_manifest_io.py
@@ -1,0 +1,318 @@
+"""Tests for `stemforge.forge.manifest_io` — Phase 1A compat shim.
+
+Covers:
+- `load_forge` auto-detection of new vs legacy shape.
+- Atomic write helpers + manifest_hash recomputation invariant.
+- Pydantic-validated reads with clean error surfacing.
+- Legacy → new conversion via `migrate_legacy`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from stemforge.configurator.schemas import (
+    ArrangementManifest,
+    ForgeClip,
+    ForgeManifest,
+    compute_manifest_hash,
+)
+from stemforge.forge import (
+    ForgeManifestError,
+    build_empty_arrangement,
+    build_from_curated_dict,
+    legacy_manifest_exists,
+    load_arrangement,
+    load_forge,
+    migrate_legacy,
+    new_manifest_exists,
+    write_arrangement,
+    write_auto_curation,
+)
+from stemforge.forge.manifest_io import (
+    ARRANGEMENT_FILENAME,
+    AUTO_CURATION_FILENAME,
+)
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "forges"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _legacy_manifest_from_new(new_path: Path, source_audio: str = "/tmp/test.wav") -> dict:
+    """Build a legacy v1 single-file `curated/manifest.json` dict equivalent
+    to a Phase 0 new-shape `auto_curation_manifest.json`.
+
+    Maps the new shape's per-clip entries into the legacy `stems` dict so we
+    can round-trip migrate → new and assert byte-for-byte equality on the
+    invariants.
+    """
+    new_data = json.loads(new_path.read_text())
+    stems: dict[str, list] = {}
+    # We need to map new clip stem labels (drum/bass/vocal/other) back to the
+    # legacy plural form (drums/bass/vocals/other) so _stem_label round-trips.
+    LABEL_TO_LEGACY = {"drum": "drums", "bass": "bass", "vocal": "vocals", "other": "other"}
+    for clip in new_data["clips"]:
+        legacy_stem = LABEL_TO_LEGACY[clip["stem"]]
+        stems.setdefault(legacy_stem, []).append(
+            {
+                "position": stems.get(legacy_stem, [{}])[-1].get("position", 0) + 1
+                if stems.get(legacy_stem)
+                else 1,
+                "clip_id": clip["clip_id"],
+                "file": clip["audio_path"],
+                "duration_bars": clip["duration_bars"],
+                "tags": clip["tags"],
+            }
+        )
+    return {
+        "track": new_data["forge_slug"],
+        "source_audio": new_data.get("source_audio") or source_audio,
+        "strategy": "max-diversity",
+        "n_bars": new_data["clips"][0]["duration_bars"] if new_data["clips"] else 4,
+        "bpm": new_data["bpm"],
+        "first_downbeat_sec": new_data["first_downbeat_sec"],
+        "time_signature_numerator": 4,
+        "stems": stems,
+    }
+
+
+# ── Helper round-trips ───────────────────────────────────────────────────────
+
+
+def test_compute_manifest_hash_canonical_independent_of_key_order():
+    """Two dicts with the same content but different insertion order hash
+    to the same value — keys are canonicalized before hashing."""
+    a = [{"clip_id": "x", "stem": "drum"}]
+    b = [{"stem": "drum", "clip_id": "x"}]
+    assert compute_manifest_hash(a) == compute_manifest_hash(b)
+
+
+def test_compute_manifest_hash_matches_phase0_fixtures():
+    """The Phase 0 fixtures' stored manifest_hash equals what
+    compute_manifest_hash returns on their clips/chunks arrays."""
+    for forge in ("sample-forge", "breaks-n-beats-deck"):
+        ac = json.loads((FIXTURES / forge / "auto_curation_manifest.json").read_text())
+        ar = json.loads((FIXTURES / forge / "arrangement_manifest.json").read_text())
+        assert ac["manifest_hash"] == compute_manifest_hash(ac["clips"]), forge
+        assert ar["manifest_hash"] == compute_manifest_hash(ar["chunks"]), forge
+
+
+# ── Atomic writers ──────────────────────────────────────────────────────────
+
+
+def test_write_auto_curation_atomic_recomputes_hash(tmp_path: Path):
+    """Writer recomputes manifest_hash from the canonical clips array,
+    overwriting whatever the caller put on the model."""
+    fm = ForgeManifest(
+        schema_version=1,
+        forge_slug="test",
+        source_audio="/tmp/t.wav",
+        bpm=120.0,
+        first_downbeat_sec=0.0,
+        manifest_hash="0" * 64,  # bogus — writer must overwrite
+        clips=[
+            ForgeClip(
+                clip_id="drum-bar0-4",
+                audio_path="curated_audio/drum-bar0-4.wav",
+                stem="drum",
+                source_bar_range=(0, 4),
+                duration_bars=4,
+            )
+        ],
+    )
+    out = write_auto_curation(tmp_path, fm)
+    assert out.name == AUTO_CURATION_FILENAME
+    on_disk = json.loads(out.read_text())
+    expected = compute_manifest_hash([c.model_dump(mode="json") for c in fm.clips])
+    assert on_disk["manifest_hash"] == expected
+    assert on_disk["manifest_hash"] != "0" * 64
+    # No leftover temp file
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_write_arrangement_atomic_recomputes_hash(tmp_path: Path):
+    am = build_empty_arrangement(
+        slug="test", source_audio="/tmp/t.wav", bpm=120.0, first_downbeat_sec=0.0
+    )
+    out = write_arrangement(tmp_path, am)
+    assert out.name == ARRANGEMENT_FILENAME
+    on_disk = json.loads(out.read_text())
+    assert on_disk["manifest_hash"] == compute_manifest_hash([])
+    assert on_disk["chunks"] == []
+
+
+# ── load_forge auto-detection ────────────────────────────────────────────────
+
+
+def test_load_forge_new_shape(tmp_path: Path):
+    """load_forge returns a ForgeManifest from the new-shape file."""
+    fixture = FIXTURES / "sample-forge"
+    for f in ("auto_curation_manifest.json", "arrangement_manifest.json"):
+        (tmp_path / f).write_text((fixture / f).read_text())
+    assert new_manifest_exists(tmp_path)
+    fm = load_forge("sample-forge", forge_dir=tmp_path)
+    assert isinstance(fm, ForgeManifest)
+    assert fm.forge_slug == "sample-forge"
+    assert len(fm.clips) == 4
+    am = load_arrangement("sample-forge", forge_dir=tmp_path)
+    assert isinstance(am, ArrangementManifest)
+    assert len(am.chunks) == 2
+
+
+def test_load_forge_legacy_shape_only(tmp_path: Path):
+    """When only legacy curated/manifest.json exists, load_forge converts on read."""
+    legacy = _legacy_manifest_from_new(FIXTURES / "sample-forge" / "auto_curation_manifest.json")
+    legacy_path = tmp_path / "curated" / "manifest.json"
+    legacy_path.parent.mkdir()
+    legacy_path.write_text(json.dumps(legacy))
+    assert legacy_manifest_exists(tmp_path)
+    assert not new_manifest_exists(tmp_path)
+    fm = load_forge("sample-forge", forge_dir=tmp_path)
+    assert isinstance(fm, ForgeManifest)
+    assert fm.bpm == 120.0
+    assert len(fm.clips) == 4
+    # arrangement should be None (no inline arrangement in legacy)
+    assert load_arrangement("sample-forge", forge_dir=tmp_path) is None
+
+
+def test_load_forge_missing_both_raises_clean_error(tmp_path: Path):
+    with pytest.raises(ForgeManifestError) as exc:
+        load_forge("ghost", forge_dir=tmp_path)
+    assert "ghost" in str(exc.value)
+    assert "no manifest" in str(exc.value).lower()
+
+
+def test_load_forge_corrupt_json_clean_error(tmp_path: Path):
+    (tmp_path / AUTO_CURATION_FILENAME).write_text("{not valid json")
+    with pytest.raises(ForgeManifestError) as exc:
+        load_forge("broken", forge_dir=tmp_path)
+    msg = str(exc.value)
+    assert "broken" in msg
+    assert "malformed" in msg.lower() or "invalid" in msg.lower()
+
+
+def test_load_forge_malformed_pydantic_clean_error(tmp_path: Path):
+    """Schema-valid JSON but Pydantic-invalid (negative bpm) → clean ClickException."""
+    (tmp_path / AUTO_CURATION_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "forge_slug": "bad",
+                "source_audio": "/tmp/x.wav",
+                "bpm": -1.0,  # forbidden
+                "first_downbeat_sec": 0.0,
+                "manifest_hash": "0" * 64,
+                "clips": [],
+            }
+        )
+    )
+    with pytest.raises(ForgeManifestError) as exc:
+        load_forge("bad", forge_dir=tmp_path)
+    assert "bad" in str(exc.value)
+    assert "bpm" in str(exc.value).lower()
+
+
+# ── migrate_legacy ───────────────────────────────────────────────────────────
+
+
+def test_migrate_legacy_round_trip_against_phase0_fixture(tmp_path: Path):
+    """Round-trip: build legacy from Phase 0 fixture → migrate → assert
+    the produced new-shape manifest matches the fixture on key invariants
+    (bpm, first_downbeat_sec, clip count, manifest_hash via canonical).
+    """
+    fixture_new = json.loads(
+        (FIXTURES / "breaks-n-beats-deck" / "auto_curation_manifest.json").read_text()
+    )
+    legacy_dict = _legacy_manifest_from_new(
+        FIXTURES / "breaks-n-beats-deck" / "auto_curation_manifest.json"
+    )
+    (tmp_path / "curated").mkdir()
+    (tmp_path / "curated" / "manifest.json").write_text(json.dumps(legacy_dict))
+
+    fm_path, am_path = migrate_legacy("breaks-n-beats-deck", tmp_path)
+
+    # Both files exist and validate.
+    assert fm_path.exists()
+    assert am_path.exists()
+    on_disk_fm = json.loads(fm_path.read_text())
+    assert on_disk_fm["forge_slug"] == "breaks-n-beats-deck"
+    assert on_disk_fm["bpm"] == fixture_new["bpm"]
+    assert on_disk_fm["first_downbeat_sec"] == fixture_new["first_downbeat_sec"]
+    assert on_disk_fm["schema_version"] == 1
+    # Same number of clips — content fidelity through the round-trip.
+    assert len(on_disk_fm["clips"]) == len(fixture_new["clips"])
+    # manifest_hash recomputed against on-disk clips.
+    assert on_disk_fm["manifest_hash"] == compute_manifest_hash(on_disk_fm["clips"])
+    # Legacy file is preserved (one-release compat window).
+    assert (tmp_path / "curated" / "manifest.json").exists()
+
+
+def test_migrate_legacy_missing_legacy_raises(tmp_path: Path):
+    with pytest.raises(ForgeManifestError) as exc:
+        migrate_legacy("ghost", tmp_path)
+    assert "no legacy manifest" in str(exc.value).lower()
+
+
+def test_migrate_legacy_malformed_legacy_raises(tmp_path: Path):
+    (tmp_path / "curated").mkdir()
+    (tmp_path / "curated" / "manifest.json").write_text("{ not json")
+    with pytest.raises(ForgeManifestError) as exc:
+        migrate_legacy("broken", tmp_path)
+    msg = str(exc.value).lower()
+    assert "malformed" in msg and "broken" in msg
+
+
+# ── build_from_curated_dict ─────────────────────────────────────────────────
+
+
+def test_build_from_curated_dict_synthesizes_bpm_when_missing(tmp_path: Path):
+    """Legacy v0 forge dicts sometimes lack bpm — build_from_curated_dict
+    synthesizes a placeholder (120.0) so the schema-required positive bpm
+    doesn't reject the migration. Callers can override via the bpm kwarg.
+    """
+    curated = {
+        "track": "x",
+        "source_audio": "/tmp/x.wav",
+        "stems": {"drums": [{"position": 1, "file": "curated/drums/bar_01.wav"}]},
+        "n_bars": 1,
+    }
+    fm = build_from_curated_dict(slug="x", forge_dir=tmp_path, curated=curated)
+    assert fm.bpm == 120.0
+    assert len(fm.clips) == 1
+    # Override path
+    fm2 = build_from_curated_dict(slug="x", forge_dir=tmp_path, curated=curated, bpm=88.5)
+    assert fm2.bpm == 88.5
+
+
+def test_build_from_curated_dict_handles_v2_production_loops_block(tmp_path: Path):
+    """v0 production curator nests entries under stems[X].loops — our
+    extractor handles both list and dict-with-loops shapes."""
+    curated = {
+        "track": "prod",
+        "source_audio": "/tmp/prod.wav",
+        "bpm": 138.0,
+        "n_bars": 4,
+        "stems": {
+            "drums": {
+                "loops": [
+                    {"position": 1, "file": "curated/drums/bar_01.wav", "duration_bars": 4},
+                    {"position": 2, "file": "curated/drums/bar_02.wav", "duration_bars": 4},
+                ],
+                "oneshots": [],
+            },
+            "bass": [
+                {"position": 1, "file": "curated/bass/bar_01.wav", "duration_bars": 4},
+            ],
+        },
+    }
+    fm = build_from_curated_dict(slug="prod", forge_dir=tmp_path, curated=curated)
+    drum_clips = [c for c in fm.clips if c.stem == "drum"]
+    bass_clips = [c for c in fm.clips if c.stem == "bass"]
+    assert len(drum_clips) == 2
+    assert len(bass_clips) == 1


### PR DESCRIPTION
## Summary

Phase 1A of `docs/configurator/EXECUTION_PLAN_v1.md`. Unblocks Phase 1B/1C/1D consumers of the new forge shape.

Five deliverables landed on the Python source-pipeline side:

1. **`stemforge migrate-forge <slug>`** — reads legacy `~/stemforge/processed/<slug>/curated/manifest.json`, writes `auto_curation_manifest.json` + `arrangement_manifest.json` at the forge root with `schema_version: 1` and a computed `manifest_hash`. Atomic via `.tmp` + `os.replace`. Legacy file left in place for one release.
2. **All forge writers emit the new shape** — `stemforge forge` (both inline + `--curation` production paths), `stemforge re-anchor`, and `stemforge reslice-curated` all emit the new two-file shape alongside the legacy `curated/manifest.json` during the compat window. Pydantic-validated serialization via the new `stemforge/forge/manifest_io.py` (not hand-rolled `json.dump`).
3. **`stemforge re-curate <slug>`** — re-runs auto-curation only (skips stem separation), producing a fresh `manifest_hash`. This is what Phase 4B's stale detection hangs off of. Replays strategy/n_bars from the legacy manifest unless overridden via `-s` / `-n`.
4. **Compatibility shim** — `stemforge/forge/manifest_io.py` adds `load_forge` / `load_arrangement` that auto-detect old vs new shapes and convert legacy → new on read. Old-only forges get a `ForgeManifest` returned in memory; on-disk legacy is left untouched until the user runs `migrate-forge`.
5. **Pydantic-validated reads** — every forge manifest read goes through the schema. Malformed manifests produce a clean `ClickException` (`"forge <slug> has malformed manifest: <validation detail>"`) instead of a stacktrace.

`compute_manifest_hash(items)` helper added to `stemforge/configurator/schemas/forge.py` — SHA-256 of canonical JSON of the clips/chunks array (matches spec §2.2 and the Phase 0 fixture `manifest_hash` values exactly).

## Test plan

- [x] `uv run pytest tests/test_forge_manifest_io.py tests/test_cli_forge_migration.py tests/test_curator_new_shape_emission.py -v` → **29 passed**.
- [x] `uv run pytest stemforge/ tests/ -q --deselect tests/test_canonical_tempos.py` → **950 passed, 10 skipped, 0 failed**. (The 6 `test_canonical_tempos.py` failures are pre-existing: they require `torch + demucs` from the `native` extra, which the configurator-only CI env doesn't install. Not in this lane's scope.)
- [x] `uv run ruff check stemforge/ tests/test_forge_manifest_io.py tests/test_cli_forge_migration.py tests/test_curator_new_shape_emission.py` → clean.
- [x] `uv run mypy stemforge/forge/` → 0 errors in lane code (1 pre-existing yaml-stub warning in `stemforge/config.py` outside scope).
- [x] `migrate-forge` round-trips Phase 0 `breaks-n-beats-deck` fixture → new shape matches expected on bpm, first_downbeat_sec, clip count, and recomputed manifest_hash.
- [x] `re-curate` produces a fresh `manifest_hash` when clips change (test_re_curate_produces_fresh_manifest_hash_when_params_change).
- [x] `load_forge` succeeds on both new and legacy shapes (test_load_forge_new_shape + test_load_forge_legacy_shape_only).
- [x] Malformed manifest produces a clean `ClickException` (test_load_forge_corrupt_json_clean_error + test_load_forge_malformed_pydantic_clean_error).
- [x] Missing manifests → clear error (test_load_forge_missing_both_raises_clean_error, test_migrate_forge_missing_legacy_clean_error).
- [x] `stemforge --help` shows both new subcommands; `--help` on each renders cleanly.

## Compat-shim removal timeline

The legacy `curated/manifest.json` write/read path stays alive for **one release**. A follow-up cleanup PR (Phase 1A.1) will:

- Delete the legacy-file write in `forge` / `re-anchor` / `reslice-curated`.
- Drop `_legacy_extract` / `migrate_legacy` from `stemforge/forge/manifest_io.py`.
- Remove `curated/manifest.json` from any exporters that still read it (currently `stemforge/exporters/koala.py` and `stemforge/exporters/chompi.py` — both will be migrated to read `auto_curation_manifest.json` directly).

Phase 1A of `docs/configurator/EXECUTION_PLAN_v1.md`. Unblocks Phase 1B/1C/1D consumers of the new forge shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
