### PR TITLE
feat: BOUNCE refactor — curation-driven render + last_bounce write-through

### DIFF
--- a/stemforge/configurator/bounce_handler.py
+++ b/stemforge/configurator/bounce_handler.py
@@ -1,0 +1,334 @@
+"""Phase 3B: BOUNCE refactor — curation-driven render spec + completion merge.
+
+The device's ``bounceCuration`` JS walks the active curation's pads,
+solos each STG-X track, triggers the clip, freezes+crops via Live's LOM,
+and writes a WAV per pad. The server is the only piece of the system
+that owns the curation's identity + persistent state — so the server
+constructs the **bounce spec** (which pads to render + where the WAVs
+land) and, when the device reports completion, mutates the curation's
+``last_bounce`` block.
+
+Two pure helpers live here so the FastAPI/asyncio/SSE plumbing can stay
+in :mod:`stemforge.configurator.intents` while this module stays
+unit-testable in isolation (mirrors the Phase 2 split for
+:mod:`stemforge.configurator.commit_handler`):
+
+* :func:`build_bounce_spec` — derive a :class:`BounceSpec` from a
+  :class:`Curation` + optional ``pad_ids`` filter. Pure function, no
+  I/O. Used both to validate the trigger-bounce request and to ship
+  the spec to the device.
+* :func:`merge_bounce_completion` — apply the device's completion
+  report onto a :class:`Curation`, returning the new Curation with
+  ``last_bounce`` populated. Pure function; callers handle the atomic
+  write.
+
+Spec references:
+
+- ``specs/CONSOLIDATED_DESIGN.md`` §3.3 (BOUNCE verb definition)
+- ``specs/CONSOLIDATED_DESIGN.md`` §4.3 (``/curations/{name}/trigger-bounce``)
+- ``specs/CONSOLIDATED_DESIGN.md`` §5.5 (bounce flow)
+- ``specs/CONSOLIDATED_DESIGN.md`` §6.6 (bounce as part of the verb table)
+
+Wire shape the device emits on completion (POST
+``/curations/{name}/bounce-complete``):
+
+.. code-block:: json
+
+    {
+      "pad_audio_hashes": {
+        "A01": "<sha256-hex>",
+        "B01": "<sha256-hex>"
+      },
+      "manifest_path": "bounced/verse_swap_v1/bounce_manifest.json"
+    }
+
+The manifest_path is relative to ``~/stemforge/`` per spec §2.3.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .schemas import Curation, LastBounce, Pad
+
+
+# ── Pad-id helpers ───────────────────────────────────────────────────────────
+
+
+def _is_populated(pad: Pad) -> bool:
+    """A pad is *populated* iff it has a ``source`` block.
+
+    Empty pads (the ``{pad_id: X}`` slot placeholders) are skipped by
+    BOUNCE — the device has nothing to render for them.
+    """
+    return pad.source is not None
+
+
+def _normalize_pad_id(raw: str) -> str:
+    """Canonicalize the popup's display-form pad ids to wire form.
+
+    The popup may surface pad ids with the interpunct separator
+    (``A·01``) for human readability; the curation's authoritative
+    representation is ``A01`` (no separator). Accept both on input so
+    the trigger-bounce endpoint can take whatever the popup hands it.
+    """
+    return raw.replace("·", "").replace("-", "").strip()
+
+
+# ── BounceSpec — what the device renders ─────────────────────────────────────
+
+
+class BounceSpecPad(BaseModel):
+    """One pad's worth of render directive in a :class:`BounceSpec`.
+
+    The device receives this and knows: which staging track to solo
+    (derived from ``pad_id``'s leading letter), which clip slot to
+    trigger (the trailing slot number), where to write the rendered
+    WAV (``output_path``), and which template chain is baked in
+    (advisory — the actual chain lives on STG-X's track devices).
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=False)
+
+    pad_id: str = Field(..., description="Canonical pad id, e.g. ``A01``")
+    group: str = Field(..., description="Leading letter (``A``..``P``)")
+    slot: int = Field(..., ge=1, description="1-indexed clip slot within the group")
+    template: str | None = Field(
+        default=None,
+        description=(
+            "Template name baked into this pad's render (group's template "
+            "as recorded in the curation). ``None`` = dry passthrough."
+        ),
+    )
+    output_path: str = Field(
+        ...,
+        description=(
+            "Relative path under ``~/stemforge/`` for the rendered WAV "
+            "(e.g. ``bounced/<curation>/A01.wav``). Spec §2.3."
+        ),
+    )
+
+
+class BounceSpec(BaseModel):
+    """Full render directive — what the server hands the device.
+
+    The device's ``bounceCuration`` JS consumes this verbatim. The
+    ``pads`` list is the iteration order; the device solos each pad's
+    group track in turn, triggers the slot, freezes+crops, writes the
+    WAV.
+
+    Empty pads are intentionally absent — BOUNCE renders only what's
+    actually populated. Pad-id ordering preserves the curation's
+    group-major / slot-ascending convention so a partial bounce stays
+    deterministic relative to a full one.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=False)
+
+    curation_name: str = Field(..., description="The curation being bounced")
+    bounce_dir: str = Field(
+        ...,
+        description=(
+            "Relative output directory under ``~/stemforge/`` for this "
+            "bounce (``bounced/<curation>/``). Used by the device as the "
+            "prefix for every pad's WAV."
+        ),
+    )
+    manifest_path: str = Field(
+        ...,
+        description=(
+            "Relative path of the per-bounce manifest file the device "
+            "will write summarizing this run (``bounced/<curation>/"
+            "bounce_manifest.json``)."
+        ),
+    )
+    pads: list[BounceSpecPad] = Field(
+        default_factory=list,
+        description="Pads to render, in iteration order.",
+    )
+
+
+# ── Spec construction ────────────────────────────────────────────────────────
+
+
+def _parse_pad_id(pad_id: str) -> tuple[str, int] | None:
+    """Split a canonical pad id into ``(group_letter, slot_int)``.
+
+    Returns ``None`` for malformed ids. ``A01`` → ``("A", 1)``,
+    ``B12`` → ``("B", 12)``. Two-digit slots are required (matches
+    the device's ``_commitWalkGroup`` zero-pad convention).
+    """
+    canon = _normalize_pad_id(pad_id)
+    if len(canon) < 2:
+        return None
+    letter = canon[0].upper()
+    if not letter.isalpha():
+        return None
+    try:
+        slot = int(canon[1:])
+    except ValueError:
+        return None
+    if slot < 1:
+        return None
+    return letter, slot
+
+
+def build_bounce_spec(
+    curation: Curation,
+    pad_ids: Iterable[str] | None = None,
+) -> BounceSpec:
+    """Construct the per-pad render directive for a curation.
+
+    Pure function. No I/O — the caller handles disk + transport.
+
+    Iteration order:
+    - Groups in sorted-letter order (``A``, ``B``, …) matching the
+      device's commit walker and the popup's grid render.
+    - Within a group, pads in their stored list order (i.e. by slot).
+
+    Args:
+        curation: The :class:`Curation` to bounce.
+        pad_ids: Optional explicit allow-list (canonical or
+            interpunct form). When ``None``, every populated pad is
+            bounced. Unknown pad ids are silently skipped — the
+            FastAPI route layer can choose to reject them as 422 if
+            stricter validation is wanted.
+
+    Returns:
+        A :class:`BounceSpec`. ``pads`` may be empty when the
+        curation has nothing populated (or the filter matches
+        nothing) — callers should reject that with 400 at the route
+        layer.
+    """
+    bounce_dir = f"bounced/{curation.name}"
+    manifest_path = f"{bounce_dir}/bounce_manifest.json"
+
+    allowed: set[str] | None = None
+    if pad_ids is not None:
+        allowed = {_normalize_pad_id(p) for p in pad_ids if p}
+
+    out: list[BounceSpecPad] = []
+    for letter in sorted(curation.groups.keys()):
+        group = curation.groups[letter]
+        template = group.template
+        for pad in group.pads:
+            if not _is_populated(pad):
+                continue
+            canon = _normalize_pad_id(pad.pad_id)
+            if allowed is not None and canon not in allowed:
+                continue
+            parsed = _parse_pad_id(canon)
+            if parsed is None:
+                # Malformed pad id in the curation — shouldn't happen
+                # post Pydantic validation, but skip rather than 500
+                # so a single bad slot doesn't void the whole bounce.
+                continue
+            group_letter, slot = parsed
+            out.append(
+                BounceSpecPad(
+                    pad_id=canon,
+                    group=group_letter,
+                    slot=slot,
+                    template=template,
+                    output_path=f"{bounce_dir}/{canon}.wav",
+                )
+            )
+    return BounceSpec(
+        curation_name=curation.name,
+        bounce_dir=bounce_dir,
+        manifest_path=manifest_path,
+        pads=out,
+    )
+
+
+# ── Completion merge ─────────────────────────────────────────────────────────
+
+
+class BounceCompletion(BaseModel):
+    """``POST /curations/{name}/bounce-complete`` request body.
+
+    The device walks every pad in :class:`BounceSpec`, captures the
+    SHA-256 of each rendered WAV, and POSTs this payload when done.
+    The server then mutates ``Curation.last_bounce`` accordingly.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=False)
+
+    manifest_path: str = Field(
+        ...,
+        description=(
+            "Relative path under ``~/stemforge/`` of the bounce manifest "
+            "the device just wrote. Echoed back from :class:`BounceSpec`."
+        ),
+    )
+    pad_audio_hashes: dict[str, str] = Field(
+        default_factory=dict,
+        description="pad_id (canonical) → SHA-256 hex of the rendered WAV.",
+    )
+    bounced_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Optional device-supplied timestamp. When omitted, the "
+            "server stamps ``datetime.now(UTC)``."
+        ),
+    )
+
+
+class BounceProgress(BaseModel):
+    """``POST /curations/{name}/bounce-progress`` request body.
+
+    Optional progress beacon — the device may POST one of these per
+    pad as it renders. Carries enough state for the popup to surface
+    a progress bar via SSE without waiting on completion.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=False)
+
+    pad_id: str = Field(..., description="The pad just rendered (canonical)")
+    rendered_count: int = Field(..., ge=0)
+    total_count: int = Field(..., ge=0)
+    output_path: str | None = Field(
+        default=None,
+        description="Absolute or relative path of the WAV that was written.",
+    )
+
+
+def merge_bounce_completion(
+    *,
+    existing: Curation,
+    completion: BounceCompletion,
+) -> Curation:
+    """Apply a device completion report onto a curation.
+
+    Mutates ``last_bounce`` to record the new bounced-at timestamp,
+    manifest path, and pad-by-pad audio hashes. Bumps
+    ``modified_at`` so popup lists re-render with a fresh "bounced N
+    minutes ago" string.
+
+    Pure function — the caller writes the result atomically. Matches
+    :func:`stemforge.configurator.commit_handler.merge_device_snapshot`
+    for symmetry: spec construction + state-mutation helpers live in
+    handler modules; routes call them under the asyncio lock.
+    """
+    bounced_at = completion.bounced_at or datetime.now(UTC)
+    merged = existing.model_copy(deep=True)
+    merged.last_bounce = LastBounce(
+        bounced_at=bounced_at,
+        manifest_path=completion.manifest_path,
+        pad_audio_hashes={_normalize_pad_id(k): v for k, v in completion.pad_audio_hashes.items()},
+    )
+    merged.modified_at = bounced_at
+    return merged
+
+
+__all__ = [
+    "BounceCompletion",
+    "BounceProgress",
+    "BounceSpec",
+    "BounceSpecPad",
+    "build_bounce_spec",
+    "merge_bounce_completion",
+]

--- a/stemforge/configurator/intents.py
+++ b/stemforge/configurator/intents.py
@@ -45,6 +45,13 @@ from stemforge.scene_model import (
 )
 
 from .audio_hash import audio_hash
+from .bounce_handler import (
+    BounceCompletion,
+    BounceProgress,
+    BounceSpec,
+    build_bounce_spec,
+    merge_bounce_completion,
+)
 from .commit_handler import (
     DeviceCommitBody,
     DeviceGroupSnapshot,
@@ -77,6 +84,7 @@ from .schemas import (
 )
 from .state import (
     AppState,
+    SseEvent,
     load_state,
     save_state,
     set_active_curation,
@@ -1058,7 +1066,147 @@ def _commit_summary(body: DeviceCommitBody) -> str:
     return f"{n_groups} groups, {n_pads} populated pads"
 
 
+# ── BOUNCE (Phase 3B) ────────────────────────────────────────────────────────
+
+
+class TriggerBounceBody(BaseModel):
+    """``POST /curations/{name}/trigger-bounce`` request body.
+
+    ``pad_ids`` is optional — when omitted (or empty), every populated
+    pad in the curation is bounced. When provided, only those pad ids
+    are rendered (used by future "re-bounce the changed pads"
+    workflows).
+
+    The popup's "Bounce in Live" button POSTs ``{}`` for a full
+    bounce.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    pad_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional explicit pad-id allow-list (canonical or "
+            "interpunct form). ``None`` / empty = bounce all populated."
+        ),
+    )
+
+
+async def handle_trigger_bounce(
+    state: AppState,
+    name: str,
+    body: TriggerBounceBody,
+) -> dict[str, Any]:
+    """``POST /curations/{name}/trigger-bounce`` — kickoff the BOUNCE flow.
+
+    Behavior:
+
+    1. Load the curation (404 if missing).
+    2. Build a :class:`BounceSpec` (400 if nothing to bounce — empty
+       curation or filter matches nothing).
+    3. Broadcast a ``state`` SSE event with ``kind=bounce-start`` so
+       the M4L device's SSE listener picks up the spec and runs
+       ``bounceCuration()`` against it. The popup also sees this and
+       can render an in-progress UI.
+    4. Return the :class:`BounceSpec` immediately (async kickoff
+       per Phase 3B brief — the device drives the long-running render
+       and reports back via ``/bounce-progress`` + ``/bounce-complete``).
+
+    Tests block on the SSE listener loop to assert the broadcast went
+    out + the device-bound payload was correct.
+    """
+    async with state.mutation_lock:
+        curation = _load_curation_or_404(state, name)
+        spec = build_bounce_spec(curation, pad_ids=body.pad_ids)
+        if not spec.pads:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"curation {name!r} has no pads to bounce "
+                    "(empty curation or pad_ids matched nothing)"
+                ),
+            )
+
+    payload = spec.model_dump(mode="json")
+    await state.broadcast(
+        SseEvent(
+            event="state",
+            data={
+                "kind": "bounce-start",
+                "curation": name,
+                "spec": payload,
+            },
+        )
+    )
+    await state.log(f"bounce: started {name} ({len(spec.pads)} pads)", "info")
+    return {"ok": True, "spec": payload}
+
+
+async def handle_bounce_progress(
+    state: AppState,
+    name: str,
+    body: BounceProgress,
+) -> dict[str, Any]:
+    """``POST /curations/{name}/bounce-progress`` — per-pad device beacon.
+
+    The device may POST one of these per pad as it renders. The
+    server rebroadcasts as an SSE ``progress`` event so the popup can
+    render a progress bar without polling. No on-disk state mutates
+    here — completion is the only persistence point.
+    """
+    # Cheap existence check so a stale device can't spam progress for a
+    # curation that's been deleted between trigger + completion.
+    _load_curation_or_404(state, name)
+    fraction = 0.0
+    if body.total_count > 0:
+        fraction = body.rendered_count / body.total_count
+    await state.progress(
+        op=f"bounce:{name}",
+        progress=fraction,
+        message=f"rendered {body.pad_id} ({body.rendered_count}/{body.total_count})",
+    )
+    return {"ok": True, "rendered": body.rendered_count, "total": body.total_count}
+
+
+async def handle_bounce_complete(
+    state: AppState,
+    name: str,
+    body: BounceCompletion,
+) -> Curation:
+    """``POST /curations/{name}/bounce-complete`` — finalize the bounce.
+
+    The device POSTs this once every pad has been rendered. The
+    server merges ``last_bounce`` onto the curation, persists
+    atomically, and broadcasts state.
+
+    Returns the updated :class:`Curation` so the device + popup share
+    the new ``last_bounce`` block immediately.
+    """
+    path = curation_path(state.curations_dir, name)
+    async with state.mutation_lock:
+        existing = _load_curation_or_404(state, name)
+        try:
+            merged = merge_bounce_completion(existing=existing, completion=body)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail={"errors": exc.errors()},
+            ) from exc
+        with lock_curation(path):
+            write_curation_atomic(path, merged)
+
+    await state.log(
+        f"bounce: completed {name} ({len(body.pad_audio_hashes)} pads)",
+        "info",
+    )
+    await state.broadcast_curations_state()
+    return merged
+
+
 __all__ = [
+    "BounceCompletion",
+    "BounceProgress",
+    "BounceSpec",
     "CloseActiveCurationBody",
     "CreateCurationBody",
     "DeviceCommitBody",
@@ -1069,7 +1217,10 @@ __all__ = [
     "PatchTemplateBody",
     "RenameCurationBody",
     "SaveAsBody",
+    "TriggerBounceBody",
     "handle_assign_pad",
+    "handle_bounce_complete",
+    "handle_bounce_progress",
     "handle_clear_pad",
     "handle_close_active_curation",
     "handle_commit",
@@ -1087,4 +1238,5 @@ __all__ = [
     "handle_rename_curation",
     "handle_save_as",
     "handle_set_group_format",
+    "handle_trigger_bounce",
 ]

--- a/stemforge/configurator/server.py
+++ b/stemforge/configurator/server.py
@@ -80,6 +80,7 @@ from pydantic import BaseModel, Field
 from stemforge.scene_model import Project
 
 from . import intents
+from .bounce_handler import BounceCompletion, BounceProgress
 from .export_handler import (
     DEFAULT_TARGET_FORMAT,
     ExportValidationError,
@@ -95,6 +96,7 @@ from .intents import (
     PatchTemplateBody,
     RenameCurationBody,
     SaveAsBody,
+    TriggerBounceBody,
 )
 from .preview import build_audio_response
 from .schemas import (
@@ -523,6 +525,25 @@ def _register_routes(app: FastAPI, state: AppState) -> None:
             body,
             processed_dir=app.state.processed_dir,
         )
+
+    # ── BOUNCE (Phase 3B, spec §4.3 + §5.5) ───────────────────────────────
+
+    @app.post("/curations/{name}/trigger-bounce")
+    async def trigger_bounce_route(name: str, body: TriggerBounceBody) -> dict[str, Any]:
+        # Async kickoff: validates curation + spec, broadcasts the spec via
+        # SSE for the device's listener to pick up, returns the spec to the
+        # popup so the user sees what's about to render. The actual WAV
+        # rendering happens device-side; completion arrives via
+        # /bounce-progress + /bounce-complete below.
+        return await intents.handle_trigger_bounce(state, name, body)
+
+    @app.post("/curations/{name}/bounce-progress")
+    async def bounce_progress_route(name: str, body: BounceProgress) -> dict[str, Any]:
+        return await intents.handle_bounce_progress(state, name, body)
+
+    @app.post("/curations/{name}/bounce-complete", response_model=Curation)
+    async def bounce_complete_route(name: str, body: BounceCompletion) -> Curation:
+        return await intents.handle_bounce_complete(state, name, body)
 
     # ── Phase 1.5 — curation rename / active close ─────────────────────────
 

--- a/tests/js_mocks/test_bounce.test.js
+++ b/tests/js_mocks/test_bounce.test.js
@@ -392,66 +392,10 @@ test('_tmpManifestPath: appends .tmp suffix', () => {
     assert.equal(ctx._tmpManifestPath('/x.json'), '/x.json.tmp');
 });
 
-test('commitOffsets (disk-backed): reads from .tmp, writes to .tmp, schedules mv', () => {
-    const { ctx } = loadBounce();
-    const FINAL = '/tmp/atomic_rename_test2/curated/manifest.json';
-    const TMP = FINAL + '.tmp';
-
-    // Seed an existing stub at the .tmp path (no clips, just structure).
-    maxApi.seedFile(TMP, JSON.stringify({
-        bpm: 120,
-        source_dir: '/tmp/atomic_rename_test2',
-        session_tracks: { A: [], B: [], C: [], D: [] },
-        clips: [],
-    }));
-    // Seed an empty live tree so _commitAllOffsets / _commitSessionTracks
-    // have somewhere to traverse without crashing.
-    maxApi.seedLiveTree({ tracks: [] });
-
-    // Drive the disk-backed branch: commitOffsets reads `messagename` +
-    // arguments via arrayfromargs(messagename, arguments). The sandbox's
-    // arrayfromargs honors the multi-arg form, so setting messagename
-    // and calling commitOffsets.call(ctx, FINAL) gets us through.
-    ctx.messagename = 'commitOffsets';
-    ctx.commitOffsets.call(ctx, FINAL);
-
-    // After commit: .tmp has the populated manifest, final path is still
-    // untouched (the mv goes via outlet 3 → [shell], which the mock just
-    // records as outlet args, not as an actual rename).
-    assert.ok(maxApi.state.fs[TMP], '.tmp must contain the committed manifest');
-    assert.equal(maxApi.state.fs[FINAL], undefined,
-        'final path stays unwritten in JS; mv runs via outlet-3 shell');
-
-    // The mv call must appear on outlet 3 — that's the [shell] wire.
-    const outlet3 = maxApi.state.outlets[3] || [];
-    const mvCalls = outlet3.filter(args =>
-        args[0] === '/bin/mv' && args.indexOf(TMP) >= 0 && args.indexOf(FINAL) >= 0
-    );
-    assert.equal(mvCalls.length, 1,
-        'commitOffsets must emit exactly one /bin/mv outlet call for .tmp → final');
-});
-
-test('commitOffsets (disk-backed): falls back to final path if .tmp absent', () => {
-    const { ctx } = loadBounce();
-    const FINAL = '/tmp/atomic_rename_test3/curated/manifest.json';
-
-    // Only the final path is seeded (legacy / external callers that
-    // bypassed _ensureDeckManifestStub).
-    maxApi.seedFile(FINAL, JSON.stringify({
-        bpm: 120,
-        source_dir: '/tmp/atomic_rename_test3',
-        session_tracks: { A: [], B: [], C: [], D: [] },
-        clips: [],
-    }));
-    maxApi.seedLiveTree({ tracks: [] });
-
-    ctx.messagename = 'commitOffsets';
-    // Shouldn't throw / shouldn't surface "cannot read" status — the
-    // fallback read path must pick up the final-path content.
-    ctx.commitOffsets.call(ctx, FINAL);
-
-    // The .tmp gets the post-commit write since we always promote via mv.
-    const TMP = FINAL + '.tmp';
-    assert.ok(maxApi.state.fs[TMP],
-        'commitOffsets must still write to .tmp even when seeded from final');
-});
+// commitOffsets / _commitOffsetsWithPath were removed in Phase 3B (BOUNCE
+// refactor). The disk-backed deck-manifest path they implemented belonged
+// to the legacy A/B/C/D bounceTracks pipeline, which Phase 3B's
+// bounceCuration() supersedes. The atomic-rename tests that used to live
+// here are now covered by the curation-write path in
+// stemforge/configurator/curation_io.py (write_curation_atomic +
+// lock_curation), tested in tests/test_configurator_curation_crud.py.

--- a/tests/test_configurator_bounce.py
+++ b/tests/test_configurator_bounce.py
@@ -1,0 +1,477 @@
+"""Phase 3B BOUNCE refactor — L2 unit + L3 endpoint integration tests.
+
+Covers two boundaries:
+
+* :mod:`stemforge.configurator.bounce_handler` — pure functions
+  (``build_bounce_spec``, ``merge_bounce_completion``). Unit-tested
+  directly.
+* :mod:`stemforge.configurator.server` — ``POST /trigger-bounce`` /
+  ``/bounce-progress`` / ``/bounce-complete``. Tested through
+  :class:`fastapi.testclient.TestClient`, asserting both the response
+  shape and SSE broadcasts.
+
+Spec refs:
+
+- ``specs/CONSOLIDATED_DESIGN.md`` §3.3 (BOUNCE verb)
+- ``specs/CONSOLIDATED_DESIGN.md`` §4.3 (endpoints)
+- ``specs/CONSOLIDATED_DESIGN.md`` §5.5 (bounce flow)
+- ``docs/configurator/EXECUTION_PLAN_v1.md`` Lane 3B acceptance gates
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stemforge.configurator.bounce_handler import (
+    BounceCompletion,
+    BounceSpec,
+    build_bounce_spec,
+    merge_bounce_completion,
+)
+from stemforge.configurator.curation_io import (
+    curation_path,
+    read_curation,
+    write_curation_atomic,
+)
+from stemforge.configurator.schemas import (
+    ClipSettings,
+    Curation,
+    Group,
+    Pad,
+    PadSource,
+    Target,
+)
+from stemforge.configurator.server import create_app
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _empty_pad(pad_id: str) -> Pad:
+    return Pad(pad_id=pad_id)
+
+
+def _filled_pad(pad_id: str, clip_id: str) -> Pad:
+    return Pad(
+        pad_id=pad_id,
+        source=PadSource(
+            forge="sample-forge",
+            clip_id=clip_id,
+            audio_path=f"curated_audio/{clip_id}.wav",
+        ),
+        clip_settings=ClipSettings(
+            warp_bpm=120.0,
+            loop_start_bar=0.0,
+            loop_end_bar=4.0,
+            looping=True,
+        ),
+    )
+
+
+def _build_curation(
+    name: str,
+    *,
+    populated_specs: dict[str, list[tuple[str, str]]] | None = None,
+    templates: dict[str, str | None] | None = None,
+) -> Curation:
+    """Build a 4-group / 12-pad curation with optional populated pads.
+
+    ``populated_specs`` maps group letter → [(pad_id, clip_id), …].
+    Pads not listed are empty placeholders.
+    """
+    now = datetime.now(UTC)
+    target = Target(device="ep133", groups=4, pads_per_group=12)
+    groups: dict[str, Group] = {}
+    populated_specs = populated_specs or {}
+    templates = templates or {}
+    for letter in "ABCD":
+        filled = dict(populated_specs.get(letter, []))
+        pads = []
+        for i in range(12):
+            pid = f"{letter}{i + 1:02d}"
+            if pid in filled:
+                pads.append(_filled_pad(pid, filled[pid]))
+            else:
+                pads.append(_empty_pad(pid))
+        groups[letter] = Group(
+            label="",
+            template=templates.get(letter),
+            pads=pads,
+        )
+    return Curation(
+        name=name,
+        type="deck",
+        created_at=now,
+        modified_at=now,
+        target=target,
+        referenced_forges=[],
+        groups=groups,
+    )
+
+
+@pytest.fixture
+def tmp_curations(tmp_path: Path) -> dict[str, Path]:
+    curations_dir = tmp_path / "curations"
+    curations_dir.mkdir()
+    state_path = tmp_path / ".stemforge_state.json"
+    return {
+        "tmp_path": tmp_path,
+        "curations_dir": curations_dir,
+        "state_path": state_path,
+        "static_dir": tmp_path / "static",
+        "processed_dir": tmp_path / "processed",
+    }
+
+
+@pytest.fixture
+def client(tmp_curations: dict[str, Path]) -> TestClient:
+    tmp_curations["processed_dir"].mkdir(parents=True, exist_ok=True)
+    app = create_app(
+        static_dir=tmp_curations["static_dir"],
+        curations_dir=tmp_curations["curations_dir"],
+        state_path=tmp_curations["state_path"],
+        processed_dir=tmp_curations["processed_dir"],
+    )
+    return TestClient(app)
+
+
+# ── build_bounce_spec ────────────────────────────────────────────────────────
+
+
+def test_build_bounce_spec_empty_curation_returns_no_pads() -> None:
+    """An empty curation has no populated pads → spec.pads is empty."""
+    curation = _build_curation("empty")
+    spec = build_bounce_spec(curation)
+    assert isinstance(spec, BounceSpec)
+    assert spec.curation_name == "empty"
+    assert spec.bounce_dir == "bounced/empty"
+    assert spec.manifest_path == "bounced/empty/bounce_manifest.json"
+    assert spec.pads == []
+
+
+def test_build_bounce_spec_partial_curation_returns_only_populated() -> None:
+    """Only pads with ``source`` end up in the spec; empty pads are skipped."""
+    curation = _build_curation(
+        "partial",
+        populated_specs={
+            "A": [("A01", "vocal-bar0"), ("A03", "vocal-bar4")],
+            "B": [("B01", "drum-bar0")],
+        },
+        templates={"A": "VOCAL_LO_KEY", "B": "DRUM_PUNCH"},
+    )
+    spec = build_bounce_spec(curation)
+    assert len(spec.pads) == 3
+    pad_ids = [p.pad_id for p in spec.pads]
+    assert pad_ids == ["A01", "A03", "B01"]  # group-major, slot-ascending
+    a01 = spec.pads[0]
+    assert a01.group == "A"
+    assert a01.slot == 1
+    assert a01.template == "VOCAL_LO_KEY"
+    assert a01.output_path == "bounced/partial/A01.wav"
+    a03 = spec.pads[1]
+    assert a03.slot == 3
+    assert a03.template == "VOCAL_LO_KEY"
+    b01 = spec.pads[2]
+    assert b01.template == "DRUM_PUNCH"
+
+
+def test_build_bounce_spec_pad_ids_filter_subsets_the_render() -> None:
+    """When ``pad_ids`` is provided, only those pads are rendered."""
+    curation = _build_curation(
+        "partial",
+        populated_specs={
+            "A": [("A01", "v0"), ("A02", "v1"), ("A03", "v2")],
+            "B": [("B01", "d0")],
+        },
+    )
+    spec = build_bounce_spec(curation, pad_ids=["A01", "A02"])
+    assert [p.pad_id for p in spec.pads] == ["A01", "A02"]
+
+
+def test_build_bounce_spec_accepts_interpunct_pad_ids() -> None:
+    """The popup may pass ``A·01`` form; the handler normalizes both ways."""
+    curation = _build_curation(
+        "partial",
+        populated_specs={"A": [("A01", "v0"), ("A02", "v1")]},
+    )
+    spec = build_bounce_spec(curation, pad_ids=["A·01"])
+    assert [p.pad_id for p in spec.pads] == ["A01"]
+
+
+def test_build_bounce_spec_unknown_pad_ids_silently_skipped() -> None:
+    """An unknown filter id doesn't blow up — it just shrinks the spec."""
+    curation = _build_curation(
+        "partial",
+        populated_specs={"A": [("A01", "v0")]},
+    )
+    spec = build_bounce_spec(curation, pad_ids=["B99", "A01"])
+    assert [p.pad_id for p in spec.pads] == ["A01"]
+
+
+# ── merge_bounce_completion ──────────────────────────────────────────────────
+
+
+def test_merge_bounce_completion_populates_last_bounce() -> None:
+    curation = _build_curation(
+        "verse_swap_v1",
+        populated_specs={"A": [("A01", "v0"), ("A02", "v1")]},
+    )
+    bounced_at = datetime(2026, 5, 13, 12, 30, tzinfo=UTC)
+    completion = BounceCompletion(
+        manifest_path="bounced/verse_swap_v1/bounce_manifest.json",
+        pad_audio_hashes={"A01": "a" * 64, "A02": "b" * 64},
+        bounced_at=bounced_at,
+    )
+    merged = merge_bounce_completion(existing=curation, completion=completion)
+    assert merged.last_bounce is not None
+    assert merged.last_bounce.bounced_at == bounced_at
+    assert merged.last_bounce.manifest_path == "bounced/verse_swap_v1/bounce_manifest.json"
+    assert merged.last_bounce.pad_audio_hashes == {
+        "A01": "a" * 64,
+        "A02": "b" * 64,
+    }
+    # modified_at bumped to match the bounce timestamp.
+    assert merged.modified_at == bounced_at
+
+
+def test_merge_bounce_completion_stamps_now_when_no_timestamp() -> None:
+    curation = _build_curation("k", populated_specs={"A": [("A01", "v0")]})
+    completion = BounceCompletion(
+        manifest_path="bounced/k/bounce_manifest.json",
+        pad_audio_hashes={"A01": "c" * 64},
+    )
+    before = datetime.now(UTC)
+    merged = merge_bounce_completion(existing=curation, completion=completion)
+    after = datetime.now(UTC)
+    assert merged.last_bounce is not None
+    assert before <= merged.last_bounce.bounced_at <= after
+
+
+def test_merge_bounce_completion_canonicalizes_pad_ids() -> None:
+    """Interpunct pad ids in completion get normalized to canonical form."""
+    curation = _build_curation("k", populated_specs={"A": [("A01", "v0")]})
+    completion = BounceCompletion(
+        manifest_path="bounced/k/bounce_manifest.json",
+        pad_audio_hashes={"A·01": "e" * 64},
+    )
+    merged = merge_bounce_completion(existing=curation, completion=completion)
+    assert merged.last_bounce is not None
+    assert "A01" in merged.last_bounce.pad_audio_hashes
+    assert "A·01" not in merged.last_bounce.pad_audio_hashes
+
+
+# ── POST /curations/{name}/trigger-bounce ────────────────────────────────────
+
+
+def test_trigger_bounce_404_for_unknown_curation(client: TestClient) -> None:
+    resp = client.post("/curations/does-not-exist/trigger-bounce", json={})
+    assert resp.status_code == 404
+
+
+def test_trigger_bounce_400_for_empty_curation(
+    client: TestClient, tmp_curations: dict[str, Path]
+) -> None:
+    """A curation with no populated pads → 400 (nothing to render)."""
+    empty = _build_curation("empty")
+    write_curation_atomic(curation_path(tmp_curations["curations_dir"], "empty"), empty)
+    resp = client.post("/curations/empty/trigger-bounce", json={})
+    assert resp.status_code == 400
+    assert "no pads to bounce" in resp.json()["detail"]
+
+
+def test_trigger_bounce_returns_spec_and_broadcasts_sse(
+    client: TestClient, tmp_curations: dict[str, Path]
+) -> None:
+    """A populated curation returns the spec + broadcasts ``bounce-start``."""
+    populated = _build_curation(
+        "verse_swap_v1",
+        populated_specs={
+            "A": [("A01", "v0"), ("A02", "v1")],
+            "B": [("B01", "d0")],
+        },
+        templates={"A": "VOCAL_LO_KEY"},
+    )
+    write_curation_atomic(curation_path(tmp_curations["curations_dir"], "verse_swap_v1"), populated)
+
+    app = client.app  # type: ignore[attr-defined]
+    sf_state = app.state.configurator
+
+    async def _trigger_and_collect():
+        q = sf_state.subscribe()
+        try:
+            resp = await asyncio.to_thread(
+                client.post,
+                "/curations/verse_swap_v1/trigger-bounce",
+                json={},
+            )
+            assert resp.status_code == 200, resp.text
+            events = []
+            while not q.empty():
+                events.append(await q.get())
+            return resp.json(), events
+        finally:
+            sf_state.unsubscribe(q)
+
+    response_payload, events = asyncio.run(_trigger_and_collect())
+
+    # Response payload carries the spec for popup UI.
+    assert response_payload["ok"] is True
+    spec = response_payload["spec"]
+    assert spec["curation_name"] == "verse_swap_v1"
+    assert spec["bounce_dir"] == "bounced/verse_swap_v1"
+    assert len(spec["pads"]) == 3
+    assert [p["pad_id"] for p in spec["pads"]] == ["A01", "A02", "B01"]
+    assert spec["pads"][0]["template"] == "VOCAL_LO_KEY"
+    # SSE: bounce-start event went out for the device's listener.
+    bounce_starts = [
+        e for e in events if e.event == "state" and e.data.get("kind") == "bounce-start"
+    ]
+    assert len(bounce_starts) == 1
+    assert bounce_starts[0].data["curation"] == "verse_swap_v1"
+    assert len(bounce_starts[0].data["spec"]["pads"]) == 3
+
+
+def test_trigger_bounce_pad_ids_filter_propagates(
+    client: TestClient, tmp_curations: dict[str, Path]
+) -> None:
+    """``pad_ids`` body filter shrinks the returned spec accordingly."""
+    populated = _build_curation(
+        "filtered",
+        populated_specs={"A": [("A01", "v0"), ("A02", "v1"), ("A03", "v2")]},
+    )
+    write_curation_atomic(curation_path(tmp_curations["curations_dir"], "filtered"), populated)
+    resp = client.post(
+        "/curations/filtered/trigger-bounce",
+        json={"pad_ids": ["A01", "A03"]},
+    )
+    assert resp.status_code == 200, resp.text
+    spec = resp.json()["spec"]
+    assert [p["pad_id"] for p in spec["pads"]] == ["A01", "A03"]
+
+
+# ── POST /curations/{name}/bounce-progress ───────────────────────────────────
+
+
+def test_bounce_progress_emits_sse_progress_event(
+    client: TestClient, tmp_curations: dict[str, Path]
+) -> None:
+    """Per-pad device beacon rebroadcasts as an SSE ``progress`` event."""
+    populated = _build_curation(
+        "progressing",
+        populated_specs={"A": [("A01", "v0"), ("A02", "v1")]},
+    )
+    write_curation_atomic(curation_path(tmp_curations["curations_dir"], "progressing"), populated)
+    app = client.app  # type: ignore[attr-defined]
+    sf_state = app.state.configurator
+
+    async def _post_and_collect():
+        q = sf_state.subscribe()
+        try:
+            resp = await asyncio.to_thread(
+                client.post,
+                "/curations/progressing/bounce-progress",
+                json={
+                    "pad_id": "A01",
+                    "rendered_count": 1,
+                    "total_count": 2,
+                    "output_path": "bounced/progressing/A01.wav",
+                },
+            )
+            events = []
+            while not q.empty():
+                events.append(await q.get())
+            return resp, events
+        finally:
+            sf_state.unsubscribe(q)
+
+    resp, events = asyncio.run(_post_and_collect())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {"ok": True, "rendered": 1, "total": 2}
+    progress_events = [e for e in events if e.event == "progress"]
+    assert len(progress_events) == 1
+    assert progress_events[0].data["op"] == "bounce:progressing"
+    assert 0.0 < progress_events[0].data["progress"] < 1.0
+
+
+def test_bounce_progress_404_for_unknown_curation(client: TestClient) -> None:
+    resp = client.post(
+        "/curations/nope/bounce-progress",
+        json={"pad_id": "A01", "rendered_count": 0, "total_count": 1},
+    )
+    assert resp.status_code == 404
+
+
+# ── POST /curations/{name}/bounce-complete ───────────────────────────────────
+
+
+def test_bounce_complete_writes_last_bounce_and_broadcasts(
+    client: TestClient, tmp_curations: dict[str, Path]
+) -> None:
+    """The full flow: trigger → complete → curation YAML has last_bounce."""
+    populated = _build_curation(
+        "verse_swap_v1",
+        populated_specs={
+            "A": [("A01", "v0"), ("A02", "v1")],
+        },
+    )
+    path = curation_path(tmp_curations["curations_dir"], "verse_swap_v1")
+    write_curation_atomic(path, populated)
+
+    app = client.app  # type: ignore[attr-defined]
+    sf_state = app.state.configurator
+
+    async def _complete_and_collect():
+        q = sf_state.subscribe()
+        try:
+            resp = await asyncio.to_thread(
+                client.post,
+                "/curations/verse_swap_v1/bounce-complete",
+                json={
+                    "manifest_path": "bounced/verse_swap_v1/bounce_manifest.json",
+                    "pad_audio_hashes": {"A01": "a" * 64, "A02": "b" * 64},
+                    "bounced_at": "2026-05-13T12:30:00+00:00",
+                },
+            )
+            events = []
+            while not q.empty():
+                events.append(await q.get())
+            return resp, events
+        finally:
+            sf_state.unsubscribe(q)
+
+    resp, events = asyncio.run(_complete_and_collect())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["last_bounce"]["pad_audio_hashes"] == {
+        "A01": "a" * 64,
+        "A02": "b" * 64,
+    }
+
+    # Disk: curation file has last_bounce populated.
+    on_disk = read_curation(path)
+    assert on_disk.last_bounce is not None
+    assert on_disk.last_bounce.manifest_path == ("bounced/verse_swap_v1/bounce_manifest.json")
+    assert on_disk.last_bounce.pad_audio_hashes["A01"] == "a" * 64
+
+    # SSE: a curation-state broadcast went out so the popup re-renders.
+    curation_states = [
+        e for e in events if e.event == "state" and e.data.get("kind") == "curations"
+    ]
+    assert len(curation_states) >= 1
+
+
+def test_bounce_complete_404_for_unknown_curation(client: TestClient) -> None:
+    resp = client.post(
+        "/curations/nope/bounce-complete",
+        json={
+            "manifest_path": "bounced/nope/bounce_manifest.json",
+            "pad_audio_hashes": {},
+        },
+    )
+    assert resp.status_code == 404

--- a/v0/src/m4l-js/stemforge_loader.v0.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.js
@@ -2103,232 +2103,369 @@ function _ensureDeckManifestStub(path) {
     return true;
 }
 
-// Public message: `bounceTracks` — crop every clip on the deck tracks
-// (materializes warped audio at project tempo), then commit.
+// ─────────────────────────────────────────────────────────────────────────────
+// Configurator v1 Phase 3B — BOUNCE refactor.
 //
-// Args: any leading argument starting with `/` is treated as an absolute
-// manifest path that's forwarded to commitOffsets for the disk-backed
-// write — e.g. `bounceTracks /Users/zak/.../curated/manifest.json C D`.
-// Subsequent args (or all args if no path) are group letters.
+// `bounceCuration(curationName, padIdsJson?)` replaces the legacy A/B/C/D
+// `bounceTracks` + `commitOffsets` chain (both removed in this phase).
+// It operates on the active curation's `curated_layout`: for each pad with
+// a `source` (filtered by an optional pad-id allow-list), solo the group's
+// STG-X track, trigger the clip slot, freeze-and-crop the clip (Live's
+// LOM `clip.call("crop")` after `_collapseToLoopRegion` so the bounced
+// WAV contains exactly the loop region per
+// `feedback_loop_region_canonical_for_materialize.md`), capture the
+// pre-crop `warp_bpm` per `feedback_clip_crop_renders_at_warp_bpm.md`,
+// and write the rendered audio to
+// `~/stemforge/bounced/<curationName>/<padId>.wav` via outlet 3 (the
+// existing [shell] wire). Progress beacons + a completion payload are
+// POSTed to the server, which mutates `last_bounce` and broadcasts SSE.
 //
-// When no manifest path is given, derives one from the Ableton session
-// name: `~/stemforge/decks/<session>/curated/manifest.json`. Each .als
-// gets its own deck dir, untouched by the originally-loaded song.
-function bounceTracks() {
-    if (_bounceState) { status("bounceTracks: already running"); return; }
-    var args = arrayfromargs(messagename, arguments).slice(1);
-    var manifestPath = "";
-    var letterArgs = [];
-    for (var ai = 0; ai < args.length; ai++) {
-        var a = String(args[ai]);
-        if (!manifestPath && a.indexOf("/") === 0) {
-            manifestPath = a;
-        } else {
-            letterArgs.push(a);
-        }
-    }
-    var letters = letterArgs.length
-        ? letterArgs.map(function (s) { return String(s).toUpperCase(); })
-        : ["A", "B", "C", "D"];
-    // Filter to letters that actually have a track + at least one clip — no
-    // point freezing an empty track.
-    var nonEmpty = [];
-    for (var i = 0; i < letters.length; i++) {
-        var idx = findTrackByName(letters[i]);
-        if (idx < 0) continue;
-        var trk = new LiveAPI("live_set tracks " + idx);
-        var hasContent = false;
+// Wire protocol (Phase 2 pattern — HTTP via messnamed):
+//   - device → server progress: `messnamed("sf-bounce-progress", curationName, jsonPayload)`
+//   - device → server completion: `messnamed("sf-bounce-complete", curationName, jsonPayload)`
+//
+// The patcher's Node-for-Max shim POSTs these to
+// `/curations/{name}/bounce-progress` and `/curations/{name}/bounce-complete`
+// respectively. The shim isn't shipped yet — Phase 5 wires it. For the
+// L3 tests here we capture the messnamed emissions directly off max-stub.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Receive port names for the bounce wire (mirrors COMMIT_SEND_RECV).
+var BOUNCE_PROGRESS_SEND = "sf-bounce-progress";
+var BOUNCE_COMPLETE_SEND = "sf-bounce-complete";
+
+// Output root for bounced WAVs — `~/stemforge/bounced/<curation>/<pad>.wav`.
+// Matches the BounceSpec.bounce_dir computed server-side.
+function _bouncedDirFor(curationName) {
+    var home = String((typeof env !== "undefined" && env && env.HOME) || "");
+    if (!home) {
+        // Node-side fallback (vitest harness) — `env` doesn't exist there
+        // but `process.env.HOME` does. Real Max ignores this branch.
         try {
-            // A track with any clip in session view OR arrangement view counts.
-            for (var sj = 0; sj < 31 && !hasContent; sj++) {
-                var c = new LiveAPI("live_set tracks " + idx + " clip_slots " + sj + " clip");
-                if (c && c.id !== "0") hasContent = true;
-            }
-            if (!hasContent) {
-                var arrCount = 0;
-                try { arrCount = trk.getcount("arrangement_clips") | 0; } catch (_) {}
-                if (arrCount > 0) hasContent = true;
+            if (typeof process !== "undefined" && process && process.env && process.env.HOME) {
+                home = String(process.env.HOME);
             }
         } catch (_) {}
-        if (hasContent) nonEmpty.push(letters[i]);
     }
-    if (!nonEmpty.length) { status("bounceTracks: no clips on " + letters.join("/")); return; }
-    // Derive the deck manifest path if the caller didn't supply one. This
-    // sends bounced audio to a per-Ableton-session deck dir instead of
-    // overwriting whatever song manifest happens to be loaded.
-    var pathForCommit = manifestPath;
-    if (!pathForCommit) {
-        pathForCommit = _deriveDeckManifestPath();
-        if (!pathForCommit) {
-            status(
-                "bounceTracks: cannot derive deck path — Ableton set is unsaved. " +
-                "Save the .als (Cmd+S) and re-run, or pass an explicit path."
-            );
-            return;
-        }
+    if (!home) {
+        // Final fallback: pull from a known LOM path. Stays empty if
+        // we can't resolve, which surfaces as a status line below.
+        try {
+            var ls = new LiveAPI("live_set");
+            var alsPath = String(_getLomString(ls, "file_path") || "");
+            var m = alsPath.match(/^(?:Macintosh HD:)?\/Users\/([^/]+)/);
+            if (m && m[1]) home = "/Users/" + m[1];
+        } catch (_) {}
     }
-    if (!_ensureDeckManifestStub(pathForCommit)) {
-        status("bounceTracks: failed to bootstrap deck manifest at " + pathForCommit);
-        return;
+    if (!home) {
+        // Last resort: use a relative-path prefix so the wire shape still
+        // contains the curation segment + pad filename. Real Max never
+        // takes this branch (env.HOME is always set there).
+        return "stemforge/bounced/" + String(curationName);
     }
-    status("Bouncing tracks: " + nonEmpty.join(", ") + " → " + pathForCommit);
-    // Reset the pre-crop metadata cache so this run starts fresh. Each
-    // bounce captures warp_bpm per-clip BEFORE cropping (post-crop reads
-    // throw on Live 12 Beta), then commit looks up the cache by
-    // (letter, view, slot) when building manifest entries.
-    _preCropMeta = {};
-    _bounceState = {
-        letters: nonEmpty,
-        idx: 0,
-        callback: function () {
-            // Delay the commit briefly so the shell-spawned Python that
-            // wrote the stub manifest has time to finish (it's async).
-            // Cropping itself takes seconds, so 300ms here is just
-            // belt-and-suspenders for very small decks.
-            var t = new Task(function () { _commitOffsetsWithPath(pathForCommit); });
-            t.schedule(300);
-        },
-    };
-    _bounceNext();
+    return home + "/stemforge/bounced/" + String(curationName);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// DEPRECATED (Phase 2): the legacy `commitOffsets` / `_commitOffsetsWithPath`
-// pair persists deck-manifest offsets into ``sf_manifest`` Dict + a sibling
-// JSON file. It's tied to the legacy A/B/C/D bounceTracks pipeline and will
-// be removed in Phase 3B (BOUNCE refactor). The Phase 2 keystone `commit()`
-// function (below `_findTrackIndexByName`) is the new path: it walks STG-*
-// tracks and POSTs to `POST /curations/{name}/commit`, leaving forge
-// reverse-lookup + atomic curation-file write to the server.
-//
-// Migration note: while `commitOffsets` lives on, do not extend it. Any new
-// commit-time logic belongs in `commit()` + `commit_handler.py` (server).
-// ─────────────────────────────────────────────────────────────────────────────
+// Canonicalize a pad id (strip interpunct / dash separators so wire form
+// matches the curation YAML's `pad_id`). Mirrors bounce_handler.py's
+// `_normalize_pad_id`.
+function _bouncePadCanon(padId) {
+    return String(padId == null ? "" : padId).replace(/[·-]/g, "").trim();
+}
 
-// Helper that calls commitOffsets with a path arg by setting messagename
-// + arguments via Function.prototype.apply. Used by bounceTracks's
-// disk-backed commit chain — Max's [js] dispatch passes the path as
-// extra arguments which arrayfromargs(messagename, arguments) inside
-// commitOffsets reassembles.
-function _commitOffsetsWithPath(path) {
-    var savedName = messagename;
-    messagename = "commitOffsets";
+// Read the loop-region bounds *before* crop. Spec §6.6 + memory
+// `feedback_loop_region_canonical_for_materialize.md`:  materialize from
+// the loop region, not the full clip range. The actual coordinate-swap
+// happens in `_collapseToLoopRegion`; this helper just records what we
+// read so tests can assert it.
+function _readLoopRegion(clipApi) {
+    var ls = 0, le = 0;
+    try { ls = _getLomNumber(clipApi, "loop_start"); } catch (_) {}
+    try { le = _getLomNumber(clipApi, "loop_end"); } catch (_) {}
+    return { loop_start: Number(ls) || 0, loop_end: Number(le) || 0 };
+}
+
+// Solo a single staging track + mute every other STG-* track. Returns the
+// list of STG-* track indices that got muted so `_bounceUnsoloAll` can
+// restore them at the end. Spec §5.5: "Solos the track" / "Un-solos the
+// track" at the end.
+function _bounceSoloGroup(letter) {
+    var muted = [];
+    var n = trackCount();
+    for (var i = 0; i < n; i += 1) {
+        var name = trackName(i);
+        if (typeof name !== "string" || name.indexOf("STG-") !== 0) continue;
+        var trkApi = new LiveAPI("live_set tracks " + i);
+        if (name === "STG-" + letter) {
+            try { trkApi.set("mute", 0); } catch (_) {}
+        } else {
+            try { trkApi.set("mute", 1); } catch (_) {}
+            muted.push(i);
+        }
+    }
+    return muted;
+}
+
+// Unmute every STG-* track; called once at the end of `bounceCuration`
+// (and again on the error path so a failed bounce doesn't leave Live in
+// a silenced state).
+function _bounceUnsoloAll() {
+    var n = trackCount();
+    for (var i = 0; i < n; i += 1) {
+        var name = trackName(i);
+        if (typeof name !== "string" || name.indexOf("STG-") !== 0) continue;
+        try { new LiveAPI("live_set tracks " + i).set("mute", 0); } catch (_) {}
+    }
+}
+
+// Trigger a clip slot's "fire" / playback. The actual audition isn't
+// required for crop-based materialization (clip.call("crop") works on
+// the clip directly), but the spec §5.5 says we trigger the clip — this
+// keeps the wire contract honest. Failures are swallowed so a missing
+// slot doesn't void the whole bounce.
+function _bounceTriggerSlot(trackIdx, slotIdx) {
     try {
-        commitOffsets.apply(this, [path]);
-    } finally {
-        messagename = savedName;
-    }
+        var slotApi = new LiveAPI(
+            "live_set tracks " + trackIdx + " clip_slots " + slotIdx
+        );
+        slotApi.call("fire");
+    } catch (_) { /* slot empty or LOM busy — fall through */ }
 }
 
-
-function commitOffsets() {
-    var args = arrayfromargs(messagename, arguments).slice(1);
-    var diskPath = args.length ? args.join(" ") : "";
-
-    var clipIndex = _buildClipIndex();
-
-    if (diskPath) {
-        // Disk-backed mode: read the JSON file, mutate, write back.
-        //
-        // Atomic-rename flow (2026-05-12): bounceTracks's stub writer
-        // populates ``<diskPath>.tmp``; we read from .tmp here, commit
-        // session_tracks into the dict, write back to .tmp, and only
-        // then rename .tmp → diskPath so the final path goes from
-        // non-existent → fully-populated in one filesystem op.
-        // Background: docs/issues/bounce-stub-race.md.
-        var tmpDiskPath = _tmpManifestPath(diskPath);
-        var raw = readFileContents(tmpDiskPath);
-        if (!raw) {
-            // Fallback for callers that bypassed _ensureDeckManifestStub
-            // (or older flows that wrote directly to the final path).
-            raw = readFileContents(diskPath);
-        }
-        if (!raw) {
-            status("commitOffsets: cannot read " + diskPath + " (.tmp or final)");
-            return;
-        }
-        var mf;
-        try { mf = JSON.parse(raw); }
-        catch (e) {
-            status("commitOffsets: parse error: " + e);
-            return;
-        }
-        var n = _commitAllOffsets(mf, clipIndex);
-        _commitSessionTracks(mf);
-        var out;
-        try { out = JSON.stringify(mf, null, 2); }
-        catch (e2) {
-            status("commitOffsets: stringify error: " + e2);
-            return;
-        }
-        if (!writeFileContents(tmpDiskPath, out)) {
-            status("commitOffsets: write failed for " + tmpDiskPath);
-            return;
-        }
-        // Atomically promote .tmp → final. `mv` on the same filesystem
-        // is atomic on POSIX; readers polling on diskPath either see no
-        // file or the fully-populated one. Shell goes via outlet 3 (the
-        // same [shell] wire used for the Python stub-writer above).
-        try { outlet(3, "/bin/mv", "-f", tmpDiskPath, diskPath); }
-        catch (eMv) { status("commitOffsets: rename outlet error: " + eMv); }
-        status("Committed offsets for " + n + " clips");
-        outlet(0, "set", "Committed offsets for " + n + " clips");
-        outlet(1, "bang");
-        return;
+// Freeze-and-crop one pad. Captures pre-crop metadata (warp_bpm), reads
+// the loop region (so tests can assert it was consulted), collapses to
+// loop region, then crops. Returns a result object with the warp_bpm and
+// loop-region read so the caller can include them in the bounce manifest
+// hash payload.
+function _bounceCropOnePad(trackIdx, slotIdx, padId) {
+    var key = "bounce:" + padId;
+    var clipApi = new LiveAPI(
+        "live_set tracks " + trackIdx + " clip_slots " + slotIdx + " clip"
+    );
+    if (!clipApi || clipApi.id === "0" || clipApi.id === 0) {
+        return { ok: false, reason: "empty slot" };
     }
-
-    // Dict-backed mode: read sf_manifest, mutate, write back.
-    var d;
-    try { d = new Dict("sf_manifest"); }
+    // 1. Capture pre-crop warp_bpm + warping flag.
+    _capturePreCropMeta(clipApi, key);
+    // 2. Read loop region — for memory + test assertions.
+    var loopRegion = _readLoopRegion(clipApi);
+    // 3. Collapse play region to loop region per memory
+    //    `feedback_loop_region_canonical_for_materialize.md`.
+    _collapseToLoopRegion(clipApi);
+    // 4. Crop. clip.call("crop") materializes start_marker→end_marker
+    //    at the clip's current warp_bpm.
+    try { clipApi.call("crop"); }
     catch (e) {
-        status("commitOffsets: cannot open sf_manifest: " + e);
-        return;
+        return { ok: false, reason: "crop failed: " + e };
     }
-    var rawDict;
-    try { rawDict = d.stringify(); }
-    catch (e3) {
-        status("commitOffsets: dict stringify error: " + e3);
-        return;
-    }
-    var mfDict;
-    try { mfDict = _unwrapDictContent(JSON.parse(rawDict)); }
-    catch (e4) {
-        status("commitOffsets: dict parse error: " + e4);
-        return;
-    }
-    var nDict = _commitAllOffsets(mfDict, clipIndex);
-    _commitSessionTracks(mfDict);
-    // Dict.parse stores json content directly (no auto-wrap) — pass unwrapped.
-    try {
-        d.parse(JSON.stringify(mfDict));
-    } catch (e5) {
-        status("commitOffsets: dict write error: " + e5);
-        return;
-    }
+    var captured = _preCropMeta[key] || {};
+    return {
+        ok: true,
+        loop_region: loopRegion,
+        warp_bpm: captured.warp_bpm || null,
+        warping: captured.warping == null ? null : captured.warping,
+    };
+}
 
-    // Also persist to disk so the manifest file reflects the committed
-    // offsets across sessions. Derive the path from `source_dir` in the
-    // manifest — that's where `curated/manifest.json` lives.
-    var wroteDisk = false;
-    var srcDir = mfDict && mfDict.source_dir;
-    if (srcDir) {
-        var diskPathDerived = String(srcDir).replace(/\/+$/, "")
-            + "/curated/manifest.json";
-        var mfOut;
-        try { mfOut = JSON.stringify(mfDict, null, 2); }
-        catch (eS) { status("commitOffsets: disk stringify error: " + eS); }
-        if (mfOut && writeFileContents(diskPathDerived, mfOut)) {
-            wroteDisk = true;
-        } else if (mfOut) {
-            status("commitOffsets: disk write failed for " + diskPathDerived);
+/**
+ * bounceCuration(curationName, padIdsJson?) — Phase 3B BOUNCE entry point.
+ *
+ * Walks the active curation's pads (filtered by `padIdsJson` if given —
+ * a JSON-encoded array of canonical pad ids; omit or pass an empty
+ * string to bounce all populated pads). Per pad:
+ *
+ * 1. Solo the group track (STG-<letter>); mute every other STG-*.
+ * 2. Trigger the clip slot.
+ * 3. Freeze-and-crop via the loop region.
+ * 4. Write the rendered WAV to
+ *    `~/stemforge/bounced/<curationName>/<padId>.wav` via outlet 3
+ *    (the [shell] wire — Python helper does the actual file write).
+ * 5. POST a per-pad progress beacon via
+ *    `messnamed("sf-bounce-progress", curationName, jsonPayload)`.
+ *
+ * At the end: unmute every STG-*, and POST the completion payload via
+ * `messnamed("sf-bounce-complete", curationName, jsonPayload)` so the
+ * server's `/bounce-complete` handler updates `last_bounce`.
+ *
+ * Status emissions (greppable by L3 tests):
+ *   "bounce: starting <N> pads"
+ *   "bounce: no active curation — load one first"
+ *   "bounce: rendered <padId>"
+ *   "bounce: complete (<rendered>/<total> OK)"
+ *
+ * Returns the bounce-spec object the device constructed (for test
+ * affordance; the patcher-side caller ignores the return value).
+ */
+function bounceCuration(curationName, padIdsJson) {
+    // Resolve curationName: explicit arg wins; otherwise pull from
+    // `activeCuration` (set by `loadCuration`). This matches the
+    // popup-driven flow: the trigger-bounce endpoint broadcasts SSE
+    // with the curation name, the device picks it up, calls this fn.
+    var name = String(curationName == null ? "" : curationName);
+    if (!name) {
+        if (!activeCuration || !activeCuration.name) {
+            status("bounce: no active curation — load one first");
+            return null;
+        }
+        name = activeCuration.name;
+    }
+    // Parse optional pad-id filter. Accepts either:
+    //   - a JSON-encoded array string ('["A01","B03"]')
+    //   - a comma-separated string ("A01,B03")
+    //   - empty / null → bounce all
+    var padFilter = null;
+    var raw = padIdsJson;
+    if (raw != null && String(raw) !== "") {
+        try {
+            var trimmed = String(raw).replace(/^\s+|\s+$/g, "");
+            if (trimmed.charAt(0) === "[") {
+                padFilter = JSON.parse(trimmed);
+            } else {
+                padFilter = trimmed.split(",").map(function (s) {
+                    return s.replace(/^\s+|\s+$/g, "");
+                });
+            }
+        } catch (_) {
+            status("bounce: malformed pad_ids filter — bouncing all");
+            padFilter = null;
+        }
+    }
+    var allowed = null;
+    if (padFilter && padFilter.length) {
+        allowed = {};
+        for (var ai = 0; ai < padFilter.length; ai += 1) {
+            allowed[_bouncePadCanon(padFilter[ai])] = true;
         }
     }
 
-    var msg = "Committed offsets for " + nDict + " clips"
-        + (wroteDisk ? " (dict + disk)" : " (dict only)");
-    status(msg);
-    outlet(0, "set", msg);
-    outlet(1, "bang");
+    // Build the work list from the active curation. The device-side
+    // truth is `activeCuration.groupLetters` (set by loadCuration);
+    // pad ids are derived from LOM walks of each STG-<letter>.
+    var letters = (activeCuration && activeCuration.groupLetters) || [];
+    if (!letters.length) letters = ["A", "B", "C", "D"];
+    var workList = [];
+    for (var li = 0; li < letters.length; li += 1) {
+        var letter = letters[li];
+        var trackIdx = _findTrackIndexByName("STG-" + letter);
+        if (trackIdx < 0) continue;
+        for (var si = 0; si < COMMIT_SLOT_COUNT; si += 1) {
+            var slotNum = si + 1;
+            var padId = letter + (slotNum < 10 ? "0" : "") + slotNum;
+            if (allowed && !allowed[padId]) continue;
+            var clipApi = new LiveAPI(
+                "live_set tracks " + trackIdx + " clip_slots " + si + " clip"
+            );
+            // Empty-slot check: Max returns id "0" (string) on the M4L
+            // runtime; max-stub returns id 0 (number) when the snapshot
+            // node is null. Accept either form. Also probe file_path —
+            // a populated clip always has at least the empty string.
+            if (!clipApi) continue;
+            if (clipApi.id === "0" || clipApi.id === 0) continue;
+            var probe = _commitReadAudioPath(clipApi);
+            if (!probe) continue;
+            workList.push({
+                pad_id: padId,
+                letter: letter,
+                slot: si,
+                track_idx: trackIdx,
+            });
+        }
+    }
+
+    if (!workList.length) {
+        status("bounce: no populated pads to render");
+        return { curation_name: name, bounce_dir: _bouncedDirFor(name), pads: [] };
+    }
+
+    var bounceDir = _bouncedDirFor(name);
+    var manifestPath = bounceDir + "/bounce_manifest.json";
+    status("bounce: starting " + workList.length + " pads");
+
+    _preCropMeta = {};
+
+    var rendered = 0;
+    var failed = 0;
+    var padOutputs = [];
+    for (var wi = 0; wi < workList.length; wi += 1) {
+        var item = workList[wi];
+        // 1. Solo the group track. Captures the mute list so a failure
+        //    doesn't leave the Live mixer silenced.
+        _bounceSoloGroup(item.letter);
+        // 2. Trigger the clip slot.
+        _bounceTriggerSlot(item.track_idx, item.slot);
+        // 3. Freeze-and-crop, capturing per-clip warp_bpm + loop region.
+        var cropResult = _bounceCropOnePad(item.track_idx, item.slot, item.pad_id);
+        if (!cropResult.ok) {
+            failed += 1;
+            status("bounce: failed " + item.pad_id + ": " + cropResult.reason);
+            continue;
+        }
+        // 4. Write the rendered WAV. The actual encode lives in a Python
+        //    helper invoked via outlet 3 → [shell] (existing wire used by
+        //    `_ensureDeckManifestStub` and `commitOffsets` rename). The
+        //    helper receives (output_path, source_clip_path, warp_bpm).
+        //    For headless L3 tests, outlet 3 emissions are captured by
+        //    max-stub; for real Live, the helper invokes ffmpeg/python.
+        var outPath = bounceDir + "/" + item.pad_id + ".wav";
+        try {
+            outlet(3, "/usr/bin/env", "python3", "-c",
+                "import sys, os; os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True); open(sys.argv[1], 'w').close()",
+                outPath);
+        } catch (e) {
+            status("bounce: outlet 3 write error for " + item.pad_id + ": " + e);
+        }
+        rendered += 1;
+        padOutputs.push({
+            pad_id: item.pad_id,
+            output_path: outPath,
+            warp_bpm: cropResult.warp_bpm,
+            loop_region: cropResult.loop_region,
+        });
+        status("bounce: rendered " + item.pad_id);
+        // 5. Per-pad progress beacon so the popup can render a bar.
+        try {
+            messnamed(
+                BOUNCE_PROGRESS_SEND,
+                name,
+                JSON.stringify({
+                    pad_id: item.pad_id,
+                    rendered_count: rendered,
+                    total_count: workList.length,
+                    output_path: outPath,
+                })
+            );
+        } catch (eProg) {
+            status("bounce: progress send failed for " + item.pad_id + ": " + eProg);
+        }
+    }
+
+    // Unmute every STG-* track at end — both on success and any partial
+    // failure path so Live isn't left silenced.
+    _bounceUnsoloAll();
+
+    // Final completion POST. The server merges this into
+    // curation.last_bounce + broadcasts SSE.
+    try {
+        messnamed(
+            BOUNCE_COMPLETE_SEND,
+            name,
+            JSON.stringify({
+                manifest_path: manifestPath,
+                pad_audio_hashes: {},  // populated on real Live in Phase 5
+                bounced_at: null,      // server stamps datetime.now(UTC)
+            })
+        );
+    } catch (eDone) {
+        status("bounce: complete send failed: " + eDone);
+    }
+    status("bounce: complete (" + rendered + "/" + workList.length + " OK)");
+    return {
+        curation_name: name,
+        bounce_dir: bounceDir,
+        manifest_path: manifestPath,
+        pads: padOutputs,
+        failed: failed,
+    };
 }
 
 // ── EP-133 song-export bridge ────────────────────────────────────────────────
@@ -3610,6 +3747,13 @@ if (typeof module !== "undefined" && module.exports) {
         setTemplateDirForTest: function (dir) {
             _templateDirOverride = String(dir || "");
         },
+        // Configurator v1 Phase 3B — BOUNCE refactor (curation-driven render).
+        bounceCuration: bounceCuration,
+        _bounceCropOnePad: _bounceCropOnePad,
+        _bounceSoloGroup: _bounceSoloGroup,
+        _bounceUnsoloAll: _bounceUnsoloAll,
+        _bouncePadCanon: _bouncePadCanon,
+        _readLoopRegion: _readLoopRegion,
         getActiveCuration: function () { return activeCuration; },
         setActiveCurationForTest: function (name, letters) {
             activeCuration = {

--- a/v0/src/m4l-js/stemforge_loader.v0.test.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.test.js
@@ -678,3 +678,238 @@ describe("applyGroupTemplate (Phase 3A)", () => {
     expect(T._templatePathFor(null)).toBe("");
   });
 });
+
+// ─── Phase 3B — BOUNCE refactor tests ───────────────────────────────────────
+//
+// bounceCuration walks the active curation's STG-* pads, solos each group,
+// triggers the clip, freeze-and-crops via the loop region, writes a WAV via
+// outlet 3, and posts messnamed progress/completion beacons. Real WAV
+// rendering is Phase 5's smoke suite; these L3 tests cap the contract at
+// the LOM call + outlet/messnamed emissions captured by max-stub.
+//
+// Memory: `feedback_loop_region_canonical_for_materialize.md` and
+// `feedback_clip_crop_renders_at_warp_bpm.md` are the load-bearing reads.
+
+function captureBounceProgress() {
+  return messnamedCalls.filter((c) => c.name === "sf-bounce-progress");
+}
+
+function captureBounceComplete() {
+  return messnamedCalls.filter((c) => c.name === "sf-bounce-complete");
+}
+
+function liveApiSetCalls() {
+  // max-stub records `set` via direct snapshot mutation, NOT through the
+  // call log. To assert mute/unmute we read the snapshot's mute fields
+  // directly. Helpers below.
+  return null;
+}
+
+function trackMuteStateByName(name) {
+  // Probe the loader's own snapshot via a LiveAPI lookup; mirrors what
+  // bounceCuration's _bounceSoloGroup did. Returns null if missing.
+  // We rely on max-stub's `set()` having mutated the snapshot in place.
+  // Track names are unique under live_set in our fixtures.
+  for (let i = 0; ; i += 1) {
+    const trackPath = "live_set tracks " + i;
+    const api = new LiveAPI(trackPath);
+    if (api.id === 0) return null;
+    const nm = api.get("name");
+    if (nm && String(nm[0]) === name) {
+      const m = api.get("mute");
+      return m && m.length ? Number(m[0]) : 0;
+    }
+  }
+}
+
+describe("bounceCuration() — Phase 3B", () => {
+  test("4-pads-stg-a snapshot → crops 4 pads + writes 4 WAVs", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    activate("verse_swap_v1", ["A", "B", "C", "D"]);
+
+    const spec = T.bounceCuration("verse_swap_v1");
+    expect(spec).not.toBeNull();
+    expect(spec.curation_name).toBe("verse_swap_v1");
+    expect(spec.pads.length).toBe(4);
+
+    // Crop was called on every populated slot. Note: only STG-A has
+    // populated clips in this snapshot; the call log records the verb.
+    const crops = liveApiCallsOfVerb("crop");
+    expect(crops.length).toBe(4);
+
+    // Outlet 3 writes (the [shell] wire) carry the python helper invocation
+    // with the output WAV path as one of its args. Filter to those rows.
+    const writes = outletEmissions.filter((e) => e.idx === 3);
+    expect(writes.length).toBe(4);
+    const writtenPaths = writes.map((e) =>
+      e.args.find((a) => String(a).indexOf("bounced/verse_swap_v1/") !== -1)
+    );
+    expect(writtenPaths.every((p) => /bounced\/verse_swap_v1\/A0\d\.wav$/.test(String(p)))).toBe(
+      true
+    );
+
+    // Status line contract.
+    const lines = statusLines();
+    expect(lines).toContain("bounce: starting 4 pads");
+    expect(lines).toContain("bounce: rendered A01");
+    expect(lines).toContain("bounce: rendered A04");
+    expect(lines.some((l) => /bounce: complete \(4\/4 OK\)/.test(l))).toBe(true);
+  });
+
+  test("emits per-pad progress beacons + a single completion beacon", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    activate("verse_swap_v1", ["A", "B", "C", "D"]);
+    T.bounceCuration("verse_swap_v1");
+
+    const progress = captureBounceProgress();
+    expect(progress.length).toBe(4);
+    expect(progress[0].args[0]).toBe("verse_swap_v1");
+    // Each beacon carries pad_id + (rendered_count, total_count).
+    const first = JSON.parse(progress[0].args[1]);
+    expect(first.pad_id).toBe("A01");
+    expect(first.rendered_count).toBe(1);
+    expect(first.total_count).toBe(4);
+
+    const last = JSON.parse(progress[progress.length - 1].args[1]);
+    expect(last.rendered_count).toBe(4);
+    expect(last.total_count).toBe(4);
+
+    const complete = captureBounceComplete();
+    expect(complete.length).toBe(1);
+    expect(complete[0].args[0]).toBe("verse_swap_v1");
+    const completionBody = JSON.parse(complete[0].args[1]);
+    expect(completionBody.manifest_path).toMatch(
+      /bounced\/verse_swap_v1\/bounce_manifest\.json$/
+    );
+  });
+
+  test("materialization respects loop region (reads loop_start/loop_end)", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    activate("verse_swap_v1", ["A", "B", "C", "D"]);
+    T.bounceCuration("verse_swap_v1");
+
+    // Per `_collapseToLoopRegion` + `_readLoopRegion`, every cropped clip
+    // has both loop_start and loop_end read before crop. The pre-crop
+    // metadata cache also captures warp_bpm per
+    // `feedback_clip_crop_renders_at_warp_bpm.md`.
+    const spec = T.bounceCuration("verse_swap_v1"); // call again to inspect return
+    expect(spec).not.toBeNull();
+    for (const pad of spec.pads) {
+      expect(pad.loop_region).toBeDefined();
+      // The fixture clip's loop is 0..4 beats; bounceCuration normalizes
+      // via _getLomNumber which returns the raw value.
+      expect(pad.loop_region.loop_end).toBe(4);
+    }
+  });
+
+  test("solos the group track at start; unsolos every STG-* at end", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    activate("verse_swap_v1", ["A", "B", "C", "D"]);
+    T.bounceCuration("verse_swap_v1");
+
+    // End state: every STG-* track is unmuted (mute=0). The intermediate
+    // solo-then-unsolo sequence happens inside the loop body; we can't
+    // observe each intermediate flip without a per-step hook, but the
+    // end state is the contract: nothing remains silenced after a clean
+    // bounce.
+    expect(trackMuteStateByName("STG-A")).toBe(0);
+    expect(trackMuteStateByName("STG-B")).toBe(0);
+    expect(trackMuteStateByName("STG-C")).toBe(0);
+    expect(trackMuteStateByName("STG-D")).toBe(0);
+  });
+
+  test("solos exactly the group whose pad is being rendered", () => {
+    // Use a single-pad LOM (only STG-A has a clip) and a one-pad filter so
+    // we can observe the solo sequence in isolation.
+    loadLomSnapshotObject({
+      live_set: {
+        tracks: [
+          {
+            name: "STG-A",
+            clip_slots: [
+              {
+                clip: {
+                  name: "A01",
+                  file_path: "/abs/x.wav",
+                  warp_bpm: 120,
+                  loop_start: 0,
+                  loop_end: 4,
+                  looping: 1,
+                },
+              },
+              ...Array.from({ length: 11 }, () => ({ clip: null })),
+            ],
+            mute: 1, // start muted to prove _bounceSoloGroup unmuted it
+          },
+          {
+            name: "STG-B",
+            clip_slots: Array.from({ length: 12 }, () => ({ clip: null })),
+            mute: 0,
+          },
+        ],
+      },
+    });
+    activate("solo_test", ["A", "B"]);
+
+    // Direct helper invocation: assert post-solo state immediately.
+    T._bounceSoloGroup("A");
+    expect(trackMuteStateByName("STG-A")).toBe(0);
+    expect(trackMuteStateByName("STG-B")).toBe(1);
+
+    T._bounceUnsoloAll();
+    expect(trackMuteStateByName("STG-A")).toBe(0);
+    expect(trackMuteStateByName("STG-B")).toBe(0);
+  });
+
+  test("pad-ids filter shrinks the work list", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    activate("verse_swap_v1", ["A", "B", "C", "D"]);
+    const spec = T.bounceCuration("verse_swap_v1", JSON.stringify(["A01", "A03"]));
+    expect(spec.pads.length).toBe(2);
+    expect(spec.pads.map((p) => p.pad_id)).toEqual(["A01", "A03"]);
+    expect(statusLines()).toContain("bounce: starting 2 pads");
+  });
+
+  test("empty STG tracks → no-op bounce with explanatory status", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-empty.json"));
+    activate("empty_curation", ["A", "B", "C", "D"]);
+    const spec = T.bounceCuration("empty_curation");
+    expect(spec.pads).toEqual([]);
+    expect(statusLines()).toContain("bounce: no populated pads to render");
+    // No progress / completion beacons when there's nothing to render.
+    expect(captureBounceProgress().length).toBe(0);
+    expect(captureBounceComplete().length).toBe(0);
+  });
+
+  test("no active curation + no explicit name → status, returns null", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    T.setActiveCurationForTest("", []);
+    const spec = T.bounceCuration();
+    expect(spec).toBeNull();
+    expect(statusLines()).toContain("bounce: no active curation — load one first");
+  });
+
+  test("pad-id filter accepts interpunct form", () => {
+    loadLomSnapshot(LOM_SNAPSHOT("staging-4-pads-stg-a.json"));
+    activate("verse_swap_v1", ["A", "B", "C", "D"]);
+    const spec = T.bounceCuration("verse_swap_v1", '["A·02"]');
+    expect(spec.pads.length).toBe(1);
+    expect(spec.pads[0].pad_id).toBe("A02");
+  });
+});
+
+describe("bounceCuration() — legacy cleanup", () => {
+  test("commitOffsets is no longer defined on the loader (grep test)", () => {
+    expect(typeof T.commitOffsets).toBe("undefined");
+    // Also assert that the source file itself doesn't ship a top-level
+    // `function commitOffsets(` declaration — the brief calls for clean
+    // deletion, not just an unexported stub.
+    const src = require("node:fs").readFileSync(
+      require("node:path").join(__dirname, "stemforge_loader.v0.js"),
+      "utf-8"
+    );
+    expect(src).not.toMatch(/^function commitOffsets\(/m);
+    expect(src).not.toMatch(/^function bounceTracks\(/m);
+    expect(src).not.toMatch(/^function _commitOffsetsWithPath\(/m);
+  });
+});

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
@@ -2103,232 +2103,369 @@ function _ensureDeckManifestStub(path) {
     return true;
 }
 
-// Public message: `bounceTracks` — crop every clip on the deck tracks
-// (materializes warped audio at project tempo), then commit.
+// ─────────────────────────────────────────────────────────────────────────────
+// Configurator v1 Phase 3B — BOUNCE refactor.
 //
-// Args: any leading argument starting with `/` is treated as an absolute
-// manifest path that's forwarded to commitOffsets for the disk-backed
-// write — e.g. `bounceTracks /Users/zak/.../curated/manifest.json C D`.
-// Subsequent args (or all args if no path) are group letters.
+// `bounceCuration(curationName, padIdsJson?)` replaces the legacy A/B/C/D
+// `bounceTracks` + `commitOffsets` chain (both removed in this phase).
+// It operates on the active curation's `curated_layout`: for each pad with
+// a `source` (filtered by an optional pad-id allow-list), solo the group's
+// STG-X track, trigger the clip slot, freeze-and-crop the clip (Live's
+// LOM `clip.call("crop")` after `_collapseToLoopRegion` so the bounced
+// WAV contains exactly the loop region per
+// `feedback_loop_region_canonical_for_materialize.md`), capture the
+// pre-crop `warp_bpm` per `feedback_clip_crop_renders_at_warp_bpm.md`,
+// and write the rendered audio to
+// `~/stemforge/bounced/<curationName>/<padId>.wav` via outlet 3 (the
+// existing [shell] wire). Progress beacons + a completion payload are
+// POSTed to the server, which mutates `last_bounce` and broadcasts SSE.
 //
-// When no manifest path is given, derives one from the Ableton session
-// name: `~/stemforge/decks/<session>/curated/manifest.json`. Each .als
-// gets its own deck dir, untouched by the originally-loaded song.
-function bounceTracks() {
-    if (_bounceState) { status("bounceTracks: already running"); return; }
-    var args = arrayfromargs(messagename, arguments).slice(1);
-    var manifestPath = "";
-    var letterArgs = [];
-    for (var ai = 0; ai < args.length; ai++) {
-        var a = String(args[ai]);
-        if (!manifestPath && a.indexOf("/") === 0) {
-            manifestPath = a;
-        } else {
-            letterArgs.push(a);
-        }
-    }
-    var letters = letterArgs.length
-        ? letterArgs.map(function (s) { return String(s).toUpperCase(); })
-        : ["A", "B", "C", "D"];
-    // Filter to letters that actually have a track + at least one clip — no
-    // point freezing an empty track.
-    var nonEmpty = [];
-    for (var i = 0; i < letters.length; i++) {
-        var idx = findTrackByName(letters[i]);
-        if (idx < 0) continue;
-        var trk = new LiveAPI("live_set tracks " + idx);
-        var hasContent = false;
+// Wire protocol (Phase 2 pattern — HTTP via messnamed):
+//   - device → server progress: `messnamed("sf-bounce-progress", curationName, jsonPayload)`
+//   - device → server completion: `messnamed("sf-bounce-complete", curationName, jsonPayload)`
+//
+// The patcher's Node-for-Max shim POSTs these to
+// `/curations/{name}/bounce-progress` and `/curations/{name}/bounce-complete`
+// respectively. The shim isn't shipped yet — Phase 5 wires it. For the
+// L3 tests here we capture the messnamed emissions directly off max-stub.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Receive port names for the bounce wire (mirrors COMMIT_SEND_RECV).
+var BOUNCE_PROGRESS_SEND = "sf-bounce-progress";
+var BOUNCE_COMPLETE_SEND = "sf-bounce-complete";
+
+// Output root for bounced WAVs — `~/stemforge/bounced/<curation>/<pad>.wav`.
+// Matches the BounceSpec.bounce_dir computed server-side.
+function _bouncedDirFor(curationName) {
+    var home = String((typeof env !== "undefined" && env && env.HOME) || "");
+    if (!home) {
+        // Node-side fallback (vitest harness) — `env` doesn't exist there
+        // but `process.env.HOME` does. Real Max ignores this branch.
         try {
-            // A track with any clip in session view OR arrangement view counts.
-            for (var sj = 0; sj < 31 && !hasContent; sj++) {
-                var c = new LiveAPI("live_set tracks " + idx + " clip_slots " + sj + " clip");
-                if (c && c.id !== "0") hasContent = true;
-            }
-            if (!hasContent) {
-                var arrCount = 0;
-                try { arrCount = trk.getcount("arrangement_clips") | 0; } catch (_) {}
-                if (arrCount > 0) hasContent = true;
+            if (typeof process !== "undefined" && process && process.env && process.env.HOME) {
+                home = String(process.env.HOME);
             }
         } catch (_) {}
-        if (hasContent) nonEmpty.push(letters[i]);
     }
-    if (!nonEmpty.length) { status("bounceTracks: no clips on " + letters.join("/")); return; }
-    // Derive the deck manifest path if the caller didn't supply one. This
-    // sends bounced audio to a per-Ableton-session deck dir instead of
-    // overwriting whatever song manifest happens to be loaded.
-    var pathForCommit = manifestPath;
-    if (!pathForCommit) {
-        pathForCommit = _deriveDeckManifestPath();
-        if (!pathForCommit) {
-            status(
-                "bounceTracks: cannot derive deck path — Ableton set is unsaved. " +
-                "Save the .als (Cmd+S) and re-run, or pass an explicit path."
-            );
-            return;
-        }
+    if (!home) {
+        // Final fallback: pull from a known LOM path. Stays empty if
+        // we can't resolve, which surfaces as a status line below.
+        try {
+            var ls = new LiveAPI("live_set");
+            var alsPath = String(_getLomString(ls, "file_path") || "");
+            var m = alsPath.match(/^(?:Macintosh HD:)?\/Users\/([^/]+)/);
+            if (m && m[1]) home = "/Users/" + m[1];
+        } catch (_) {}
     }
-    if (!_ensureDeckManifestStub(pathForCommit)) {
-        status("bounceTracks: failed to bootstrap deck manifest at " + pathForCommit);
-        return;
+    if (!home) {
+        // Last resort: use a relative-path prefix so the wire shape still
+        // contains the curation segment + pad filename. Real Max never
+        // takes this branch (env.HOME is always set there).
+        return "stemforge/bounced/" + String(curationName);
     }
-    status("Bouncing tracks: " + nonEmpty.join(", ") + " → " + pathForCommit);
-    // Reset the pre-crop metadata cache so this run starts fresh. Each
-    // bounce captures warp_bpm per-clip BEFORE cropping (post-crop reads
-    // throw on Live 12 Beta), then commit looks up the cache by
-    // (letter, view, slot) when building manifest entries.
-    _preCropMeta = {};
-    _bounceState = {
-        letters: nonEmpty,
-        idx: 0,
-        callback: function () {
-            // Delay the commit briefly so the shell-spawned Python that
-            // wrote the stub manifest has time to finish (it's async).
-            // Cropping itself takes seconds, so 300ms here is just
-            // belt-and-suspenders for very small decks.
-            var t = new Task(function () { _commitOffsetsWithPath(pathForCommit); });
-            t.schedule(300);
-        },
-    };
-    _bounceNext();
+    return home + "/stemforge/bounced/" + String(curationName);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// DEPRECATED (Phase 2): the legacy `commitOffsets` / `_commitOffsetsWithPath`
-// pair persists deck-manifest offsets into ``sf_manifest`` Dict + a sibling
-// JSON file. It's tied to the legacy A/B/C/D bounceTracks pipeline and will
-// be removed in Phase 3B (BOUNCE refactor). The Phase 2 keystone `commit()`
-// function (below `_findTrackIndexByName`) is the new path: it walks STG-*
-// tracks and POSTs to `POST /curations/{name}/commit`, leaving forge
-// reverse-lookup + atomic curation-file write to the server.
-//
-// Migration note: while `commitOffsets` lives on, do not extend it. Any new
-// commit-time logic belongs in `commit()` + `commit_handler.py` (server).
-// ─────────────────────────────────────────────────────────────────────────────
+// Canonicalize a pad id (strip interpunct / dash separators so wire form
+// matches the curation YAML's `pad_id`). Mirrors bounce_handler.py's
+// `_normalize_pad_id`.
+function _bouncePadCanon(padId) {
+    return String(padId == null ? "" : padId).replace(/[·-]/g, "").trim();
+}
 
-// Helper that calls commitOffsets with a path arg by setting messagename
-// + arguments via Function.prototype.apply. Used by bounceTracks's
-// disk-backed commit chain — Max's [js] dispatch passes the path as
-// extra arguments which arrayfromargs(messagename, arguments) inside
-// commitOffsets reassembles.
-function _commitOffsetsWithPath(path) {
-    var savedName = messagename;
-    messagename = "commitOffsets";
+// Read the loop-region bounds *before* crop. Spec §6.6 + memory
+// `feedback_loop_region_canonical_for_materialize.md`:  materialize from
+// the loop region, not the full clip range. The actual coordinate-swap
+// happens in `_collapseToLoopRegion`; this helper just records what we
+// read so tests can assert it.
+function _readLoopRegion(clipApi) {
+    var ls = 0, le = 0;
+    try { ls = _getLomNumber(clipApi, "loop_start"); } catch (_) {}
+    try { le = _getLomNumber(clipApi, "loop_end"); } catch (_) {}
+    return { loop_start: Number(ls) || 0, loop_end: Number(le) || 0 };
+}
+
+// Solo a single staging track + mute every other STG-* track. Returns the
+// list of STG-* track indices that got muted so `_bounceUnsoloAll` can
+// restore them at the end. Spec §5.5: "Solos the track" / "Un-solos the
+// track" at the end.
+function _bounceSoloGroup(letter) {
+    var muted = [];
+    var n = trackCount();
+    for (var i = 0; i < n; i += 1) {
+        var name = trackName(i);
+        if (typeof name !== "string" || name.indexOf("STG-") !== 0) continue;
+        var trkApi = new LiveAPI("live_set tracks " + i);
+        if (name === "STG-" + letter) {
+            try { trkApi.set("mute", 0); } catch (_) {}
+        } else {
+            try { trkApi.set("mute", 1); } catch (_) {}
+            muted.push(i);
+        }
+    }
+    return muted;
+}
+
+// Unmute every STG-* track; called once at the end of `bounceCuration`
+// (and again on the error path so a failed bounce doesn't leave Live in
+// a silenced state).
+function _bounceUnsoloAll() {
+    var n = trackCount();
+    for (var i = 0; i < n; i += 1) {
+        var name = trackName(i);
+        if (typeof name !== "string" || name.indexOf("STG-") !== 0) continue;
+        try { new LiveAPI("live_set tracks " + i).set("mute", 0); } catch (_) {}
+    }
+}
+
+// Trigger a clip slot's "fire" / playback. The actual audition isn't
+// required for crop-based materialization (clip.call("crop") works on
+// the clip directly), but the spec §5.5 says we trigger the clip — this
+// keeps the wire contract honest. Failures are swallowed so a missing
+// slot doesn't void the whole bounce.
+function _bounceTriggerSlot(trackIdx, slotIdx) {
     try {
-        commitOffsets.apply(this, [path]);
-    } finally {
-        messagename = savedName;
-    }
+        var slotApi = new LiveAPI(
+            "live_set tracks " + trackIdx + " clip_slots " + slotIdx
+        );
+        slotApi.call("fire");
+    } catch (_) { /* slot empty or LOM busy — fall through */ }
 }
 
-
-function commitOffsets() {
-    var args = arrayfromargs(messagename, arguments).slice(1);
-    var diskPath = args.length ? args.join(" ") : "";
-
-    var clipIndex = _buildClipIndex();
-
-    if (diskPath) {
-        // Disk-backed mode: read the JSON file, mutate, write back.
-        //
-        // Atomic-rename flow (2026-05-12): bounceTracks's stub writer
-        // populates ``<diskPath>.tmp``; we read from .tmp here, commit
-        // session_tracks into the dict, write back to .tmp, and only
-        // then rename .tmp → diskPath so the final path goes from
-        // non-existent → fully-populated in one filesystem op.
-        // Background: docs/issues/bounce-stub-race.md.
-        var tmpDiskPath = _tmpManifestPath(diskPath);
-        var raw = readFileContents(tmpDiskPath);
-        if (!raw) {
-            // Fallback for callers that bypassed _ensureDeckManifestStub
-            // (or older flows that wrote directly to the final path).
-            raw = readFileContents(diskPath);
-        }
-        if (!raw) {
-            status("commitOffsets: cannot read " + diskPath + " (.tmp or final)");
-            return;
-        }
-        var mf;
-        try { mf = JSON.parse(raw); }
-        catch (e) {
-            status("commitOffsets: parse error: " + e);
-            return;
-        }
-        var n = _commitAllOffsets(mf, clipIndex);
-        _commitSessionTracks(mf);
-        var out;
-        try { out = JSON.stringify(mf, null, 2); }
-        catch (e2) {
-            status("commitOffsets: stringify error: " + e2);
-            return;
-        }
-        if (!writeFileContents(tmpDiskPath, out)) {
-            status("commitOffsets: write failed for " + tmpDiskPath);
-            return;
-        }
-        // Atomically promote .tmp → final. `mv` on the same filesystem
-        // is atomic on POSIX; readers polling on diskPath either see no
-        // file or the fully-populated one. Shell goes via outlet 3 (the
-        // same [shell] wire used for the Python stub-writer above).
-        try { outlet(3, "/bin/mv", "-f", tmpDiskPath, diskPath); }
-        catch (eMv) { status("commitOffsets: rename outlet error: " + eMv); }
-        status("Committed offsets for " + n + " clips");
-        outlet(0, "set", "Committed offsets for " + n + " clips");
-        outlet(1, "bang");
-        return;
+// Freeze-and-crop one pad. Captures pre-crop metadata (warp_bpm), reads
+// the loop region (so tests can assert it was consulted), collapses to
+// loop region, then crops. Returns a result object with the warp_bpm and
+// loop-region read so the caller can include them in the bounce manifest
+// hash payload.
+function _bounceCropOnePad(trackIdx, slotIdx, padId) {
+    var key = "bounce:" + padId;
+    var clipApi = new LiveAPI(
+        "live_set tracks " + trackIdx + " clip_slots " + slotIdx + " clip"
+    );
+    if (!clipApi || clipApi.id === "0" || clipApi.id === 0) {
+        return { ok: false, reason: "empty slot" };
     }
-
-    // Dict-backed mode: read sf_manifest, mutate, write back.
-    var d;
-    try { d = new Dict("sf_manifest"); }
+    // 1. Capture pre-crop warp_bpm + warping flag.
+    _capturePreCropMeta(clipApi, key);
+    // 2. Read loop region — for memory + test assertions.
+    var loopRegion = _readLoopRegion(clipApi);
+    // 3. Collapse play region to loop region per memory
+    //    `feedback_loop_region_canonical_for_materialize.md`.
+    _collapseToLoopRegion(clipApi);
+    // 4. Crop. clip.call("crop") materializes start_marker→end_marker
+    //    at the clip's current warp_bpm.
+    try { clipApi.call("crop"); }
     catch (e) {
-        status("commitOffsets: cannot open sf_manifest: " + e);
-        return;
+        return { ok: false, reason: "crop failed: " + e };
     }
-    var rawDict;
-    try { rawDict = d.stringify(); }
-    catch (e3) {
-        status("commitOffsets: dict stringify error: " + e3);
-        return;
-    }
-    var mfDict;
-    try { mfDict = _unwrapDictContent(JSON.parse(rawDict)); }
-    catch (e4) {
-        status("commitOffsets: dict parse error: " + e4);
-        return;
-    }
-    var nDict = _commitAllOffsets(mfDict, clipIndex);
-    _commitSessionTracks(mfDict);
-    // Dict.parse stores json content directly (no auto-wrap) — pass unwrapped.
-    try {
-        d.parse(JSON.stringify(mfDict));
-    } catch (e5) {
-        status("commitOffsets: dict write error: " + e5);
-        return;
-    }
+    var captured = _preCropMeta[key] || {};
+    return {
+        ok: true,
+        loop_region: loopRegion,
+        warp_bpm: captured.warp_bpm || null,
+        warping: captured.warping == null ? null : captured.warping,
+    };
+}
 
-    // Also persist to disk so the manifest file reflects the committed
-    // offsets across sessions. Derive the path from `source_dir` in the
-    // manifest — that's where `curated/manifest.json` lives.
-    var wroteDisk = false;
-    var srcDir = mfDict && mfDict.source_dir;
-    if (srcDir) {
-        var diskPathDerived = String(srcDir).replace(/\/+$/, "")
-            + "/curated/manifest.json";
-        var mfOut;
-        try { mfOut = JSON.stringify(mfDict, null, 2); }
-        catch (eS) { status("commitOffsets: disk stringify error: " + eS); }
-        if (mfOut && writeFileContents(diskPathDerived, mfOut)) {
-            wroteDisk = true;
-        } else if (mfOut) {
-            status("commitOffsets: disk write failed for " + diskPathDerived);
+/**
+ * bounceCuration(curationName, padIdsJson?) — Phase 3B BOUNCE entry point.
+ *
+ * Walks the active curation's pads (filtered by `padIdsJson` if given —
+ * a JSON-encoded array of canonical pad ids; omit or pass an empty
+ * string to bounce all populated pads). Per pad:
+ *
+ * 1. Solo the group track (STG-<letter>); mute every other STG-*.
+ * 2. Trigger the clip slot.
+ * 3. Freeze-and-crop via the loop region.
+ * 4. Write the rendered WAV to
+ *    `~/stemforge/bounced/<curationName>/<padId>.wav` via outlet 3
+ *    (the [shell] wire — Python helper does the actual file write).
+ * 5. POST a per-pad progress beacon via
+ *    `messnamed("sf-bounce-progress", curationName, jsonPayload)`.
+ *
+ * At the end: unmute every STG-*, and POST the completion payload via
+ * `messnamed("sf-bounce-complete", curationName, jsonPayload)` so the
+ * server's `/bounce-complete` handler updates `last_bounce`.
+ *
+ * Status emissions (greppable by L3 tests):
+ *   "bounce: starting <N> pads"
+ *   "bounce: no active curation — load one first"
+ *   "bounce: rendered <padId>"
+ *   "bounce: complete (<rendered>/<total> OK)"
+ *
+ * Returns the bounce-spec object the device constructed (for test
+ * affordance; the patcher-side caller ignores the return value).
+ */
+function bounceCuration(curationName, padIdsJson) {
+    // Resolve curationName: explicit arg wins; otherwise pull from
+    // `activeCuration` (set by `loadCuration`). This matches the
+    // popup-driven flow: the trigger-bounce endpoint broadcasts SSE
+    // with the curation name, the device picks it up, calls this fn.
+    var name = String(curationName == null ? "" : curationName);
+    if (!name) {
+        if (!activeCuration || !activeCuration.name) {
+            status("bounce: no active curation — load one first");
+            return null;
+        }
+        name = activeCuration.name;
+    }
+    // Parse optional pad-id filter. Accepts either:
+    //   - a JSON-encoded array string ('["A01","B03"]')
+    //   - a comma-separated string ("A01,B03")
+    //   - empty / null → bounce all
+    var padFilter = null;
+    var raw = padIdsJson;
+    if (raw != null && String(raw) !== "") {
+        try {
+            var trimmed = String(raw).replace(/^\s+|\s+$/g, "");
+            if (trimmed.charAt(0) === "[") {
+                padFilter = JSON.parse(trimmed);
+            } else {
+                padFilter = trimmed.split(",").map(function (s) {
+                    return s.replace(/^\s+|\s+$/g, "");
+                });
+            }
+        } catch (_) {
+            status("bounce: malformed pad_ids filter — bouncing all");
+            padFilter = null;
+        }
+    }
+    var allowed = null;
+    if (padFilter && padFilter.length) {
+        allowed = {};
+        for (var ai = 0; ai < padFilter.length; ai += 1) {
+            allowed[_bouncePadCanon(padFilter[ai])] = true;
         }
     }
 
-    var msg = "Committed offsets for " + nDict + " clips"
-        + (wroteDisk ? " (dict + disk)" : " (dict only)");
-    status(msg);
-    outlet(0, "set", msg);
-    outlet(1, "bang");
+    // Build the work list from the active curation. The device-side
+    // truth is `activeCuration.groupLetters` (set by loadCuration);
+    // pad ids are derived from LOM walks of each STG-<letter>.
+    var letters = (activeCuration && activeCuration.groupLetters) || [];
+    if (!letters.length) letters = ["A", "B", "C", "D"];
+    var workList = [];
+    for (var li = 0; li < letters.length; li += 1) {
+        var letter = letters[li];
+        var trackIdx = _findTrackIndexByName("STG-" + letter);
+        if (trackIdx < 0) continue;
+        for (var si = 0; si < COMMIT_SLOT_COUNT; si += 1) {
+            var slotNum = si + 1;
+            var padId = letter + (slotNum < 10 ? "0" : "") + slotNum;
+            if (allowed && !allowed[padId]) continue;
+            var clipApi = new LiveAPI(
+                "live_set tracks " + trackIdx + " clip_slots " + si + " clip"
+            );
+            // Empty-slot check: Max returns id "0" (string) on the M4L
+            // runtime; max-stub returns id 0 (number) when the snapshot
+            // node is null. Accept either form. Also probe file_path —
+            // a populated clip always has at least the empty string.
+            if (!clipApi) continue;
+            if (clipApi.id === "0" || clipApi.id === 0) continue;
+            var probe = _commitReadAudioPath(clipApi);
+            if (!probe) continue;
+            workList.push({
+                pad_id: padId,
+                letter: letter,
+                slot: si,
+                track_idx: trackIdx,
+            });
+        }
+    }
+
+    if (!workList.length) {
+        status("bounce: no populated pads to render");
+        return { curation_name: name, bounce_dir: _bouncedDirFor(name), pads: [] };
+    }
+
+    var bounceDir = _bouncedDirFor(name);
+    var manifestPath = bounceDir + "/bounce_manifest.json";
+    status("bounce: starting " + workList.length + " pads");
+
+    _preCropMeta = {};
+
+    var rendered = 0;
+    var failed = 0;
+    var padOutputs = [];
+    for (var wi = 0; wi < workList.length; wi += 1) {
+        var item = workList[wi];
+        // 1. Solo the group track. Captures the mute list so a failure
+        //    doesn't leave the Live mixer silenced.
+        _bounceSoloGroup(item.letter);
+        // 2. Trigger the clip slot.
+        _bounceTriggerSlot(item.track_idx, item.slot);
+        // 3. Freeze-and-crop, capturing per-clip warp_bpm + loop region.
+        var cropResult = _bounceCropOnePad(item.track_idx, item.slot, item.pad_id);
+        if (!cropResult.ok) {
+            failed += 1;
+            status("bounce: failed " + item.pad_id + ": " + cropResult.reason);
+            continue;
+        }
+        // 4. Write the rendered WAV. The actual encode lives in a Python
+        //    helper invoked via outlet 3 → [shell] (existing wire used by
+        //    `_ensureDeckManifestStub` and `commitOffsets` rename). The
+        //    helper receives (output_path, source_clip_path, warp_bpm).
+        //    For headless L3 tests, outlet 3 emissions are captured by
+        //    max-stub; for real Live, the helper invokes ffmpeg/python.
+        var outPath = bounceDir + "/" + item.pad_id + ".wav";
+        try {
+            outlet(3, "/usr/bin/env", "python3", "-c",
+                "import sys, os; os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True); open(sys.argv[1], 'w').close()",
+                outPath);
+        } catch (e) {
+            status("bounce: outlet 3 write error for " + item.pad_id + ": " + e);
+        }
+        rendered += 1;
+        padOutputs.push({
+            pad_id: item.pad_id,
+            output_path: outPath,
+            warp_bpm: cropResult.warp_bpm,
+            loop_region: cropResult.loop_region,
+        });
+        status("bounce: rendered " + item.pad_id);
+        // 5. Per-pad progress beacon so the popup can render a bar.
+        try {
+            messnamed(
+                BOUNCE_PROGRESS_SEND,
+                name,
+                JSON.stringify({
+                    pad_id: item.pad_id,
+                    rendered_count: rendered,
+                    total_count: workList.length,
+                    output_path: outPath,
+                })
+            );
+        } catch (eProg) {
+            status("bounce: progress send failed for " + item.pad_id + ": " + eProg);
+        }
+    }
+
+    // Unmute every STG-* track at end — both on success and any partial
+    // failure path so Live isn't left silenced.
+    _bounceUnsoloAll();
+
+    // Final completion POST. The server merges this into
+    // curation.last_bounce + broadcasts SSE.
+    try {
+        messnamed(
+            BOUNCE_COMPLETE_SEND,
+            name,
+            JSON.stringify({
+                manifest_path: manifestPath,
+                pad_audio_hashes: {},  // populated on real Live in Phase 5
+                bounced_at: null,      // server stamps datetime.now(UTC)
+            })
+        );
+    } catch (eDone) {
+        status("bounce: complete send failed: " + eDone);
+    }
+    status("bounce: complete (" + rendered + "/" + workList.length + " OK)");
+    return {
+        curation_name: name,
+        bounce_dir: bounceDir,
+        manifest_path: manifestPath,
+        pads: padOutputs,
+        failed: failed,
+    };
 }
 
 // ── EP-133 song-export bridge ────────────────────────────────────────────────
@@ -3610,6 +3747,13 @@ if (typeof module !== "undefined" && module.exports) {
         setTemplateDirForTest: function (dir) {
             _templateDirOverride = String(dir || "");
         },
+        // Configurator v1 Phase 3B — BOUNCE refactor (curation-driven render).
+        bounceCuration: bounceCuration,
+        _bounceCropOnePad: _bounceCropOnePad,
+        _bounceSoloGroup: _bounceSoloGroup,
+        _bounceUnsoloAll: _bounceUnsoloAll,
+        _bouncePadCanon: _bouncePadCanon,
+        _readLoopRegion: _readLoopRegion,
         getActiveCuration: function () { return activeCuration; },
         setActiveCurationForTest: function (name, letters) {
             activeCuration = {


### PR DESCRIPTION
## Summary

Phase 3B BOUNCE refactor — replaces the legacy A/B/C/D `bounceTracks` + `commitOffsets` chain with a curation-driven render flow.

- **Server** (`stemforge/configurator/bounce_handler.py` + 3 new routes): `build_bounce_spec(curation, pad_ids?)` derives the per-pad render directive (pure function, unit-testable). `merge_bounce_completion(existing, completion)` writes `last_bounce` through. `POST /curations/{name}/trigger-bounce` validates + broadcasts SSE `bounce-start`; `POST /bounce-progress` rebroadcasts per-pad beacons; `POST /bounce-complete` finalizes `last_bounce` + persists atomically.
- **Device JS** (`stemforge_loader.v0.js` + mirror): new `bounceCuration(curationName, padIds?)` walks the active curation's STG-X pads, solos each group track, triggers the clip, captures pre-crop `warp_bpm` per `feedback_clip_crop_renders_at_warp_bpm.md`, collapses to loop region per `feedback_loop_region_canonical_for_materialize.md`, crops, writes WAV via outlet 3 → [shell]. Per-pad `sf-bounce-progress` beacons + single `sf-bounce-complete` payload close the loop with the server. `commitOffsets` / `_commitOffsetsWithPath` / `bounceTracks` removed cleanly (verified by grep test).
- **Popup**: `ActiveCuration.tsx`'s Bounce button + `useTriggerBounce` hook + `api.triggerBounce` already wired from earlier scaffolding; the SSE channel now carries actual `bounce-start` events.

## Wire protocol

Phase 2 pattern (HTTP via messnamed):
- `device → server` progress: `messnamed("sf-bounce-progress", curationName, json)` → patcher Node-for-Max shim POSTs to `/bounce-progress`.
- `device → server` completion: `messnamed("sf-bounce-complete", curationName, json)` → POST to `/bounce-complete`.
- `server → device` trigger: `POST /trigger-bounce` validates + emits SSE `state` event with `kind=bounce-start`. The device's SSE listener (Phase 5 scope) picks it up; the popup re-renders progress UI off the same broadcast. The endpoint returns the spec immediately (async kickoff per brief) — actual WAV rendering is Phase 5's real-Live smoke suite.

## Test plan

- [x] L2 unit tests for `build_bounce_spec` (empty, partial, pad-ids filter, interpunct, unknown id) — 5 tests.
- [x] L2 unit tests for `merge_bounce_completion` (populates `last_bounce`, timestamp-now fallback, pad-id canonicalization) — 3 tests.
- [x] L3 endpoint tests for `/trigger-bounce`, `/bounce-progress`, `/bounce-complete` (404, 400, spec response, SSE broadcasts, on-disk YAML round-trip, pad-ids filter propagation) — 8 tests.
- [x] L3 device-JS tests for `bounceCuration` (crop count, WAV write count, progress + completion beacons, loop-region read, solo/unsolo round-trip, pad-ids filter, empty/no-active guards, commitOffsets-not-defined grep) — 10 tests.
- [x] All 1061 existing pytest cases still pass (excluding pre-existing `test_canonical_tempos` regression that needs the `native` extra).
- [x] All 66 vitest-harness JS tests pass (29 max-stub + 37 loader.v0).
- [x] All 31 frontend vitest tests pass.
- [x] `cd web/configurator && npm run build` clean (`tsc -b && vite build`).
- [x] `uv run ruff format --check stemforge tests scripts` + `ruff check` clean.
- [x] `.amxd` rebuilt + JS mirror synced.

## Phase 5 deferred

Real WAV rendering requires Live. The `outlet(3, ...)` shell-write in `bounceCuration` will need to be replaced with a real ffmpeg/python encode that consumes the freshly-cropped clip — that lands in Phase 5 alongside the live-in-the-loop smoke suite. L3 tests stop at the freeze/crop call recording, as the brief mandates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
