### PR TITLE
feat(server): forge endpoints + curation rename/close + schema slots (Phase 1.5 bridge)

### DIFF
--- a/scripts/gen_typescript_types.py
+++ b/scripts/gen_typescript_types.py
@@ -33,9 +33,7 @@ from stemforge.configurator.schemas.export import (  # noqa: E402
     export_all_json_schemas,
 )
 
-OUTPUT_PATH = (
-    _REPO_ROOT / "web" / "configurator" / "src" / "lib" / "api-types.generated.ts"
-)
+OUTPUT_PATH = _REPO_ROOT / "web" / "configurator" / "src" / "lib" / "api-types.generated.ts"
 
 BANNER = (
     "// AUTO-GENERATED — do not edit. Run "

--- a/stemforge/configurator/curation_io.py
+++ b/stemforge/configurator/curation_io.py
@@ -154,6 +154,39 @@ def write_curation_atomic(path: Path, curation: Curation) -> None:
         raise
 
 
+def rename_curation_atomic(src: Path, dst: Path) -> None:
+    """Rename ``src`` → ``dst`` atomically on the same filesystem.
+
+    Used by ``POST /curations/{name}/rename``. The caller is expected to
+    hold both files' :func:`lock_curation` advisory locks for the
+    duration so concurrent writers don't clobber either side. The rename
+    itself is :func:`os.replace`, which is atomic on POSIX same-volume
+    moves.
+
+    Raises :class:`FileNotFoundError` when ``src`` is missing and
+    :class:`FileExistsError` when ``dst`` already exists. The latter is
+    deliberate — overwriting an existing curation in a rename would lose
+    data; the caller surfaces this as 409.
+    """
+    if not src.is_file():
+        raise FileNotFoundError(f"source curation missing: {src}")
+    if dst.exists():
+        raise FileExistsError(f"destination curation exists: {dst}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(src, dst)
+    # Best-effort: rename the lock sidecar too so future ``lock_curation``
+    # calls on the new path find the same flock target. Missing sidecar
+    # is fine — :func:`lock_curation` creates one on demand.
+    src_sidecar = src.with_suffix(src.suffix + ".lock")
+    dst_sidecar = dst.with_suffix(dst.suffix + ".lock")
+    if src_sidecar.exists() and not dst_sidecar.exists():
+        try:
+            os.replace(src_sidecar, dst_sidecar)
+        except OSError:
+            # Lock sidecar move is non-critical; flock() will recreate.
+            pass
+
+
 # ── File lock ────────────────────────────────────────────────────────────────
 
 
@@ -211,5 +244,6 @@ __all__ = [
     "list_curations",
     "lock_curation",
     "read_curation",
+    "rename_curation_atomic",
     "write_curation_atomic",
 ]

--- a/stemforge/configurator/forge_io.py
+++ b/stemforge/configurator/forge_io.py
@@ -1,0 +1,254 @@
+"""Filesystem scan + delegation helpers for the Phase 1.5 forge endpoints.
+
+These helpers wrap the on-disk shape of ``~/stemforge/processed/<slug>/``
+so the server's HTTP routes stay thin. Two responsibilities live here:
+
+1. **Discovery** — :func:`list_forges` walks the processed root and emits
+   one :class:`ForgeIndexEntry` per subdir that has either the new-shape
+   ``auto_curation_manifest.json`` or the legacy ``curated/manifest.json``.
+   Both are recognized via :mod:`stemforge.forge.manifest_io`.
+2. **Slug resolution** — :func:`resolve_forge_dir` validates a slug and
+   returns its dir, or raises a 404-shaped :class:`HTTPException`.
+
+The endpoints themselves (``POST /forges/{slug}/load``, etc.) live in
+:mod:`stemforge.configurator.server`; this module is pure I/O so it stays
+test-friendly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from stemforge.forge.manifest_io import (
+    ARRANGEMENT_FILENAME,
+    AUTO_CURATION_FILENAME,
+    LEGACY_FILENAME,
+    LEGACY_PARENT,
+    ForgeManifestError,
+    load_arrangement,
+    load_forge,
+)
+
+# Reuse the curation-name validator's character class for slug safety —
+# the processed dir's child names mirror the same constraint set.
+_SLUG_FORBIDDEN = ("/", "\\", "..", "\x00")
+
+
+@dataclass
+class ForgeIndexEntry:
+    """One row in ``GET /forges`` — projection over a single forge dir.
+
+    Field set is the union of what the popup's ``ForgeIndexEntry`` and
+    the task brief reference. Optional fields are emitted only when the
+    underlying manifest had them (rather than stamping zeros).
+    """
+
+    slug: str
+    name: str
+    manifest_hash: str
+    modified_at: str
+    has_arrangement: bool
+    sample_count: int
+    bar_count: int
+    target_format: str
+    bpm: float | None = None
+    source_audio: str | None = None
+    chunk_count: int | None = None
+    clip_count: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Emit the dict shape ``GET /forges`` returns over the wire.
+
+        Optional fields are dropped when ``None`` so the popup doesn't have
+        to special-case nulls. Order is alphabetical to keep diffs stable.
+        """
+        payload: dict[str, object] = {
+            "bar_count": self.bar_count,
+            "has_arrangement": self.has_arrangement,
+            "manifest_hash": self.manifest_hash,
+            "modified_at": self.modified_at,
+            "name": self.name,
+            "sample_count": self.sample_count,
+            "slug": self.slug,
+            "target_format": self.target_format,
+        }
+        if self.bpm is not None:
+            payload["bpm"] = self.bpm
+        if self.source_audio is not None:
+            payload["source_audio"] = self.source_audio
+        if self.chunk_count is not None:
+            payload["chunk_count"] = self.chunk_count
+        if self.clip_count is not None:
+            payload["clip_count"] = self.clip_count
+        return payload
+
+
+def default_processed_dir() -> Path:
+    """Return the canonical processed dir (``~/stemforge/processed``)."""
+    return Path.home() / "stemforge" / "processed"
+
+
+def _is_valid_slug(slug: str) -> bool:
+    """Reject the obvious path-traversal patterns; everything else is fine.
+
+    Forge slugs are user-chosen track names that have already been sanitized
+    by ``stemforge forge``. The endpoint surface only needs to refuse
+    actively dangerous values; legitimate slug pickyness lives in the
+    forge writer.
+    """
+    if not isinstance(slug, str) or not slug:
+        return False
+    if any(token in slug for token in _SLUG_FORBIDDEN):
+        return False
+    return True
+
+
+def resolve_forge_dir(
+    processed_dir: Path,
+    slug: str,
+) -> Path:
+    """Return the forge dir for ``slug`` or raise 404.
+
+    Validates the slug shape first (400) before stating the dir (404), so
+    callers get the right error for the right failure mode. Caller is
+    expected to be inside an HTTP handler — the raised exceptions are
+    FastAPI :class:`HTTPException` instances.
+    """
+    if not _is_valid_slug(slug):
+        raise HTTPException(status_code=400, detail=f"invalid forge slug: {slug!r}")
+    forge_dir = processed_dir / slug
+    if not forge_dir.is_dir():
+        raise HTTPException(status_code=404, detail=f"forge not found: {slug}")
+    return forge_dir
+
+
+def has_any_manifest(forge_dir: Path) -> bool:
+    """True if ``forge_dir`` carries either new-shape or legacy manifest.
+
+    Used as the entry-gate in :func:`list_forges` — directories that lack
+    both shapes are not visible to the popup at all (so leftover/work-in-
+    progress dirs don't pollute the rail).
+    """
+    return (forge_dir / AUTO_CURATION_FILENAME).is_file() or (
+        forge_dir / LEGACY_PARENT / LEGACY_FILENAME
+    ).is_file()
+
+
+def _modified_at_iso(path: Path) -> str:
+    """ISO-8601 mtime for ``path`` (UTC). Falls back to "" if path missing."""
+    try:
+        st = os.stat(path)
+    except FileNotFoundError:
+        return ""
+    return datetime.fromtimestamp(st.st_mtime, tz=UTC).isoformat()
+
+
+def _best_mtime_path(forge_dir: Path) -> Path:
+    """Return the manifest file whose mtime should drive ``modified_at``.
+
+    Prefer the new-shape auto-curation manifest when present (it's the
+    canonical document); fall back to the legacy manifest, then the dir
+    itself. Keeps the index sortable by "recently touched" even on
+    pre-migration forges.
+    """
+    new = forge_dir / AUTO_CURATION_FILENAME
+    if new.is_file():
+        return new
+    legacy = forge_dir / LEGACY_PARENT / LEGACY_FILENAME
+    if legacy.is_file():
+        return legacy
+    return forge_dir
+
+
+def index_entry_for(forge_dir: Path, slug: str) -> ForgeIndexEntry:
+    """Build one :class:`ForgeIndexEntry` for an already-validated forge dir.
+
+    Resilient to malformed manifests: a parse failure on ``forge_dir``'s
+    auto-curation file produces a minimal entry (no bpm/sample count, an
+    empty hash) rather than blowing up the whole index. The popup can
+    surface a "broken forge" badge from the empty hash.
+    """
+    arrangement_path = forge_dir / ARRANGEMENT_FILENAME
+    legacy_path = forge_dir / LEGACY_PARENT / LEGACY_FILENAME
+    has_arrangement = arrangement_path.is_file()
+
+    bpm: float | None = None
+    manifest_hash = ""
+    sample_count = 0
+    bar_count = 0
+    chunk_count: int | None = None
+    source_audio: str | None = None
+
+    try:
+        manifest = load_forge(slug, forge_dir=forge_dir)
+        bpm = float(manifest.bpm)
+        manifest_hash = manifest.manifest_hash
+        sample_count = len(manifest.clips)
+        bar_count = sum(int(c.duration_bars) for c in manifest.clips)
+        source_audio = manifest.source_audio or None
+    except ForgeManifestError:
+        # Surface the forge anyway with a zero-ish entry; the empty hash
+        # is the signal to UIs that something is off.
+        pass
+
+    if has_arrangement:
+        try:
+            arrangement = load_arrangement(slug, forge_dir=forge_dir)
+            if arrangement is not None:
+                chunk_count = len(arrangement.chunks)
+        except ForgeManifestError:
+            chunk_count = None
+
+    is_legacy_only = not (forge_dir / AUTO_CURATION_FILENAME).is_file() and legacy_path.is_file()
+    target_format = "legacy" if is_legacy_only else "auto_curation_v1"
+
+    return ForgeIndexEntry(
+        slug=slug,
+        name=slug,
+        manifest_hash=manifest_hash,
+        modified_at=_modified_at_iso(_best_mtime_path(forge_dir)),
+        has_arrangement=has_arrangement,
+        sample_count=sample_count,
+        bar_count=bar_count,
+        target_format=target_format,
+        bpm=bpm,
+        source_audio=source_audio,
+        chunk_count=chunk_count,
+        clip_count=sample_count if sample_count else None,
+    )
+
+
+def list_forges(processed_dir: Path) -> list[ForgeIndexEntry]:
+    """Scan ``processed_dir`` and return one entry per recognized forge.
+
+    Returns ``[]`` when ``processed_dir`` doesn't exist yet. Entries are
+    sorted by ``slug`` for stable output (the popup keeps the order; CI
+    snapshot tests rely on it).
+    """
+    if not processed_dir.is_dir():
+        return []
+    entries: list[ForgeIndexEntry] = []
+    for child in sorted(processed_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith("."):
+            continue
+        if not has_any_manifest(child):
+            continue
+        entries.append(index_entry_for(child, child.name))
+    return entries
+
+
+__all__ = [
+    "ForgeIndexEntry",
+    "default_processed_dir",
+    "has_any_manifest",
+    "index_entry_for",
+    "list_forges",
+    "resolve_forge_dir",
+]

--- a/stemforge/configurator/intents.py
+++ b/stemforge/configurator/intents.py
@@ -51,6 +51,7 @@ from .curation_io import (
     list_curations,
     lock_curation,
     read_curation,
+    rename_curation_atomic,
     write_curation_atomic,
 )
 from .schemas import (
@@ -71,6 +72,7 @@ from .schemas import (
 from .state import (
     AppState,
     load_state,
+    save_state,
     set_active_curation,
 )
 
@@ -446,6 +448,30 @@ class SaveAsBody(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class RenameCurationBody(BaseModel):
+    """Body of ``POST /curations/{name}/rename`` (Phase 1.5).
+
+    ``new_name`` follows the same shape rules as ``POST /curations`` —
+    see :func:`curation_io.is_valid_curation_name`.
+    """
+
+    new_name: str
+
+    model_config = {"extra": "forbid"}
+
+
+class CloseActiveCurationBody(BaseModel):
+    """Body of ``POST /curations/active/close`` (Phase 1.5).
+
+    Clears the active curation for ``als_path`` (sets the map entry to
+    ``None``, removing it from ``.stemforge_state.json``).
+    """
+
+    als_path: str
+
+    model_config = {"extra": "forbid"}
+
+
 class PatchTemplateBody(BaseModel):
     """Body of ``PATCH /curations/{name}/template``."""
 
@@ -462,20 +488,15 @@ class PatchTargetBody(BaseModel):
     """Body of ``PATCH /curations/{name}/target``.
 
     Any subset of fields may be supplied — unspecified fields preserve
-    their current value. ``label`` is per-group (a stretch field for
-    callers that want to relabel a group without sending the full
-    target). When provided alongside ``groups``, the label binding picks
-    the first letter (``A``) by convention.
+    their current value. ``label`` lands on :class:`Target.label`
+    (the curation's target-level hardware label). ``color_palette``
+    lands on :class:`Curation.color_palette`. Both slots were added in
+    Phase 1.5; before that the server accepted-and-dropped these fields.
     """
 
     groups: int | None = Field(default=None, ge=1, le=16)
     pads_per_group: int | None = Field(default=None, ge=1, le=32)
     device: str | None = None
-    # The spec also mentions ``color_palette`` and ``label`` — neither
-    # field exists on the Phase 0 Target/Group schema today. We accept
-    # them so the wire shape from spec §4.3 is honored and store
-    # ``label`` on the first group when present. ``color_palette`` is
-    # accepted-and-ignored at this phase (no schema slot).
     color_palette: list[str] | None = None
     label: str | None = None
 
@@ -716,6 +737,101 @@ async def handle_save_as(
     return cloned
 
 
+async def handle_rename_curation(
+    state: AppState,
+    name: str,
+    body: RenameCurationBody,
+) -> Curation:
+    """``POST /curations/{name}/rename`` — atomic on-disk rename.
+
+    Differs from ``save-as`` in that it MOVES the file (no copy) and
+    rewrites every active-curation entry pointing at the old name so
+    state integrity is preserved. Refuses with:
+
+    - 400 when ``new_name`` is malformed.
+    - 404 when ``name`` doesn't resolve to a curation file.
+    - 409 when ``new_name`` already exists.
+    """
+    if not is_valid_curation_name(name):
+        raise HTTPException(status_code=400, detail=f"invalid curation name: {name!r}")
+    if not is_valid_curation_name(body.new_name):
+        raise HTTPException(status_code=400, detail=f"invalid curation name: {body.new_name!r}")
+    src = curation_path(state.curations_dir, name)
+    dst = curation_path(state.curations_dir, body.new_name)
+
+    if name == body.new_name:
+        # No-op rename — short-circuit so callers can use this as
+        # an idempotent confirm-name endpoint.
+        return _load_curation_or_404(state, name)
+
+    async with state.mutation_lock:
+        if not src.is_file():
+            raise HTTPException(status_code=404, detail=f"curation not found: {name}")
+        if dst.exists():
+            raise HTTPException(
+                status_code=409,
+                detail=f"destination curation exists: {body.new_name}",
+            )
+        # Load + rewrite under lock so the name field on disk matches the
+        # new filename. Then move the file atomically to the new path.
+        with lock_curation(src):
+            curation = read_curation(src)
+            curation.name = body.new_name
+            curation.modified_at = datetime.now(UTC)
+            # Persist the rename in two atomic steps: write the renamed
+            # content at the OLD path (so name field == new_name on disk
+            # before the move), then move src → dst.
+            write_curation_atomic(src, curation)
+            try:
+                rename_curation_atomic(src, dst)
+            except FileExistsError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"destination curation exists: {body.new_name}",
+                ) from exc
+
+        # Patch active-curation state: any als_path pointing at the old
+        # name now points at the new one. We re-load to avoid clobbering
+        # concurrent state-file edits, then save the merged result.
+        try:
+            sf_state = load_state(state.state_path)
+        except (FileNotFoundError, json.JSONDecodeError):
+            sf_state = None
+        if sf_state is not None:
+            mutated = False
+            for als_path, active_name in list(sf_state.active_curations.items()):
+                if active_name == name:
+                    sf_state.active_curations[als_path] = body.new_name
+                    mutated = True
+            if mutated:
+                sf_state.last_seen_at = datetime.now(UTC)
+                save_state(sf_state, state.state_path)
+
+    await state.log(f"renamed curation {name} → {body.new_name}", "info")
+    await state.broadcast_curations_state()
+    return curation
+
+
+async def handle_close_active_curation(
+    state: AppState,
+    body: CloseActiveCurationBody,
+) -> dict[str, Any]:
+    """``POST /curations/active/close`` — clear active for an .als path.
+
+    Removes ``state.active_curations[als_path]`` if present; idempotent
+    when no entry exists. Always broadcasts so the popup re-renders.
+    """
+    async with state.mutation_lock:
+        sf_state = set_active_curation(body.als_path, None, state.state_path)
+    await state.log(f"closed active curation for {body.als_path}", "info")
+    await state.broadcast_curations_state()
+    return {
+        "ok": True,
+        "als_path": body.als_path,
+        "active_curations": sf_state.active_curations,
+    }
+
+
 async def handle_delete_curation(state: AppState, name: str) -> dict[str, Any]:
     """``DELETE /curations/{name}`` — remove file unless active."""
     if not is_valid_curation_name(name):
@@ -815,12 +931,19 @@ async def handle_patch_target(
                     curation.groups[letter].pads = pads[: new_target.pads_per_group]
 
         if body.label is not None:
-            # The Phase 0 schema attaches label to Group, not Target.
-            # Apply to the first group as the "primary" group label —
-            # callers wanting per-group labels use template/etc.
+            # Phase 1.5: label is a first-class Target field. Persist it
+            # on ``Target.label``. Per Phase 1B's deprecated behavior we
+            # ALSO mirror it onto the first group's label so legacy
+            # readers (which keyed off ``groups.A.label``) keep seeing
+            # it; that mirroring drops in Phase 2 once readers migrate.
+            new_target.label = body.label
+            curation.target = new_target
             first_letter = _ALL_GROUP_LETTERS[0]
             if first_letter in curation.groups:
                 curation.groups[first_letter].label = body.label
+
+        if body.color_palette is not None:
+            curation.color_palette = body.color_palette
 
         curation.modified_at = datetime.now(UTC)
         with lock_curation(path):
@@ -914,14 +1037,17 @@ async def handle_curation_commit(
 
 
 __all__ = [
+    "CloseActiveCurationBody",
     "CommitCurationBody",
     "CreateCurationBody",
     "OpenCurationBody",
     "PatchTargetBody",
     "PatchTemplateBody",
+    "RenameCurationBody",
     "SaveAsBody",
     "handle_assign_pad",
     "handle_clear_pad",
+    "handle_close_active_curation",
     "handle_commit",
     "handle_create_curation",
     "handle_curation_commit",
@@ -934,6 +1060,7 @@ __all__ = [
     "handle_patch_target",
     "handle_patch_template",
     "handle_recompute",
+    "handle_rename_curation",
     "handle_save_as",
     "handle_set_group_format",
 ]

--- a/stemforge/configurator/schemas/curation.py
+++ b/stemforge/configurator/schemas/curation.py
@@ -92,6 +92,13 @@ class Target(BaseModel):
     device: str = Field("ep133", description="Target device identifier (ep133 only in v1)")
     groups: int = Field(4, ge=1, le=16, description="Number of groups")
     pads_per_group: int = Field(12, ge=1, le=32, description="Pads per group")
+    label: str | None = Field(
+        default=None,
+        description=(
+            "Optional human-readable label for the target hardware "
+            "(e.g. 'Studio EP-133'). Distinct from per-group Group.label."
+        ),
+    )
 
 
 class ReferencedForge(BaseModel):
@@ -148,6 +155,13 @@ class Curation(BaseModel):
     modified_at: datetime
     target: Target
     referenced_forges: list[ReferencedForge] = Field(default_factory=list)
+    color_palette: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional list of color hex strings (or named-palette refs) for "
+            "the popup/device to render. Mirrors spec §2.3."
+        ),
+    )
     groups: dict[str, Group] = Field(
         default_factory=dict,
         description="Group letter (A, B, ...) → Group. Determined by target.groups.",

--- a/stemforge/configurator/server.py
+++ b/stemforge/configurator/server.py
@@ -32,6 +32,17 @@ Routes (Phase 1B — curation CRUD, spec §4.3):
 - ``PATCH  /curations/{name}/target``
 - ``POST   /curations/{name}/commit``
 
+Routes (Phase 1.5 — forge endpoints + curation rename/close bridge):
+
+- ``GET  /forges``
+- ``POST /forges/{slug}/load``
+- ``POST /forges/{slug}/unload``
+- ``POST /forges/{slug}/re-anchor``
+- ``POST /forges/{slug}/re-curate``
+- ``POST /forges/{slug}/reveal``
+- ``POST /curations/{name}/rename``
+- ``POST /curations/active/close``
+
 Plus a static-files mount on ``/`` (configurable static dir; defaults to
 the package's ``static/`` directory). Lane B's frontend build output
 lands there.
@@ -43,6 +54,7 @@ import asyncio
 import json
 import os
 import socket
+import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator
@@ -50,16 +62,20 @@ from typing import Any, AsyncIterator
 from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
 
 from stemforge.scene_model import Project
 
 from . import intents
+from .forge_io import default_processed_dir, list_forges, resolve_forge_dir
 from .intents import (
+    CloseActiveCurationBody,
     CommitCurationBody,
     CreateCurationBody,
     OpenCurationBody,
     PatchTargetBody,
     PatchTemplateBody,
+    RenameCurationBody,
     SaveAsBody,
 )
 from .preview import build_audio_response
@@ -84,6 +100,7 @@ STATIC_DIR_ENV = "STEMFORGE_CONFIGURATOR_STATIC"
 DEFAULT_STATIC_DIR = Path(__file__).parent / "static"
 CURATIONS_DIR_ENV = "STEMFORGE_CURATIONS_DIR"
 STATE_FILE_ENV = "STEMFORGE_STATE_FILE"
+PROCESSED_DIR_ENV = "STEMFORGE_PROCESSED_DIR"
 PLACEHOLDER_HTML = (
     '<!doctype html><html><head><meta charset="utf-8">'
     "<title>StemForge Configurator</title></head><body>"
@@ -101,6 +118,8 @@ def create_app(
     static_dir: Path | None = None,
     curations_dir: Path | None = None,
     state_path: Path | None = None,
+    processed_dir: Path | None = None,
+    subprocess_runner: Any | None = None,
 ) -> FastAPI:
     """Construct a fresh :class:`FastAPI` app and bind an :class:`AppState`.
 
@@ -111,6 +130,12 @@ def create_app(
     ``curations_dir`` and ``state_path`` override the on-disk locations
     used by the new Phase 1B curation CRUD endpoints; tests point them
     at ``tmp_path`` to keep the user's real ``~/stemforge`` untouched.
+
+    ``processed_dir`` overrides the forge-scan root for the Phase 1.5
+    ``/forges`` endpoints (defaults to ``~/stemforge/processed``).
+    ``subprocess_runner`` is an injection seam for tests — defaults to
+    :func:`subprocess.run`. Production code never overrides it; the test
+    suite stubs it to avoid spawning real ``stemforge`` invocations.
     """
     state = AppState()
     resolved_curations = (
@@ -131,6 +156,15 @@ def create_app(
             else state.state_path
         )
     )
+    resolved_processed = (
+        Path(processed_dir).expanduser().resolve()
+        if processed_dir is not None
+        else (
+            Path(os.environ[PROCESSED_DIR_ENV]).expanduser().resolve()
+            if os.environ.get(PROCESSED_DIR_ENV)
+            else default_processed_dir()
+        )
+    )
     state.curations_dir = resolved_curations
     state.state_path = resolved_state_path
 
@@ -146,6 +180,9 @@ def create_app(
         lifespan=lifespan,
     )
     app.state.configurator = state
+    app.state.processed_dir = resolved_processed
+    app.state.loaded_forges = set()
+    app.state.subprocess_runner = subprocess_runner or subprocess.run
 
     _register_routes(app, state)
 
@@ -167,6 +204,47 @@ def _resolve_static_dir(override: Path | None) -> Path:
     if env:
         return Path(env).expanduser().resolve()
     return DEFAULT_STATIC_DIR.resolve()
+
+
+# ── Phase 1.5 forge endpoint bodies ──────────────────────────────────────────
+
+
+class ReAnchorBody(BaseModel):
+    """Body of ``POST /forges/{slug}/re-anchor`` (Phase 1.5).
+
+    Accepts both the spec's ``downbeat_sec`` and the task brief's
+    ``first_downbeat_seconds`` for the same field. The CLI ultimately
+    receives ``--first-downbeat <float>``. ``source_bpm`` (when non-null)
+    maps to the CLI's ``--bpm`` flag; the CLI command requires both.
+    """
+
+    downbeat_sec: float | None = Field(default=None, ge=0.0)
+    first_downbeat_seconds: float | None = Field(default=None, ge=0.0)
+    source_bpm: float | None = Field(default=None, gt=0.0)
+
+    model_config = {"extra": "forbid"}
+
+    @property
+    def downbeat(self) -> float:
+        """Effective downbeat value (in seconds), preferring whichever was set."""
+        if self.downbeat_sec is not None:
+            return self.downbeat_sec
+        if self.first_downbeat_seconds is not None:
+            return self.first_downbeat_seconds
+        raise ValueError("re-anchor requires downbeat_sec or first_downbeat_seconds")
+
+
+class ReCurateBody(BaseModel):
+    """Body of ``POST /forges/{slug}/re-curate`` (Phase 1.5).
+
+    The underlying ``stemforge re-curate`` command takes no positional
+    args beyond the slug; ``params`` is accepted for forward-compat with
+    the popup's :class:`ReCurateRequest` but unused in v1.
+    """
+
+    params: dict[str, Any] | None = None
+
+    model_config = {"extra": "forbid"}
 
 
 # ── Routes ───────────────────────────────────────────────────────────────────
@@ -287,6 +365,138 @@ def _register_routes(app: FastAPI, state: AppState) -> None:
     @app.post("/curations/{name}/commit", response_model=Curation)
     async def commit_curation_route(name: str, body: CommitCurationBody) -> Curation:
         return await intents.handle_curation_commit(state, name, body)
+
+    # ── Phase 1.5 — curation rename / active close ─────────────────────────
+
+    @app.post("/curations/{name}/rename", response_model=Curation)
+    async def rename_curation_route(name: str, body: RenameCurationBody) -> Curation:
+        return await intents.handle_rename_curation(state, name, body)
+
+    @app.post("/curations/active/close")
+    async def close_active_curation_route(body: CloseActiveCurationBody) -> dict[str, Any]:
+        return await intents.handle_close_active_curation(state, body)
+
+    # ── Phase 1.5 — forge endpoints ────────────────────────────────────────
+
+    @app.get("/forges")
+    async def list_forges_route() -> dict[str, Any]:
+        entries = list_forges(app.state.processed_dir)
+        return {"forges": [e.to_dict() for e in entries]}
+
+    @app.post("/forges/{slug}/load")
+    async def load_forge_route(slug: str) -> dict[str, Any]:
+        forge_dir = resolve_forge_dir(app.state.processed_dir, slug)
+        async with state.mutation_lock:
+            app.state.loaded_forges.add(slug)
+        await state.log(f"loaded forge {slug}", "info")
+        await _broadcast_forge_state(state, app.state.loaded_forges)
+        return {"ok": True, "slug": slug, "path": str(forge_dir)}
+
+    @app.post("/forges/{slug}/unload")
+    async def unload_forge_route(slug: str) -> dict[str, Any]:
+        # Slug validity check; unload of an unknown slug is still a 404
+        # so the popup can surface "nothing to unload" cleanly.
+        resolve_forge_dir(app.state.processed_dir, slug)
+        async with state.mutation_lock:
+            app.state.loaded_forges.discard(slug)
+        await state.log(f"unloaded forge {slug}", "info")
+        await _broadcast_forge_state(state, app.state.loaded_forges)
+        return {"ok": True, "slug": slug}
+
+    @app.post("/forges/{slug}/reveal")
+    async def reveal_forge_route(slug: str) -> dict[str, Any]:
+        forge_dir = resolve_forge_dir(app.state.processed_dir, slug)
+        runner = app.state.subprocess_runner
+        try:
+            runner(["open", str(forge_dir)], check=False)
+        except FileNotFoundError as exc:
+            # ``open`` is missing — likely a non-macOS CI runner. Surface
+            # the failure plainly rather than masking with a 500.
+            raise HTTPException(
+                status_code=500,
+                detail=f"unable to invoke 'open': {exc}",
+            ) from exc
+        return {"ok": True, "path": str(forge_dir)}
+
+    @app.post("/forges/{slug}/re-anchor")
+    async def re_anchor_forge_route(slug: str, body: ReAnchorBody) -> dict[str, Any]:
+        forge_dir = resolve_forge_dir(app.state.processed_dir, slug)
+        try:
+            downbeat = body.downbeat
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        if body.source_bpm is None:
+            # ``stemforge re-anchor`` requires --bpm. Bubble that
+            # constraint up as a 422 so the popup can prompt for it.
+            raise HTTPException(
+                status_code=422,
+                detail="re-anchor requires source_bpm (the CLI's --bpm flag)",
+            )
+        cmd = [
+            "uv",
+            "run",
+            "stemforge",
+            "re-anchor",
+            str(forge_dir),
+            "--bpm",
+            str(body.source_bpm),
+            "--first-downbeat",
+            str(downbeat),
+        ]
+        runner = app.state.subprocess_runner
+        proc = runner(cmd, capture_output=True, text=True, check=False)
+        ok = getattr(proc, "returncode", 1) == 0
+        stdout = getattr(proc, "stdout", "") or ""
+        stderr = getattr(proc, "stderr", "") or ""
+        if ok:
+            await state.log(f"re-anchored forge {slug}", "info")
+            await _broadcast_forge_state(state, app.state.loaded_forges)
+        else:
+            await state.error("re_anchor_failed", stderr.strip() or "re-anchor failed")
+        return {"ok": ok, "slug": slug, "stdout": stdout, "stderr": stderr}
+
+    @app.post("/forges/{slug}/re-curate")
+    async def re_curate_forge_route(slug: str, body: ReCurateBody) -> dict[str, Any]:
+        # ``params`` is currently advisory only; the CLI subcommand takes
+        # no extra positional args beyond the slug.
+        _ = body
+        resolve_forge_dir(app.state.processed_dir, slug)
+        cmd = ["uv", "run", "stemforge", "re-curate", slug]
+        runner = app.state.subprocess_runner
+        proc = runner(cmd, capture_output=True, text=True, check=False)
+        ok = getattr(proc, "returncode", 1) == 0
+        stdout = getattr(proc, "stdout", "") or ""
+        stderr = getattr(proc, "stderr", "") or ""
+        if ok:
+            await state.log(f"re-curated forge {slug}", "info")
+            await _broadcast_forge_state(state, app.state.loaded_forges)
+        else:
+            await state.error("re_curate_failed", stderr.strip() or "re-curate failed")
+        return {"ok": ok, "slug": slug, "stdout": stdout, "stderr": stderr}
+
+
+async def _broadcast_forge_state(state: AppState, loaded: set[str]) -> None:
+    """Push a ``state`` SSE event carrying the loaded-forge set.
+
+    Distinct ``kind`` field so the popup can dispatch on it. We surface
+    ``loaded_forge`` (singular) as the last-loaded slug — matches the
+    task brief's wire shape — and ``loaded_forges`` (plural) as the full
+    set so future multi-load UIs keep working.
+    """
+    import time as _time
+
+    last = sorted(loaded)[-1] if loaded else None
+    await state.broadcast(
+        SseEvent(
+            event="state",
+            data={
+                "kind": "forges",
+                "loaded_forge": last,
+                "loaded_forges": sorted(loaded),
+                "ts": _time.time(),
+            },
+        )
+    )
 
 
 def _resolve_clip_path(project: Project, clip_id: str) -> Path | None:

--- a/tests/test_configurator_curation_extras.py
+++ b/tests/test_configurator_curation_extras.py
@@ -1,0 +1,336 @@
+"""Curation extras tests (Phase 1.5 bridge).
+
+Covers the new ``POST /curations/{name}/rename`` + ``POST /curations/
+active/close`` endpoints, plus the schema fix that makes ``color_palette``
+and ``label`` persist on ``PATCH /curations/{name}/target``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stemforge.configurator.curation_io import (
+    curation_path,
+    read_curation,
+    write_curation_atomic,
+)
+from stemforge.configurator.schemas import Curation, Group, Pad, Target
+from stemforge.configurator.server import create_app
+
+
+# ── Fixtures (mirror Phase 1B layout) ────────────────────────────────────────
+
+
+@pytest.fixture
+def configurator_paths(tmp_path: Path) -> dict[str, Path]:
+    curations_dir = tmp_path / "curations"
+    curations_dir.mkdir()
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    state_path = tmp_path / ".stemforge_state.json"
+    static_dir = tmp_path / "static"
+    return {
+        "curations_dir": curations_dir,
+        "processed_dir": processed_dir,
+        "state_path": state_path,
+        "static_dir": static_dir,
+    }
+
+
+@pytest.fixture
+def client(configurator_paths: dict[str, Path]) -> TestClient:
+    app = create_app(
+        static_dir=configurator_paths["static_dir"],
+        curations_dir=configurator_paths["curations_dir"],
+        state_path=configurator_paths["state_path"],
+        processed_dir=configurator_paths["processed_dir"],
+    )
+    return TestClient(app)
+
+
+def _seed_curation(curations_dir: Path, name: str) -> Curation:
+    """Drop a minimal curation YAML for round-trip tests."""
+    now = datetime.now(UTC)
+    target = Target()
+    groups: dict[str, Group] = {}
+    for letter in ["A", "B", "C", "D"]:
+        pads = [Pad(pad_id=f"{letter}{i + 1:02d}") for i in range(12)]
+        groups[letter] = Group(label="", template=None, pads=pads)
+    curation = Curation(
+        name=name,
+        type="deck",
+        created_at=now,
+        modified_at=now,
+        target=target,
+        referenced_forges=[],
+        groups=groups,
+    )
+    write_curation_atomic(curation_path(curations_dir, name), curation)
+    return curation
+
+
+# ── POST /curations/{name}/rename ────────────────────────────────────────────
+
+
+def test_rename_curation_roundtrip(client: TestClient, configurator_paths: dict[str, Path]) -> None:
+    _seed_curation(configurator_paths["curations_dir"], "original")
+    r = client.post("/curations/original/rename", json={"new_name": "fancy_name"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["name"] == "fancy_name"
+    # Old file gone; new file present and parses cleanly.
+    assert not curation_path(configurator_paths["curations_dir"], "original").is_file()
+    new_path = curation_path(configurator_paths["curations_dir"], "fancy_name")
+    assert new_path.is_file()
+    on_disk = read_curation(new_path)
+    assert on_disk.name == "fancy_name"
+
+
+def test_rename_curation_to_existing_returns_409(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    _seed_curation(configurator_paths["curations_dir"], "src")
+    _seed_curation(configurator_paths["curations_dir"], "dst")
+    r = client.post("/curations/src/rename", json={"new_name": "dst"})
+    assert r.status_code == 409
+    # Both originals must still be on disk.
+    assert curation_path(configurator_paths["curations_dir"], "src").is_file()
+    assert curation_path(configurator_paths["curations_dir"], "dst").is_file()
+
+
+def test_rename_curation_to_invalid_name_returns_400(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    _seed_curation(configurator_paths["curations_dir"], "valid")
+    r = client.post("/curations/valid/rename", json={"new_name": "../escape"})
+    assert r.status_code == 400
+    # File untouched.
+    assert curation_path(configurator_paths["curations_dir"], "valid").is_file()
+
+
+def test_rename_unknown_curation_returns_404(client: TestClient) -> None:
+    r = client.post("/curations/no-such/rename", json={"new_name": "whatever"})
+    assert r.status_code == 404
+
+
+def test_rename_updates_active_curation_state(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """Renaming the active curation rewrites .stemforge_state.json."""
+    _seed_curation(configurator_paths["curations_dir"], "old_name")
+    als = "/Users/zak/Music/Ableton/Set.als"
+    client.post("/curations/old_name/open", json={"als_path": als})
+    r = client.post("/curations/old_name/rename", json={"new_name": "new_name"})
+    assert r.status_code == 200
+    # State file points at the new name now.
+    state_data = json.loads(configurator_paths["state_path"].read_text())
+    assert state_data["active_curations"][als] == "new_name"
+
+
+def test_rename_idempotent_when_new_name_equals_old(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """No-op rename: same-name request must still succeed."""
+    _seed_curation(configurator_paths["curations_dir"], "stay")
+    r = client.post("/curations/stay/rename", json={"new_name": "stay"})
+    assert r.status_code == 200
+    assert r.json()["name"] == "stay"
+    assert curation_path(configurator_paths["curations_dir"], "stay").is_file()
+
+
+def test_rename_broadcasts_sse(configurator_paths: dict[str, Path]) -> None:
+    """Mutation triggers ``state`` SSE event (broker-direct test)."""
+    from stemforge.configurator.intents import (
+        RenameCurationBody,
+        handle_rename_curation,
+    )
+    from stemforge.configurator.state import AppState
+
+    _seed_curation(configurator_paths["curations_dir"], "from")
+    state = AppState()
+    state.curations_dir = configurator_paths["curations_dir"]
+    state.state_path = configurator_paths["state_path"]
+
+    async def _drive() -> list:
+        q = state.subscribe()
+        try:
+            await handle_rename_curation(state, "from", RenameCurationBody(new_name="to"))
+            collected: list = []
+            while not q.empty():
+                collected.append(q.get_nowait())
+            return collected
+        finally:
+            state.unsubscribe(q)
+
+    events = asyncio.run(_drive())
+    state_events = [e for e in events if e.event == "state"]
+    assert state_events, f"no state events; got {[e.event for e in events]}"
+    payload = state_events[-1].data
+    assert payload.get("kind") == "curations"
+    assert "to" in payload["curations"]
+
+
+# ── POST /curations/active/close ─────────────────────────────────────────────
+
+
+def test_close_active_curation_clears_state(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    _seed_curation(configurator_paths["curations_dir"], "live")
+    als = "/tmp/x.als"
+    client.post("/curations/live/open", json={"als_path": als})
+    # Sanity: it's active before close.
+    state_before = json.loads(configurator_paths["state_path"].read_text())
+    assert state_before["active_curations"][als] == "live"
+
+    r = client.post("/curations/active/close", json={"als_path": als})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["als_path"] == als
+    # State file no longer has an active for that als path.
+    state_after = json.loads(configurator_paths["state_path"].read_text())
+    assert als not in state_after["active_curations"]
+
+
+def test_close_active_curation_idempotent_when_no_active(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """No active to close is a no-op — must still return 200."""
+    r = client.post("/curations/active/close", json={"als_path": "/never.als"})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_close_broadcasts_sse(configurator_paths: dict[str, Path]) -> None:
+    from stemforge.configurator.intents import (
+        CloseActiveCurationBody,
+        handle_close_active_curation,
+    )
+    from stemforge.configurator.state import (
+        AppState,
+        set_active_curation,
+    )
+
+    _seed_curation(configurator_paths["curations_dir"], "broadcast_close")
+    state = AppState()
+    state.curations_dir = configurator_paths["curations_dir"]
+    state.state_path = configurator_paths["state_path"]
+    set_active_curation("/tmp/y.als", "broadcast_close", state.state_path)
+
+    async def _drive() -> list:
+        q = state.subscribe()
+        try:
+            await handle_close_active_curation(
+                state, CloseActiveCurationBody(als_path="/tmp/y.als")
+            )
+            collected: list = []
+            while not q.empty():
+                collected.append(q.get_nowait())
+            return collected
+        finally:
+            state.unsubscribe(q)
+
+    events = asyncio.run(_drive())
+    state_events = [e for e in events if e.event == "state"]
+    assert state_events, "expected state event on close"
+
+
+# ── PATCH /curations/{name}/target — color_palette + label persistence ──────
+
+
+def test_patch_target_persists_color_palette_and_label(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """Phase 1.5 schema fix: color_palette + label round-trip via the API."""
+    _seed_curation(configurator_paths["curations_dir"], "palette_test")
+    palette = ["#ff0000", "#00ff00", "#0000ff"]
+    r = client.patch(
+        "/curations/palette_test/target",
+        json={"color_palette": palette, "label": "Studio EP-133"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Target.label is now first-class.
+    assert body["target"]["label"] == "Studio EP-133"
+    # color_palette lives on the curation root.
+    assert body["color_palette"] == palette
+
+    # Round-trip via GET — confirm persistence on disk too.
+    r2 = client.get("/curations/palette_test")
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["target"]["label"] == "Studio EP-133"
+    assert body2["color_palette"] == palette
+
+    # And via direct file read.
+    on_disk = read_curation(curation_path(configurator_paths["curations_dir"], "palette_test"))
+    assert on_disk.target.label == "Studio EP-133"
+    assert on_disk.color_palette == palette
+
+
+def test_patch_target_color_palette_alone_preserves_label(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """Setting one slot doesn't clobber a previously-set sibling."""
+    _seed_curation(configurator_paths["curations_dir"], "preserve_test")
+    client.patch(
+        "/curations/preserve_test/target",
+        json={"label": "First Label"},
+    )
+    client.patch(
+        "/curations/preserve_test/target",
+        json={"color_palette": ["#abcdef"]},
+    )
+    r = client.get("/curations/preserve_test")
+    body = r.json()
+    assert body["target"]["label"] == "First Label"
+    assert body["color_palette"] == ["#abcdef"]
+
+
+def test_patch_target_label_lands_on_target_not_just_first_group(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """Phase 1.5 promotes label to Target. Group A mirroring continues for compat."""
+    _seed_curation(configurator_paths["curations_dir"], "label_target")
+    r = client.patch(
+        "/curations/label_target/target",
+        json={"label": "Performance Rig"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["target"]["label"] == "Performance Rig"
+    # Legacy mirroring still in place — Phase 1B readers keyed off groups.A.label.
+    assert body["groups"]["A"]["label"] == "Performance Rig"
+
+
+# ── Sanity: existing /curations endpoints unaffected ────────────────────────
+
+
+def test_existing_curations_routes_still_present(client: TestClient) -> None:
+    """Smoke test: GET /curations returns the wrapped index, not a 404."""
+    r = client.get("/curations")
+    assert r.status_code == 200
+    body = r.json()
+    assert "curations" in body
+    assert "active_curations" in body
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/forges",
+        "/curations",
+    ],
+)
+def test_index_endpoints_return_dict(client: TestClient, endpoint: str) -> None:
+    """Both index endpoints emit a top-level dict, not a bare array."""
+    r = client.get(endpoint)
+    assert r.status_code == 200
+    assert isinstance(r.json(), dict)

--- a/tests/test_configurator_forges.py
+++ b/tests/test_configurator_forges.py
@@ -1,0 +1,515 @@
+"""Forge endpoint tests (Phase 1.5 bridge, spec §4.3).
+
+Covers ``GET /forges`` discovery + ``POST /forges/{slug}/{load,unload,
+re-anchor,re-curate,reveal}``. Each test spins up an isolated server
+against ``tmp_path`` so the user's real ``~/stemforge`` is never touched;
+``subprocess_runner`` is stubbed so re-anchor / re-curate / reveal calls
+don't shell out to the real CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stemforge.configurator.schemas import (
+    ArrangementChunk,
+    ArrangementManifest,
+    ForgeClip,
+    ForgeManifest,
+    compute_manifest_hash,
+)
+from stemforge.configurator.server import create_app
+from stemforge.forge.manifest_io import (
+    write_arrangement,
+    write_auto_curation,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def configurator_paths(tmp_path: Path) -> dict[str, Path]:
+    """Isolated ``~/stemforge`` layout under ``tmp_path``."""
+    curations_dir = tmp_path / "curations"
+    curations_dir.mkdir()
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    state_path = tmp_path / ".stemforge_state.json"
+    static_dir = tmp_path / "static"
+    return {
+        "curations_dir": curations_dir,
+        "processed_dir": processed_dir,
+        "state_path": state_path,
+        "static_dir": static_dir,
+    }
+
+
+def _make_runner_stub(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> tuple[Callable, list[dict]]:
+    """Build a fake ``subprocess.run`` that records each invocation.
+
+    Returns ``(runner, calls)`` — caller asserts against ``calls``.
+    """
+    calls: list[dict] = []
+
+    def runner(cmd, **kwargs):
+        calls.append({"cmd": list(cmd), "kwargs": dict(kwargs)})
+        return SimpleNamespace(
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    return runner, calls
+
+
+@pytest.fixture
+def client_with_runner(
+    configurator_paths: dict[str, Path],
+) -> Callable:
+    """Factory: build a TestClient with a stub subprocess runner injected."""
+
+    def _build(
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> tuple[TestClient, list[dict]]:
+        runner, calls = _make_runner_stub(returncode=returncode, stdout=stdout, stderr=stderr)
+        app = create_app(
+            static_dir=configurator_paths["static_dir"],
+            curations_dir=configurator_paths["curations_dir"],
+            state_path=configurator_paths["state_path"],
+            processed_dir=configurator_paths["processed_dir"],
+            subprocess_runner=runner,
+        )
+        return TestClient(app), calls
+
+    return _build
+
+
+@pytest.fixture
+def client(client_with_runner) -> TestClient:
+    """Convenience: TestClient backed by a happy-path stub runner."""
+    c, _ = client_with_runner()
+    return c
+
+
+# ── Forge fixture seeding ───────────────────────────────────────────────────
+
+
+def _seed_new_shape_forge(
+    processed_dir: Path,
+    slug: str,
+    *,
+    with_arrangement: bool = True,
+    n_clips: int = 3,
+    n_chunks: int = 4,
+    bpm: float = 120.0,
+) -> Path:
+    """Create a new-shape forge with auto-curation + arrangement manifests."""
+    forge_dir = processed_dir / slug
+    forge_dir.mkdir(parents=True, exist_ok=True)
+    clips = [
+        ForgeClip(
+            clip_id=f"clip-{i}",
+            audio_path=f"curated_audio/clip-{i}.wav",
+            stem="drum",
+            source_bar_range=(i * 4, (i + 1) * 4),
+            duration_bars=4,
+            tags=["loop"],
+        )
+        for i in range(n_clips)
+    ]
+    manifest = ForgeManifest(
+        schema_version=1,
+        forge_slug=slug,
+        source_audio=f"/tmp/{slug}.wav",
+        bpm=bpm,
+        first_downbeat_sec=0.0,
+        manifest_hash=compute_manifest_hash([c.model_dump(mode="json") for c in clips]),
+        clips=clips,
+    )
+    write_auto_curation(forge_dir, manifest)
+    if with_arrangement:
+        chunks = [
+            ArrangementChunk(
+                chunk_id=f"chunk-{i}",
+                audio_path=f"arrangement_chunks/chunk-{i}.wav",
+                stem="drum",
+                source_position_sec=float(i),
+                duration_sec=4.0,
+                bar_position=i * 4,
+                duration_bars=4,
+            )
+            for i in range(n_chunks)
+        ]
+        arrangement = ArrangementManifest(
+            schema_version=1,
+            forge_slug=slug,
+            source_audio=f"/tmp/{slug}.wav",
+            bpm=bpm,
+            first_downbeat_sec=0.0,
+            manifest_hash=compute_manifest_hash([c.model_dump(mode="json") for c in chunks]),
+            chunks=chunks,
+        )
+        write_arrangement(forge_dir, arrangement)
+    return forge_dir
+
+
+def _seed_legacy_forge(processed_dir: Path, slug: str) -> Path:
+    """Drop a minimal legacy ``curated/manifest.json`` forge on disk."""
+    forge_dir = processed_dir / slug
+    (forge_dir / "curated").mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "forge_slug": slug,
+        "source_audio": f"/tmp/{slug}.wav",
+        "bpm": 96.0,
+        "n_bars": 4,
+        "stems": {
+            "drums": [
+                {"file": f"curated/drums/{slug}_bar0.wav", "position": 1},
+                {"file": f"curated/drums/{slug}_bar4.wav", "position": 2},
+            ]
+        },
+    }
+    (forge_dir / "curated" / "manifest.json").write_text(json.dumps(legacy))
+    return forge_dir
+
+
+# ── GET /forges ─────────────────────────────────────────────────────────────
+
+
+def test_list_forges_empty_returns_empty_array(client: TestClient) -> None:
+    r = client.get("/forges")
+    assert r.status_code == 200
+    assert r.json() == {"forges": []}
+
+
+def test_list_forges_returns_both_shapes_sorted_by_slug(
+    client: TestClient,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "zebra", n_clips=5, bpm=140.0)
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "alpha", n_clips=2)
+    _seed_legacy_forge(configurator_paths["processed_dir"], "midnight")
+
+    r = client.get("/forges")
+    assert r.status_code == 200
+    body = r.json()
+    slugs = [e["slug"] for e in body["forges"]]
+    assert slugs == ["alpha", "midnight", "zebra"]
+    # Field sanity-check on a new-shape entry.
+    alpha = next(e for e in body["forges"] if e["slug"] == "alpha")
+    assert alpha["name"] == "alpha"
+    assert alpha["sample_count"] == 2
+    assert alpha["has_arrangement"] is True
+    assert alpha["target_format"] == "auto_curation_v1"
+    assert alpha["manifest_hash"]
+    assert alpha["bar_count"] == 8  # 2 clips × 4 bars
+    assert alpha["bpm"] == 120.0
+    # Legacy entry advertises target_format=legacy.
+    legacy = next(e for e in body["forges"] if e["slug"] == "midnight")
+    assert legacy["target_format"] == "legacy"
+    assert legacy["has_arrangement"] is False
+
+
+def test_list_forges_skips_dirs_without_manifests(
+    client: TestClient,
+    configurator_paths: dict[str, Path],
+) -> None:
+    # Empty subdir — no manifest, should be skipped.
+    (configurator_paths["processed_dir"] / "wip-track").mkdir()
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "real")
+    r = client.get("/forges")
+    slugs = [e["slug"] for e in r.json()["forges"]]
+    assert slugs == ["real"]
+
+
+def test_list_forges_skips_dotdirs(
+    client: TestClient,
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Dotfiles + dotdirs are server-internal scratch (e.g. .DS_Store)."""
+    hidden = configurator_paths["processed_dir"] / ".hidden-cache"
+    hidden.mkdir()
+    (hidden / "auto_curation_manifest.json").write_text("{}")
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "visible")
+    r = client.get("/forges")
+    slugs = [e["slug"] for e in r.json()["forges"]]
+    assert slugs == ["visible"]
+
+
+# ── POST /forges/{slug}/load + /unload ──────────────────────────────────────
+
+
+def test_load_forge_404_when_slug_unknown(client: TestClient) -> None:
+    r = client.post("/forges/no-such-forge/load", json={})
+    assert r.status_code == 404
+    assert "not found" in r.json()["detail"].lower()
+
+
+def test_load_forge_400_on_dangerous_slug(client: TestClient) -> None:
+    """A slug carrying a forbidden token (``..``) must not reach the FS.
+
+    Starlette may reject the route earlier (405) when the URL-encoded
+    payload doesn't match any registered path; any non-200 result is
+    acceptable — the load-bearing invariant is that the directory was
+    never opened/escape-traversed.
+    """
+    r = client.post("/forges/contains..parent/load", json={})
+    # Slug contains ``..`` token → router validator should reject (400)
+    # or the resulting dir lookup misses (404). Either is safe.
+    assert r.status_code in (400, 404), r.text
+
+
+def test_load_forge_marks_loaded_and_returns_path(
+    client: TestClient,
+    configurator_paths: dict[str, Path],
+) -> None:
+    forge_dir = _seed_new_shape_forge(configurator_paths["processed_dir"], "loadme")
+    r = client.post("/forges/loadme/load", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"ok": True, "slug": "loadme", "path": str(forge_dir)}
+
+
+def test_unload_forge_returns_ok(
+    client: TestClient,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "unloadme")
+    # Load then unload.
+    client.post("/forges/unloadme/load", json={})
+    r = client.post("/forges/unloadme/unload", json={})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "slug": "unloadme"}
+
+
+def test_load_forge_broadcasts_sse_state(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Mutating the loaded-forge set emits a ``state`` SSE event.
+
+    We bypass TestClient (which serializes SSE behind its own portal)
+    and test the broker directly via :class:`AppState` — same pattern as
+    the Phase 1B CRUD SSE test.
+    """
+    import asyncio
+
+    from stemforge.configurator.server import create_app as _create_app
+
+    runner, _ = _make_runner_stub()
+    app = _create_app(
+        curations_dir=configurator_paths["curations_dir"],
+        state_path=configurator_paths["state_path"],
+        processed_dir=configurator_paths["processed_dir"],
+        subprocess_runner=runner,
+    )
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "ssetest")
+    state = app.state.configurator
+
+    async def _drive() -> list:
+        queue = state.subscribe()
+        try:
+            # Drive the load handler inline using TestClient to keep
+            # request plumbing simple; the broker is in-process so we
+            # still see the event in the queue.
+            with TestClient(app) as c:
+                resp = c.post("/forges/ssetest/load", json={})
+                assert resp.status_code == 200
+            collected: list = []
+            while not queue.empty():
+                collected.append(queue.get_nowait())
+            return collected
+        finally:
+            state.unsubscribe(queue)
+
+    events = asyncio.run(_drive())
+    state_events = [e for e in events if e.event == "state"]
+    assert state_events, f"no state events; got {[e.event for e in events]}"
+    forge_events = [e for e in state_events if e.data.get("kind") == "forges"]
+    assert forge_events, "expected a forge-state event"
+    assert forge_events[-1].data["loaded_forge"] == "ssetest"
+
+
+# ── POST /forges/{slug}/reveal ──────────────────────────────────────────────
+
+
+def test_reveal_invokes_open_with_forge_path(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    forge_dir = _seed_new_shape_forge(configurator_paths["processed_dir"], "showme")
+    client, calls = client_with_runner()
+    r = client.post("/forges/showme/reveal", json={})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "path": str(forge_dir)}
+    # One ``open`` call with the forge path.
+    assert any(call["cmd"][0] == "open" and call["cmd"][1] == str(forge_dir) for call in calls)
+
+
+def test_reveal_404_when_slug_unknown(client: TestClient) -> None:
+    r = client.post("/forges/ghost/reveal", json={})
+    assert r.status_code == 404
+
+
+# ── POST /forges/{slug}/re-anchor ───────────────────────────────────────────
+
+
+def test_re_anchor_invokes_cli_and_returns_stdout(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    forge_dir = _seed_new_shape_forge(configurator_paths["processed_dir"], "shiftme")
+    client, calls = client_with_runner(returncode=0, stdout="re-anchor: done\n", stderr="")
+    r = client.post(
+        "/forges/shiftme/re-anchor",
+        json={"first_downbeat_seconds": 0.247, "source_bpm": 138.0},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["slug"] == "shiftme"
+    assert "done" in body["stdout"]
+    assert body["stderr"] == ""
+    # CLI was invoked with the right args.
+    cli_calls = [c for c in calls if "re-anchor" in c["cmd"]]
+    assert len(cli_calls) == 1
+    cmd = cli_calls[0]["cmd"]
+    assert cmd[:5] == ["uv", "run", "stemforge", "re-anchor", str(forge_dir)]
+    assert "--bpm" in cmd
+    assert "138.0" in cmd
+    assert "--first-downbeat" in cmd
+    assert "0.247" in cmd
+
+
+def test_re_anchor_accepts_legacy_downbeat_sec_alias(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Spec §4.3 + popup-types both ship ``downbeat_sec``; honor it."""
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "shift2")
+    client, _ = client_with_runner()
+    r = client.post(
+        "/forges/shift2/re-anchor",
+        json={"downbeat_sec": 1.5, "source_bpm": 120.0},
+    )
+    assert r.status_code == 200
+
+
+def test_re_anchor_422_on_missing_downbeat(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "missing-db")
+    client, _ = client_with_runner()
+    r = client.post(
+        "/forges/missing-db/re-anchor",
+        json={"source_bpm": 120.0},
+    )
+    assert r.status_code == 422
+
+
+def test_re_anchor_422_on_missing_source_bpm(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "missing-bpm")
+    client, _ = client_with_runner()
+    r = client.post(
+        "/forges/missing-bpm/re-anchor",
+        json={"first_downbeat_seconds": 0.5},
+    )
+    assert r.status_code == 422
+
+
+def test_re_anchor_returns_stderr_on_failure(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "broken")
+    client, _ = client_with_runner(returncode=1, stdout="", stderr="boom\n")
+    r = client.post(
+        "/forges/broken/re-anchor",
+        json={"downbeat_sec": 0.5, "source_bpm": 120.0},
+    )
+    assert r.status_code == 200  # The endpoint reports failure in body.ok
+    body = r.json()
+    assert body["ok"] is False
+    assert "boom" in body["stderr"]
+
+
+def test_re_anchor_404_when_slug_unknown(
+    client_with_runner,
+) -> None:
+    client, _ = client_with_runner()
+    r = client.post(
+        "/forges/no-forge/re-anchor",
+        json={"downbeat_sec": 0.0, "source_bpm": 120.0},
+    )
+    assert r.status_code == 404
+
+
+def test_re_anchor_malformed_body_returns_422(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Garbage payload fails Pydantic validation before reaching the handler."""
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "tightbody")
+    client, _ = client_with_runner()
+    r = client.post(
+        "/forges/tightbody/re-anchor",
+        json={"downbeat_sec": "not-a-number"},
+    )
+    assert r.status_code == 422
+
+
+# ── POST /forges/{slug}/re-curate ───────────────────────────────────────────
+
+
+def test_re_curate_invokes_cli_with_slug(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "curateme")
+    client, calls = client_with_runner(returncode=0, stdout="re-curate: wrote ...")
+    r = client.post("/forges/curateme/re-curate", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    cli_calls = [c for c in calls if "re-curate" in c["cmd"]]
+    assert len(cli_calls) == 1
+    assert cli_calls[0]["cmd"] == ["uv", "run", "stemforge", "re-curate", "curateme"]
+
+
+def test_re_curate_404_when_slug_unknown(
+    client_with_runner,
+) -> None:
+    client, _ = client_with_runner()
+    r = client.post("/forges/no-such/re-curate", json={})
+    assert r.status_code == 404
+
+
+def test_re_curate_returns_failure_status_in_body(
+    client_with_runner,
+    configurator_paths: dict[str, Path],
+) -> None:
+    _seed_new_shape_forge(configurator_paths["processed_dir"], "willfail")
+    client, _ = client_with_runner(returncode=2, stderr="curate exploded")
+    r = client.post("/forges/willfail/re-curate", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "exploded" in body["stderr"]

--- a/web/configurator/src/lib/api-types.generated.ts
+++ b/web/configurator/src/lib/api-types.generated.ts
@@ -54,6 +54,8 @@ export interface ClipSettings {
  * Persisted as YAML at ``~/stemforge/curations/<name>.yaml``.
  */
 export interface Curation {
+  /** Optional list of color hex strings (or named-palette refs) for the popup/device to render. Mirrors spec §2.3. */
+  color_palette?: Array<string> | null;
   created_at: string;
   curation_version?: 1;
   /** Group letter (A, B, ...) → Group. Determined by target.groups. */
@@ -195,6 +197,8 @@ export interface Target {
   device?: string;
   /** Number of groups */
   groups?: number;
+  /** Optional human-readable label for the target hardware (e.g. 'Studio EP-133'). Distinct from per-group Group.label. */
+  label?: string | null;
   /** Pads per group */
   pads_per_group?: number;
 }


### PR DESCRIPTION
## Summary

Phase 1.5 bridge closing the 1B/1D endpoint-catalog gap before Phase 2. Six forge endpoints and two curation endpoints landed; two endpoints deferred to Phase 3.

**Forge endpoints (all in `stemforge/configurator/server.py`, scan logic in new `forge_io.py`):**

- `GET /forges` — scans `~/stemforge/processed/`, returns `{ forges: [...] }` with slug / name / manifest_hash / bar_count / sample_count / has_arrangement / modified_at / target_format / bpm. Recognizes both Phase 1A new-shape (`auto_curation_manifest.json`) and legacy (`curated/manifest.json`) forges via `stemforge.forge.manifest_io`.
- `POST /forges/{slug}/load` + `unload` — server-side state + SSE broadcast; device UDP wiring deferred to Phase 2.
- `POST /forges/{slug}/reveal` — `subprocess.run(["open", forge_dir])` for macOS Finder.
- `POST /forges/{slug}/re-anchor` — subprocess `uv run stemforge re-anchor <slug> --bpm <X> --first-downbeat <Y>`. Accepts both `downbeat_sec` (popup-types/spec §4.3 naming) and `first_downbeat_seconds` (task brief naming) for the same field; both 422 individually if missing. `source_bpm` is required (CLI mandates `--bpm`).
- `POST /forges/{slug}/re-curate` — subprocess `uv run stemforge re-curate <slug>`; no extra args.

**Curation endpoints:**

- `POST /curations/{name}/rename` — atomic on-disk rename via new `rename_curation_atomic` helper. 400/404/409/idempotent semantics. Rewrites every `active_curations` entry pointing at the old name.
- `POST /curations/active/close` — clears `active_curations[als_path]`. Idempotent, broadcasts SSE.

**Schema fix:** `Curation.color_palette: list[str] | None` and `Target.label: str | None` added per spec §2.3. `PATCH /curations/{name}/target` now actually persists both fields (1B accepted-and-dropped them). `label` mirroring onto `groups.A.label` retained for Phase 1B reader compat.

**Deferred to Phase 3 (per scope brief):**

- `POST /curations/{name}/export` → Phase 3C
- `POST /curations/{name}/trigger-bounce` → Phase 3B

**TS regen:** `web/configurator/src/lib/api-types.generated.ts` regenerated via `uv run python scripts/gen_typescript_types.py` to pick up the two new schema slots. Re-running the script produces no diff (`ci-types-drift.yml` invariant).

## Test plan

- [x] `uv run pytest stemforge/configurator/ tests/test_configurator_*.py -v` → 127 passing (36 new across two files)
- [x] `uv run ruff check stemforge/configurator/ scripts/` → clean
- [x] `uv run ruff format --check stemforge tests scripts` → clean
- [x] `uv run mypy stemforge/configurator/` → at baseline (27 pre-existing errors, 0 new)
- [x] `uv run python scripts/gen_typescript_types.py` → idempotent, no diff after commit
- [x] Broader suite: `uv run pytest tests/ --ignore=tests/test_canonical_tempos.py` → 1029 passing (canonical-tempos failures are pre-existing Demucs-extras gaps, unrelated)
- [ ] CI: `ci-server-configurator.yml`, `ci-types-drift.yml`, `ci-fixtures-validate.yml`, `Lint + format`, `Unit tests` — green on push
- [ ] Optional: `cd web/configurator && npm test` — additive types change, popup msw tests should keep passing

**Phase 2 (COMMIT keystone) is unblocked after this merges.**

Phase 1.5 bridge complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)