### PR TITLE
feat: active-curation persistence — .stemforge_state.json round-trip + als-opened bootstrap

### DIFF
--- a/stemforge/configurator/intents.py
+++ b/stemforge/configurator/intents.py
@@ -486,6 +486,20 @@ class CloseActiveCurationBody(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class AlsOpenedBody(BaseModel):
+    """Body of ``POST /als-opened`` (Phase 4A).
+
+    Device JS emits this on ``loadbang`` so the server can resolve the
+    Live project's saved active curation and ack the device to auto-load
+    it. Empty / missing path is accepted (Live's "Untitled" state) and
+    results in a ``None`` ack — the device simply does nothing further.
+    """
+
+    als_path: str = Field(default="", description="Absolute path to the open .als file.")
+
+    model_config = {"extra": "forbid"}
+
+
 class PatchTemplateBody(BaseModel):
     """Body of ``PATCH /curations/{name}/template``."""
 
@@ -801,6 +815,57 @@ async def handle_close_active_curation(
         "ok": True,
         "als_path": body.als_path,
         "active_curations": sf_state.active_curations,
+    }
+
+
+async def handle_als_opened(
+    state: AppState,
+    body: AlsOpenedBody,
+) -> dict[str, Any]:
+    """``POST /als-opened`` — bootstrap lookup for the device on Live open.
+
+    Looks up ``state.active_curations[als_path]`` from the in-memory cache
+    (primed at startup, refreshed on every mutation). Returns
+    ``{"als_path": ..., "active_curation": <name | None>}`` so the device
+    can decide whether to auto-load. Also broadcasts a typed
+    ``bootstrap`` SSE event so the popup mirrors the device's view
+    (useful when the user has the popup open BEFORE the device sends its
+    first ``loadbang``).
+
+    No mutation here — this is a read-only lookup. We intentionally do
+    NOT refresh the cache from disk: every legitimate writer routes
+    through :meth:`AppState.refresh_cached_stemforge_state`, so a cache
+    miss means the curation truly isn't active on this server's view of
+    the world.
+    """
+    als_path = body.als_path
+    active_name = state.cached_stemforge_state.active_curations.get(als_path)
+
+    # Broadcast a bootstrap event so any popup attached to this server
+    # sees the same answer the device just got. The popup can ignore it
+    # if it doesn't recognize ``kind=bootstrap``; explicit subscribers
+    # use it to surface "Live just opened <foo.als>" UI affordances.
+    import time as _time
+
+    await state.broadcast(
+        SseEvent(
+            event="state",
+            data={
+                "kind": "bootstrap",
+                "als_path": als_path,
+                "active_curation": active_name,
+                "ts": _time.time(),
+            },
+        )
+    )
+    if active_name:
+        await state.log(f"als-opened {als_path!r} → active={active_name}", "info")
+    else:
+        await state.log(f"als-opened {als_path!r} → no active curation", "info")
+    return {
+        "ok": True,
+        "als_path": als_path,
+        "active_curation": active_name,
     }
 
 
@@ -1204,6 +1269,7 @@ async def handle_bounce_complete(
 
 
 __all__ = [
+    "AlsOpenedBody",
     "BounceCompletion",
     "BounceProgress",
     "BounceSpec",
@@ -1218,6 +1284,7 @@ __all__ = [
     "RenameCurationBody",
     "SaveAsBody",
     "TriggerBounceBody",
+    "handle_als_opened",
     "handle_assign_pad",
     "handle_bounce_complete",
     "handle_bounce_progress",

--- a/stemforge/configurator/server.py
+++ b/stemforge/configurator/server.py
@@ -51,6 +51,10 @@ Routes (Phase 1.5 — forge endpoints + curation rename/close bridge):
 - ``POST /curations/{name}/rename``
 - ``POST /curations/active/close``
 
+Routes (Phase 4A — active-curation persistence + device bootstrap):
+
+- ``POST /als-opened``  (device → server on Live's ``loadbang``)
+
 Routes (Phase 3C — EXPORT via server):
 
 - ``POST /curations/{name}/export``
@@ -88,6 +92,7 @@ from .export_handler import (
 )
 from .forge_io import default_processed_dir, list_forges, resolve_forge_dir
 from .intents import (
+    AlsOpenedBody,
     CloseActiveCurationBody,
     CreateCurationBody,
     DeviceCommitBody,
@@ -217,6 +222,12 @@ def create_app(
     )
     state.curations_dir = resolved_curations
     state.state_path = resolved_state_path
+    # Phase 4A: prime the in-memory StemforgeState cache from disk so the
+    # device-bootstrap path (``POST /als-opened``) doesn't pay an I/O hit
+    # on every request. ``load_state_with_recovery`` handles a malformed
+    # state file by archiving it and resetting to empty — the server
+    # keeps booting either way.
+    state.refresh_cached_stemforge_state()
 
     @asynccontextmanager
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
@@ -554,6 +565,18 @@ def _register_routes(app: FastAPI, state: AppState) -> None:
     @app.post("/curations/active/close")
     async def close_active_curation_route(body: CloseActiveCurationBody) -> dict[str, Any]:
         return await intents.handle_close_active_curation(state, body)
+
+    # ── Phase 4A — device bootstrap on Live `.als` open ────────────────────
+
+    @app.post("/als-opened")
+    async def als_opened_route(body: AlsOpenedBody) -> dict[str, Any]:
+        """Device-driven bootstrap: resolve the active curation for ``als_path``.
+
+        See :func:`intents.handle_als_opened`. The response body carries
+        ``active_curation: str | null`` — the device's HTTP shim hands it
+        back to the loader JS via ``messnamed("sf-als-opened-ack", name)``.
+        """
+        return await intents.handle_als_opened(state, body)
 
     # ── Phase 3A — template index ──────────────────────────────────────────
 

--- a/stemforge/configurator/state.py
+++ b/stemforge/configurator/state.py
@@ -19,6 +19,14 @@ Persistence layout (per spec §2.4):
   Map of ``.als`` absolute path → active curation name. Tiny;
   hand-edit-safe; atomic-write.
 - ``~/stemforge/curations/*.yaml`` — see :mod:`curation_io`.
+
+Phase 4A wired the **als-opened bootstrap**: on every Live ``.als`` open,
+the device JS posts the project's absolute path to ``POST /als-opened``;
+the server consults its in-memory :class:`StemforgeState` cache and
+responds with the matching ``active_curation`` (or ``null``) so the
+device can auto-load the right curation without user intervention. See
+:func:`load_state_with_recovery` and
+:attr:`AppState.cached_stemforge_state` for the cache.
 """
 
 from __future__ import annotations
@@ -73,6 +81,26 @@ class AppState:
     state_path: Path = field(
         default_factory=lambda: Path.home() / "stemforge" / ".stemforge_state.json"
     )
+    # Phase 4A: in-memory cache of the on-disk :class:`StemforgeState`,
+    # primed by :func:`stemforge.configurator.server.create_app`. The
+    # ``POST /als-opened`` handler reads from this cache so device
+    # bootstrap is one disk-touch at process start, not per-request. The
+    # cache is refreshed lazily by readers (``load_state`` always reads
+    # disk) and replaced atomically by writers via
+    # :meth:`refresh_cached_stemforge_state`.
+    cached_stemforge_state: StemforgeState = field(default_factory=StemforgeState)
+
+    def refresh_cached_stemforge_state(self) -> StemforgeState:
+        """Re-read ``.stemforge_state.json`` into the in-memory cache.
+
+        Called by handlers after every write so the cache mirrors disk
+        without forcing every reader to round-trip through the filesystem.
+        Corruption is handled by :func:`load_state_with_recovery` — a
+        malformed file is moved aside and the cache resets to empty so the
+        server stays operational.
+        """
+        self.cached_stemforge_state = load_state_with_recovery(self.state_path)
+        return self.cached_stemforge_state
 
     # ── Subscribers / broker ─────────────────────────────────────────────────
 
@@ -112,14 +140,15 @@ class AppState:
         Used by the new curation CRUD endpoints (spec §4.3). The payload
         intentionally mirrors what ``GET /curations`` and the popup's
         SSE-driven curation list want to render.
+
+        Phase 4A: refreshes the in-memory cache before broadcasting so
+        all subsequent ``/als-opened`` lookups see the latest map without
+        re-reading disk.
         """
         from .curation_io import list_curations  # local: avoid import cycle
 
-        try:
-            current_state = load_state(self.state_path)
-            active_curations = current_state.active_curations
-        except (FileNotFoundError, json.JSONDecodeError):
-            active_curations = {}
+        current_state = self.refresh_cached_stemforge_state()
+        active_curations = current_state.active_curations
         names = [p.stem for p in list_curations(self.curations_dir)]
         await self.broadcast(
             SseEvent(
@@ -184,6 +213,53 @@ def load_state(state_path: Path | None = None) -> StemforgeState:
         return StemforgeState()
     data = json.loads(raw)
     return StemforgeState.model_validate(data)
+
+
+def load_state_with_recovery(state_path: Path | None = None) -> StemforgeState:
+    """Best-effort variant of :func:`load_state` that survives corruption.
+
+    Phase 4A startup hook. If the state file exists but is malformed
+    (truncated mid-write, hand-edited into invalid JSON, schema-version
+    drift), this helper moves the bad file aside to
+    ``<state_path>.corrupt-<unix-ts>`` and returns a fresh empty
+    :class:`StemforgeState` so the server keeps booting. A clean miss
+    (file absent / blank) falls through to :func:`load_state`'s default
+    empty-state branch — no backup written.
+
+    The backup-on-corruption behaviour means a power-cut between
+    ``fsync`` and ``rename`` (`save_state`'s atomic-write pattern) will
+    leave the OLD file intact at the real path. Only a half-written final
+    file ever triggers the backup; the OS-level atomicity of ``rename``
+    on POSIX prevents that on every platform we ship to.
+    """
+    target = state_path or (Path.home() / "stemforge" / ".stemforge_state.json")
+    try:
+        return load_state(target)
+    except json.JSONDecodeError:
+        # Move aside + reset. Preserve the bytes for forensics.
+        backup = target.with_name(f"{target.name}.corrupt-{int(time.time())}")
+        try:
+            os.replace(target, backup)
+        except OSError:
+            # Couldn't move it — try removing it. Either way we keep
+            # serving from an empty in-memory state.
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                pass
+        return StemforgeState()
+    except (ValueError, TypeError):
+        # Pydantic ValidationError lands here too (it subclasses
+        # ValueError). Same recovery: archive + reset.
+        backup = target.with_name(f"{target.name}.corrupt-{int(time.time())}")
+        try:
+            os.replace(target, backup)
+        except OSError:
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                pass
+        return StemforgeState()
 
 
 def save_state(state: StemforgeState, state_path: Path | None = None) -> None:
@@ -251,6 +327,7 @@ __all__ = [
     "SseEvent",
     "get_active_curation",
     "load_state",
+    "load_state_with_recovery",
     "save_state",
     "set_active_curation",
 ]

--- a/tests/test_configurator_state_persistence.py
+++ b/tests/test_configurator_state_persistence.py
@@ -1,0 +1,377 @@
+"""Phase 4A — active-curation persistence + ``/als-opened`` bootstrap tests.
+
+Covers:
+
+* :func:`stemforge.configurator.state.load_state_with_recovery` — the
+  startup loader that survives a corrupt state file by archiving it.
+* End-to-end round-trip across every mutation surface that touches
+  ``.stemforge_state.json`` (open / rename / close / delete) using the
+  Phase 1B + 1.5 HTTP endpoints, asserting on-disk parity with the
+  in-memory cache.
+* Atomic-write robustness — a failed write leaves the previous file
+  intact (no half-written truncation).
+* ``POST /als-opened`` returns the cached active curation and
+  broadcasts a typed ``bootstrap`` SSE event to listeners.
+
+The pattern (tmp_path-rooted ``~/stemforge/`` layout) mirrors
+``tests/test_configurator_curation_crud.py`` — same fixture shape so
+this file can share the eventual ``conftest.py`` extraction.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stemforge.configurator.curation_io import (
+    curation_path,
+    write_curation_atomic,
+)
+from stemforge.configurator.schemas import (
+    Curation,
+    Group,
+    Pad,
+    StemforgeState,
+    Target,
+)
+from stemforge.configurator.server import create_app
+from stemforge.configurator.state import (
+    load_state,
+    load_state_with_recovery,
+    save_state,
+    set_active_curation,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def configurator_paths(tmp_path: Path) -> dict[str, Path]:
+    """Provision an isolated ``~/stemforge/`` layout under ``tmp_path``."""
+    curations_dir = tmp_path / "curations"
+    curations_dir.mkdir()
+    state_path = tmp_path / ".stemforge_state.json"
+    static_dir = tmp_path / "static"
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    return {
+        "curations_dir": curations_dir,
+        "state_path": state_path,
+        "static_dir": static_dir,
+        "templates_dir": templates_dir,
+    }
+
+
+@pytest.fixture
+def client(configurator_paths: dict[str, Path]) -> TestClient:
+    app = create_app(
+        static_dir=configurator_paths["static_dir"],
+        curations_dir=configurator_paths["curations_dir"],
+        state_path=configurator_paths["state_path"],
+        templates_dir=configurator_paths["templates_dir"],
+    )
+    return TestClient(app)
+
+
+def _seed_curation(curations_dir: Path, name: str) -> Curation:
+    """Drop a minimal Curation YAML on disk via the canonical atomic writer."""
+    now = datetime.now(UTC)
+    target = Target()
+    groups: dict[str, Group] = {}
+    for letter in ["A", "B", "C", "D"]:
+        pads = [Pad(pad_id=f"{letter}{i + 1:02d}") for i in range(12)]
+        groups[letter] = Group(label="", template=None, pads=pads)
+    curation = Curation(
+        name=name,
+        type="deck",
+        created_at=now,
+        modified_at=now,
+        target=target,
+        referenced_forges=[],
+        groups=groups,
+    )
+    write_curation_atomic(curation_path(curations_dir, name), curation)
+    return curation
+
+
+# ── 1) Round-trip equality through every mutation path ────────────────────
+
+
+def test_round_trip_open_rename_close_delete(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """Walk the full lifecycle and assert disk + cache parity at each step.
+
+    open → rename (active follows new name) → close → delete. After each
+    step we read the on-disk state file ourselves and compare against
+    what ``GET /curations`` returns (the cache-backed view).
+    """
+    state_path = configurator_paths["state_path"]
+    curations_dir = configurator_paths["curations_dir"]
+    _seed_curation(curations_dir, "alpha")
+    als = "/projects/song.als"
+
+    # 1. open — writes active map entry.
+    r = client.post("/curations/alpha/open", json={"als_path": als})
+    assert r.status_code == 200
+    disk = json.loads(state_path.read_text())
+    assert disk["active_curations"] == {als: "alpha"}
+    cache_view = client.get("/curations").json()
+    assert cache_view["active_curations"] == {als: "alpha"}
+
+    # 2. rename — active map entry follows the new name.
+    r = client.post("/curations/alpha/rename", json={"new_name": "alpha_v2"})
+    assert r.status_code == 200, r.text
+    disk = json.loads(state_path.read_text())
+    assert disk["active_curations"] == {als: "alpha_v2"}
+    cache_view = client.get("/curations").json()
+    assert cache_view["active_curations"] == {als: "alpha_v2"}
+
+    # 3. close — entry removed (set to None pops it).
+    r = client.post("/curations/active/close", json={"als_path": als})
+    assert r.status_code == 200
+    disk = json.loads(state_path.read_text())
+    assert disk["active_curations"] == {}
+    cache_view = client.get("/curations").json()
+    assert cache_view["active_curations"] == {}
+
+    # 4. delete — file gone, no active entries to clean up either.
+    r = client.delete("/curations/alpha_v2")
+    assert r.status_code == 200
+    disk = json.loads(state_path.read_text())
+    assert disk["active_curations"] == {}
+    cache_view = client.get("/curations").json()
+    assert cache_view["active_curations"] == {}
+
+
+# ── 2) Atomic-write — failed write leaves prior file intact ───────────────
+
+
+def test_save_state_atomic_failure_preserves_old_file(tmp_path: Path) -> None:
+    """If the write fails mid-flight, the original file must be untouched.
+
+    We simulate a write failure by forcing the underlying ``os.replace``
+    call to raise after a successful tempfile flush. The tempfile is
+    cleaned up; the destination file (with old contents) is preserved.
+    """
+    state_path = tmp_path / "saved.json"
+    save_state(StemforgeState(active_curations={"/a.als": "old"}), state_path)
+    before = state_path.read_text()
+
+    new_state = StemforgeState(active_curations={"/a.als": "new"})
+    # Patch the replace step so it raises after the temp write completes.
+    # The save_state implementation's except branch unlinks the .tmp and
+    # re-raises; the destination file must still hold the OLD bytes.
+    with patch("stemforge.configurator.state.os.replace", side_effect=OSError("simulated")):
+        with pytest.raises(OSError, match="simulated"):
+            save_state(new_state, state_path)
+
+    after = state_path.read_text()
+    assert after == before, "old file was corrupted by failed write"
+    # The .tmp scratch file should have been cleaned up by the except branch.
+    leftover = list(tmp_path.glob(".*tmp"))
+    assert not leftover, f"leftover tmp file(s) after failed write: {leftover}"
+
+
+# ── 3) Multi-path updates ─────────────────────────────────────────────────
+
+
+def test_multi_als_path_updates_keep_all_entries(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """Opening several .als → name pairs persists every entry independently.
+
+    Two .als paths, two curations, then close one — the other survives.
+    Validates the map-shaped storage works as advertised and that close
+    of one entry doesn't accidentally clear neighbors.
+    """
+    state_path = configurator_paths["state_path"]
+    _seed_curation(configurator_paths["curations_dir"], "alpha")
+    _seed_curation(configurator_paths["curations_dir"], "beta")
+
+    client.post("/curations/alpha/open", json={"als_path": "/p/a.als"})
+    client.post("/curations/beta/open", json={"als_path": "/p/b.als"})
+    disk = json.loads(state_path.read_text())
+    assert disk["active_curations"] == {"/p/a.als": "alpha", "/p/b.als": "beta"}
+
+    # Close one — the other persists.
+    client.post("/curations/active/close", json={"als_path": "/p/a.als"})
+    disk = json.loads(state_path.read_text())
+    assert disk["active_curations"] == {"/p/b.als": "beta"}
+
+
+# ── 4) Startup load with corruption recovery ──────────────────────────────
+
+
+def test_startup_load_recovers_from_corrupt_state_file(tmp_path: Path) -> None:
+    """A malformed state file is moved aside, then create_app boots clean.
+
+    Writes corrupt JSON, runs ``load_state_with_recovery``, and asserts:
+      - returned state is empty (server boots with no active curations).
+      - the corrupt file has been archived under ``.corrupt-<ts>``.
+      - the canonical path is gone (next save_state will create it fresh).
+    """
+    state_path = tmp_path / ".stemforge_state.json"
+    state_path.write_text("{not valid json at all")
+    recovered = load_state_with_recovery(state_path)
+
+    assert isinstance(recovered, StemforgeState)
+    assert recovered.active_curations == {}
+    assert not state_path.is_file(), "corrupt file should have been moved aside"
+
+    # Backup file present with the corrupt-<ts> suffix.
+    backups = list(tmp_path.glob(".stemforge_state.json.corrupt-*"))
+    assert len(backups) == 1
+    assert "{not valid json at all" in backups[0].read_text()
+
+
+def test_startup_load_returns_empty_when_file_absent(tmp_path: Path) -> None:
+    """No state file == fresh-install state; no backup needed, no error."""
+    target = tmp_path / ".stemforge_state.json"
+    recovered = load_state_with_recovery(target)
+    assert recovered.active_curations == {}
+    assert not target.exists()  # we did NOT create it as a side-effect
+    # And no backup either — clean absence is not corruption.
+    assert not list(tmp_path.glob(".stemforge_state.json.corrupt-*"))
+
+
+# ── 5) SSE broadcast on /als-opened ──────────────────────────────────────
+
+
+def test_als_opened_returns_active_and_broadcasts_bootstrap(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """``POST /als-opened`` returns the cached active curation + emits SSE.
+
+    Pre-populates the state file out-of-band, then re-creates the app so
+    the cache primes from disk at startup. Hits the route and asserts
+    both the JSON response shape and that a ``kind=bootstrap`` SSE event
+    fired on the broker.
+    """
+    state_path = configurator_paths["state_path"]
+    save_state(
+        StemforgeState(active_curations={"/projects/song.als": "verse_swap_v1"}),
+        state_path,
+    )
+
+    # Fresh app so startup-load reads the seeded file.
+    app = create_app(
+        static_dir=configurator_paths["static_dir"],
+        curations_dir=configurator_paths["curations_dir"],
+        state_path=state_path,
+        templates_dir=configurator_paths["templates_dir"],
+    )
+    fresh_client = TestClient(app)
+
+    # Capture SSE events as they're broadcast. Subscribing requires an
+    # asyncio.Queue under the running loop; we capture by tapping into
+    # the AppState's broadcast list directly.
+    captured: list[dict] = []
+    app_state = app.state.configurator
+
+    async def _capture(event):  # type: ignore[no-untyped-def]
+        captured.append({"event": event.event, "data": event.data})
+
+    original_broadcast = app_state.broadcast
+
+    async def _spy(event):  # type: ignore[no-untyped-def]
+        await _capture(event)
+        await original_broadcast(event)
+
+    app_state.broadcast = _spy  # type: ignore[assignment]
+
+    r = fresh_client.post("/als-opened", json={"als_path": "/projects/song.als"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "ok": True,
+        "als_path": "/projects/song.als",
+        "active_curation": "verse_swap_v1",
+    }
+
+    bootstrap_events = [
+        e for e in captured if e["event"] == "state" and e["data"].get("kind") == "bootstrap"
+    ]
+    assert len(bootstrap_events) == 1
+    assert bootstrap_events[0]["data"]["als_path"] == "/projects/song.als"
+    assert bootstrap_events[0]["data"]["active_curation"] == "verse_swap_v1"
+
+
+def test_als_opened_unknown_path_returns_null_active(
+    client: TestClient,
+) -> None:
+    """An unrecognized .als path acks with ``active_curation: None``.
+
+    First-run / unseen Live sets land here. The device's ack handler
+    interprets ``None`` as "do nothing further" — no auto-load.
+    """
+    r = client.post("/als-opened", json={"als_path": "/totally/new.als"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["als_path"] == "/totally/new.als"
+    assert body["active_curation"] is None
+
+
+def test_open_curation_refreshes_cache_for_subsequent_als_opened(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """A live ``open`` mutation is visible to a subsequent ``als-opened`` call.
+
+    Bridges the two halves of the lane: the writer (open endpoint) feeds
+    the cache that the bootstrap endpoint reads. If the cache refresh
+    were broken, the second call would still return ``null`` because the
+    in-memory map would lag behind disk.
+    """
+    _seed_curation(configurator_paths["curations_dir"], "gamma")
+    als = "/projects/late.als"
+
+    # Bootstrap before open: no active curation yet.
+    r = client.post("/als-opened", json={"als_path": als})
+    assert r.json()["active_curation"] is None
+
+    # Now open the curation for this .als path.
+    r = client.post("/curations/gamma/open", json={"als_path": als})
+    assert r.status_code == 200
+
+    # Re-bootstrap: cache must have refreshed.
+    r = client.post("/als-opened", json={"als_path": als})
+    assert r.json()["active_curation"] == "gamma"
+
+
+def test_load_state_with_recovery_handles_schema_violation(tmp_path: Path) -> None:
+    """A pydantic-invalid JSON body archives the file just like bad JSON does.
+
+    Edge case: file parses as JSON but doesn't match the StemforgeState
+    shape (e.g. ``active_curations`` is a list, not an object). Recovery
+    must still move it aside and return an empty state.
+    """
+    state_path = tmp_path / ".stemforge_state.json"
+    state_path.write_text(json.dumps({"schema_version": 1, "active_curations": ["bogus"]}))
+    recovered = load_state_with_recovery(state_path)
+    assert recovered.active_curations == {}
+    assert not state_path.is_file()
+    backups = list(tmp_path.glob(".stemforge_state.json.corrupt-*"))
+    assert len(backups) == 1
+
+
+def test_set_active_curation_sets_last_seen_at(tmp_path: Path) -> None:
+    """Sanity check on the writer: every save bumps ``last_seen_at``.
+
+    Confirms ``set_active_curation``'s timestamp behaviour persists
+    through ``load_state`` round-trip. Without this guard, a future
+    refactor could silently drop the timestamp and we'd lose forensic
+    information about when the active map was last touched.
+    """
+    state_path = tmp_path / "ts.json"
+    before = datetime.now(UTC)
+    set_active_curation("/x.als", "n", state_path)
+    reloaded = load_state(state_path)
+    assert reloaded.last_seen_at is not None
+    assert reloaded.last_seen_at >= before

--- a/v0/src/m4l-js/stemforge_loader.v0.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.js
@@ -3707,6 +3707,162 @@ function templateChanged(letter, name) {
     applyGroupTemplate(letter, name);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Configurator v1 Phase 4A — active-curation bootstrap on Live `.als` open.
+//
+// On every `loadbang` (Live finishes initializing this device), the loader
+// asks Live for the current set's absolute path and POSTs it to the server's
+// `/als-opened` route via the established `messnamed("sf-als-opened", path)`
+// HTTP shim. The patcher's HTTP wrapper does the request, hands the JSON
+// response body back via `messnamed("sf-als-opened-ack", curationOrEmpty)`,
+// which lands on `alsOpenedAck()` here. If the ack carries a curation name,
+// we load it as if the user had picked the curation YAML manually.
+//
+// LOM-verb caveat (deferred to Phase 5 — live-in-the-loop verification):
+//   The exact verb that returns the absolute path to the open `.als` is
+//   not yet fully nailed down — Live's published LOM reference advertises
+//   `live_app view get path_to_set_file` but builds differ. The loader
+//   tries that first, then falls back to `live_set get path` (newer
+//   builds) and finally `live_set get name` (filename without dir).
+//   Tests cover all three paths; field verification is part of Phase 5.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// messnamed targets for the HTTP shim. Patcher dispatches:
+//   [r sf-als-opened] → POST /als-opened → response body → [s sf-als-opened-ack]
+var ALS_OPENED_SEND = "sf-als-opened";
+var ALS_OPENED_ACK_RECV = "sf-als-opened-ack";
+
+// Guard against double-loadbang (Max fires loadbang twice in some patcher
+// reload scenarios — once on initial open, once on the [js] reload). We
+// only want a single bootstrap round-trip per device-open event.
+var _alsOpenedFired = false;
+
+// Test-only override hook: tests can pre-set the path the loader will
+// "discover" from LOM via setAlsPathForTest(). Always "" in production —
+// the LiveAPI walk wins.
+var _alsPathOverrideForTest = null;
+
+/**
+ * Resolve the absolute path to the currently-open .als file.
+ *
+ * Tries (in order):
+ *   1. The test override (set via setAlsPathForTest()).
+ *   2. `new LiveAPI("live_app view").get("path_to_set_file")` — the
+ *      documented verb.
+ *   3. `new LiveAPI("live_set").get("path")` — newer builds.
+ *   4. `new LiveAPI("live_set").get("name")` — filename-only fallback.
+ *
+ * Returns the resolved path string (possibly just a basename) or "" if
+ * nothing surfaced. The empty-string case is forwarded to the server so
+ * a "Live just opened Untitled" event still rings the SSE bell.
+ */
+function _getAlsPath() {
+    if (_alsPathOverrideForTest != null) {
+        return String(_alsPathOverrideForTest || "");
+    }
+    // Try the documented LOM verb first.
+    try {
+        var appView = new LiveAPI("live_app view");
+        var got = appView.get("path_to_set_file");
+        if (got && got.length) {
+            var path1 = String(got[0] == null ? "" : got[0]);
+            if (path1) return path1;
+        }
+    } catch (_e1) { /* fall through */ }
+    // Newer-build fallback: live_set carries the path directly.
+    try {
+        var liveSet = new LiveAPI("live_set");
+        var gotPath = liveSet.get("path");
+        if (gotPath && gotPath.length) {
+            var path2 = String(gotPath[0] == null ? "" : gotPath[0]);
+            if (path2) return path2;
+        }
+    } catch (_e2) { /* fall through */ }
+    // Last-resort fallback: at least return the filename so the server
+    // can still attempt a lookup.
+    try {
+        var liveSet2 = new LiveAPI("live_set");
+        var gotName = liveSet2.get("name");
+        if (gotName && gotName.length) {
+            return String(gotName[0] == null ? "" : gotName[0]);
+        }
+    } catch (_e3) { /* fall through */ }
+    return "";
+}
+
+/**
+ * loadbang() — Max entry point fired when this [js] object finishes
+ * loading. Sends the current .als path to the server so it can ack
+ * back with the active curation (if any) and we auto-load it.
+ *
+ * Idempotent within a single device-open event: a second loadbang
+ * (which Max fires on some [js] reloads) is a no-op.
+ */
+function loadbang() {
+    if (_alsOpenedFired) {
+        status("als-opened: skipping (already fired)");
+        return;
+    }
+    _alsOpenedFired = true;
+    var alsPath = _getAlsPath();
+    try {
+        messnamed(ALS_OPENED_SEND, alsPath);
+        status("als-opened: sent " + (alsPath || "<unknown>"));
+    } catch (e) {
+        status("als-opened: messnamed failed: " + e);
+    }
+}
+
+/**
+ * alsOpenedAck(curationOrSentinel) — message handler bound to the
+ * patcher's `[r sf-als-opened-ack]`. The HTTP shim parses the
+ * `/als-opened` response body and posts the resolved curation name
+ * (or the empty-string / "-" sentinel for "no active curation").
+ *
+ * Behaviour:
+ *   - non-empty + non-sentinel curation name → look up the curation YAML
+ *     on disk via `~/stemforge/curations/<name>.yaml` and call
+ *     loadCuration() with its contents.
+ *   - empty / "-" sentinel → emit a status line and do nothing else.
+ *
+ * Status lines (greppable by L3 tests):
+ *   "als-opened: ack <name>"
+ *   "als-opened: ack <none>"
+ *   "als-opened: curation file not found: <path>"
+ */
+function alsOpenedAck(curationOrSentinel) {
+    var name = String(curationOrSentinel == null ? "" : curationOrSentinel);
+    if (!name || name === TEMPLATE_CLEAR_SENTINEL) {
+        status("als-opened: ack <none>");
+        return;
+    }
+    status("als-opened: ack " + name);
+    // Resolve the curation file path under ~/stemforge/curations/<name>.yaml.
+    var home = "";
+    try {
+        home = _getHomePath();
+    } catch (_e) {
+        status("als-opened: home resolution failed");
+        return;
+    }
+    if (!home) {
+        status("als-opened: home resolution failed");
+        return;
+    }
+    var curationPath = home + "/stemforge/curations/" + name + ".yaml";
+    var text = "";
+    try {
+        text = readFileContents(curationPath);
+    } catch (_e2) {
+        text = "";
+    }
+    if (!text) {
+        status("als-opened: curation file not found: " + curationPath);
+        return;
+    }
+    loadCuration(text, curationPath);
+}
+
 // ── Entry points from Max ─────────────────────────────────────────────────────
 // These aren't stored on `globalThis`; Max's classic [js] object scans for
 // top-level functions automatically.
@@ -3760,6 +3916,18 @@ if (typeof module !== "undefined" && module.exports) {
                 name: String(name || ""),
                 groupLetters: (letters || []).slice()
             };
+        },
+        // Configurator v1 Phase 4A — als-opened bootstrap.
+        loadbang: loadbang,
+        alsOpenedAck: alsOpenedAck,
+        _getAlsPath: _getAlsPath,
+        ALS_OPENED_SEND: ALS_OPENED_SEND,
+        ALS_OPENED_ACK_RECV: ALS_OPENED_ACK_RECV,
+        setAlsPathForTest: function (path) {
+            _alsPathOverrideForTest = path == null ? null : String(path);
+        },
+        resetAlsOpenedFiredForTest: function () {
+            _alsOpenedFired = false;
         }
     };
 }

--- a/v0/src/m4l-js/stemforge_loader.v0.test.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.test.js
@@ -913,3 +913,161 @@ describe("bounceCuration() — legacy cleanup", () => {
     expect(src).not.toMatch(/^function _commitOffsetsWithPath\(/m);
   });
 });
+
+// ─── Phase 4A — als-opened bootstrap ─────────────────────────────────────────
+//
+// `loadbang()` queries Live for the current set's path and POSTs it to the
+// server via `messnamed("sf-als-opened", path)`. The server responds with
+// `{active_curation: name | null}` and the patcher's HTTP shim hands that
+// back via `messnamed("sf-als-opened-ack", curationOrEmpty)` → `alsOpenedAck()`.
+//
+// LOM-verb caveat (deferred to Phase 5): the production code probes three
+// LOM paths in order — `live_app view path_to_set_file`, `live_set path`,
+// `live_set name`. Tests cover each fallback level.
+
+describe("Phase 4A — als-opened bootstrap", () => {
+  beforeEach(() => {
+    // Each test starts with a fresh fired-flag so consecutive calls aren't
+    // squashed by the double-loadbang guard.
+    T.resetAlsOpenedFiredForTest();
+    T.setAlsPathForTest(null);
+  });
+
+  test("loadbang emits sf-als-opened with the LOM-reported absolute path", () => {
+    // Seed the snapshot with a `live_app view` node carrying the
+    // documented `path_to_set_file` property. The loader's first-choice
+    // probe should hit this and emit the path verbatim.
+    loadLomSnapshotObject({
+      live_app: { view: { path_to_set_file: "/Users/zak/projects/song.als" } },
+      live_set: { tracks: [], path: "", name: "song.als" },
+    });
+
+    T.loadbang();
+
+    const sends = global.messnamedCalls.filter((c) => c.name === T.ALS_OPENED_SEND);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].args[0]).toBe("/Users/zak/projects/song.als");
+  });
+
+  test("ack with a curation name reads the YAML and calls loadCuration", () => {
+    // Drop a real curation YAML under a tmp ~/stemforge/curations dir and
+    // point the loader's home-resolver at it via setTemplateDir... actually
+    // the loader resolves home via _getHomePath() which uses Folder
+    // ("Macintosh HD:/Users/") — the max-stub's Folder shim reads the
+    // real filesystem, so we have to either mock _getHomePath OR seed a
+    // fixture that the loader can actually resolve.
+    //
+    // Pragmatic approach: assert on the status emissions. The loader logs
+    // "als-opened: ack <name>" before it tries to read the file. That
+    // alone proves the ack handler routed correctly. The happy-path
+    // file-read is integration-tested by L4 (Phase 5).
+    T.alsOpenedAck("verse_swap_v1");
+    const status = global.outletEmissions
+      .filter((e) => Array.isArray(e.args) && e.args[0] === "set")
+      .map((e) => e.args.slice(1).join(" "));
+    expect(status.some((s) => s.includes("als-opened: ack verse_swap_v1"))).toBe(true);
+  });
+
+  test("ack with empty / sentinel curation is a no-op (status only)", () => {
+    T.alsOpenedAck("");
+    let status = global.outletEmissions
+      .filter((e) => Array.isArray(e.args) && e.args[0] === "set")
+      .map((e) => e.args.slice(1).join(" "));
+    expect(status.some((s) => s.includes("als-opened: ack <none>"))).toBe(true);
+    // No further loadCuration noise — no "staging:" status lines fire.
+    expect(status.some((s) => s.startsWith("staging:"))).toBe(false);
+
+    // The "-" sentinel from the template-clear convention is also a noop.
+    resetMaxStub();
+    T.resetAlsOpenedFiredForTest();
+    T.alsOpenedAck("-");
+    status = global.outletEmissions
+      .filter((e) => Array.isArray(e.args) && e.args[0] === "set")
+      .map((e) => e.args.slice(1).join(" "));
+    expect(status.some((s) => s.includes("als-opened: ack <none>"))).toBe(true);
+  });
+
+  test("LOM fallback chain — uses live_set.path when path_to_set_file is missing", () => {
+    // No `live_app.view.path_to_set_file` — the loader must fall through to
+    // `live_set.path`. We seed only the second probe target.
+    loadLomSnapshotObject({
+      live_set: { tracks: [], path: "/secondary/probe.als", name: "probe.als" },
+    });
+
+    T.loadbang();
+
+    const sends = global.messnamedCalls.filter((c) => c.name === T.ALS_OPENED_SEND);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].args[0]).toBe("/secondary/probe.als");
+  });
+
+  test("LOM fallback chain — degrades to live_set.name when no path is available", () => {
+    // Neither `path_to_set_file` nor `live_set.path` set — only `name`.
+    // The loader emits the filename-only fallback; the server may not be
+    // able to resolve an exact active-curation, but the wire round-trip
+    // still happens cleanly.
+    loadLomSnapshotObject({
+      live_set: { tracks: [], name: "fallback.als" },
+    });
+
+    T.loadbang();
+
+    const sends = global.messnamedCalls.filter((c) => c.name === T.ALS_OPENED_SEND);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].args[0]).toBe("fallback.als");
+  });
+
+  test("test override beats every LOM probe", () => {
+    // setAlsPathForTest forces the path regardless of what LOM reports —
+    // ensures L3 tests can drive the loader without LOM seeding when the
+    // path itself isn't under test.
+    loadLomSnapshotObject({
+      live_app: { view: { path_to_set_file: "/lom/wins.als" } },
+      live_set: { tracks: [], path: "/lom/wins.als", name: "wins.als" },
+    });
+    T.setAlsPathForTest("/override/wins.als");
+
+    T.loadbang();
+
+    const sends = global.messnamedCalls.filter((c) => c.name === T.ALS_OPENED_SEND);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].args[0]).toBe("/override/wins.als");
+  });
+
+  test("double loadbang is a no-op on the second call", () => {
+    // Max can fire loadbang twice on patcher reload — we MUST NOT POST
+    // /als-opened twice or the server will see duplicate bootstrap
+    // events. The fired-flag guard short-circuits the second call.
+    T.setAlsPathForTest("/once.als");
+    T.loadbang();
+    T.loadbang(); // second call — should be a no-op
+
+    const sends = global.messnamedCalls.filter((c) => c.name === T.ALS_OPENED_SEND);
+    expect(sends).toHaveLength(1);
+
+    const status = global.outletEmissions
+      .filter((e) => Array.isArray(e.args) && e.args[0] === "set")
+      .map((e) => e.args.slice(1).join(" "));
+    expect(status.some((s) => s.includes("als-opened: skipping (already fired)"))).toBe(true);
+  });
+
+  test("loadbang with no LOM info still emits (empty path is forwarded)", () => {
+    // No live_app, no live_set.path, no live_set.name. The probe chain
+    // bottoms out and the loader emits empty string. The server will
+    // ack with null; the device's ack handler logs and does nothing.
+    // We still want a single emission so the user-visible status line
+    // ("als-opened: sent <unknown>") fires and SSE listeners learn the
+    // device just booted.
+    loadLomSnapshotObject({ live_set: { tracks: [] } });
+
+    T.loadbang();
+
+    const sends = global.messnamedCalls.filter((c) => c.name === T.ALS_OPENED_SEND);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].args[0]).toBe("");
+    const status = global.outletEmissions
+      .filter((e) => Array.isArray(e.args) && e.args[0] === "set")
+      .map((e) => e.args.slice(1).join(" "));
+    expect(status.some((s) => s.includes("als-opened: sent <unknown>"))).toBe(true);
+  });
+});

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
@@ -3707,6 +3707,162 @@ function templateChanged(letter, name) {
     applyGroupTemplate(letter, name);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Configurator v1 Phase 4A — active-curation bootstrap on Live `.als` open.
+//
+// On every `loadbang` (Live finishes initializing this device), the loader
+// asks Live for the current set's absolute path and POSTs it to the server's
+// `/als-opened` route via the established `messnamed("sf-als-opened", path)`
+// HTTP shim. The patcher's HTTP wrapper does the request, hands the JSON
+// response body back via `messnamed("sf-als-opened-ack", curationOrEmpty)`,
+// which lands on `alsOpenedAck()` here. If the ack carries a curation name,
+// we load it as if the user had picked the curation YAML manually.
+//
+// LOM-verb caveat (deferred to Phase 5 — live-in-the-loop verification):
+//   The exact verb that returns the absolute path to the open `.als` is
+//   not yet fully nailed down — Live's published LOM reference advertises
+//   `live_app view get path_to_set_file` but builds differ. The loader
+//   tries that first, then falls back to `live_set get path` (newer
+//   builds) and finally `live_set get name` (filename without dir).
+//   Tests cover all three paths; field verification is part of Phase 5.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// messnamed targets for the HTTP shim. Patcher dispatches:
+//   [r sf-als-opened] → POST /als-opened → response body → [s sf-als-opened-ack]
+var ALS_OPENED_SEND = "sf-als-opened";
+var ALS_OPENED_ACK_RECV = "sf-als-opened-ack";
+
+// Guard against double-loadbang (Max fires loadbang twice in some patcher
+// reload scenarios — once on initial open, once on the [js] reload). We
+// only want a single bootstrap round-trip per device-open event.
+var _alsOpenedFired = false;
+
+// Test-only override hook: tests can pre-set the path the loader will
+// "discover" from LOM via setAlsPathForTest(). Always "" in production —
+// the LiveAPI walk wins.
+var _alsPathOverrideForTest = null;
+
+/**
+ * Resolve the absolute path to the currently-open .als file.
+ *
+ * Tries (in order):
+ *   1. The test override (set via setAlsPathForTest()).
+ *   2. `new LiveAPI("live_app view").get("path_to_set_file")` — the
+ *      documented verb.
+ *   3. `new LiveAPI("live_set").get("path")` — newer builds.
+ *   4. `new LiveAPI("live_set").get("name")` — filename-only fallback.
+ *
+ * Returns the resolved path string (possibly just a basename) or "" if
+ * nothing surfaced. The empty-string case is forwarded to the server so
+ * a "Live just opened Untitled" event still rings the SSE bell.
+ */
+function _getAlsPath() {
+    if (_alsPathOverrideForTest != null) {
+        return String(_alsPathOverrideForTest || "");
+    }
+    // Try the documented LOM verb first.
+    try {
+        var appView = new LiveAPI("live_app view");
+        var got = appView.get("path_to_set_file");
+        if (got && got.length) {
+            var path1 = String(got[0] == null ? "" : got[0]);
+            if (path1) return path1;
+        }
+    } catch (_e1) { /* fall through */ }
+    // Newer-build fallback: live_set carries the path directly.
+    try {
+        var liveSet = new LiveAPI("live_set");
+        var gotPath = liveSet.get("path");
+        if (gotPath && gotPath.length) {
+            var path2 = String(gotPath[0] == null ? "" : gotPath[0]);
+            if (path2) return path2;
+        }
+    } catch (_e2) { /* fall through */ }
+    // Last-resort fallback: at least return the filename so the server
+    // can still attempt a lookup.
+    try {
+        var liveSet2 = new LiveAPI("live_set");
+        var gotName = liveSet2.get("name");
+        if (gotName && gotName.length) {
+            return String(gotName[0] == null ? "" : gotName[0]);
+        }
+    } catch (_e3) { /* fall through */ }
+    return "";
+}
+
+/**
+ * loadbang() — Max entry point fired when this [js] object finishes
+ * loading. Sends the current .als path to the server so it can ack
+ * back with the active curation (if any) and we auto-load it.
+ *
+ * Idempotent within a single device-open event: a second loadbang
+ * (which Max fires on some [js] reloads) is a no-op.
+ */
+function loadbang() {
+    if (_alsOpenedFired) {
+        status("als-opened: skipping (already fired)");
+        return;
+    }
+    _alsOpenedFired = true;
+    var alsPath = _getAlsPath();
+    try {
+        messnamed(ALS_OPENED_SEND, alsPath);
+        status("als-opened: sent " + (alsPath || "<unknown>"));
+    } catch (e) {
+        status("als-opened: messnamed failed: " + e);
+    }
+}
+
+/**
+ * alsOpenedAck(curationOrSentinel) — message handler bound to the
+ * patcher's `[r sf-als-opened-ack]`. The HTTP shim parses the
+ * `/als-opened` response body and posts the resolved curation name
+ * (or the empty-string / "-" sentinel for "no active curation").
+ *
+ * Behaviour:
+ *   - non-empty + non-sentinel curation name → look up the curation YAML
+ *     on disk via `~/stemforge/curations/<name>.yaml` and call
+ *     loadCuration() with its contents.
+ *   - empty / "-" sentinel → emit a status line and do nothing else.
+ *
+ * Status lines (greppable by L3 tests):
+ *   "als-opened: ack <name>"
+ *   "als-opened: ack <none>"
+ *   "als-opened: curation file not found: <path>"
+ */
+function alsOpenedAck(curationOrSentinel) {
+    var name = String(curationOrSentinel == null ? "" : curationOrSentinel);
+    if (!name || name === TEMPLATE_CLEAR_SENTINEL) {
+        status("als-opened: ack <none>");
+        return;
+    }
+    status("als-opened: ack " + name);
+    // Resolve the curation file path under ~/stemforge/curations/<name>.yaml.
+    var home = "";
+    try {
+        home = _getHomePath();
+    } catch (_e) {
+        status("als-opened: home resolution failed");
+        return;
+    }
+    if (!home) {
+        status("als-opened: home resolution failed");
+        return;
+    }
+    var curationPath = home + "/stemforge/curations/" + name + ".yaml";
+    var text = "";
+    try {
+        text = readFileContents(curationPath);
+    } catch (_e2) {
+        text = "";
+    }
+    if (!text) {
+        status("als-opened: curation file not found: " + curationPath);
+        return;
+    }
+    loadCuration(text, curationPath);
+}
+
 // ── Entry points from Max ─────────────────────────────────────────────────────
 // These aren't stored on `globalThis`; Max's classic [js] object scans for
 // top-level functions automatically.
@@ -3760,6 +3916,18 @@ if (typeof module !== "undefined" && module.exports) {
                 name: String(name || ""),
                 groupLetters: (letters || []).slice()
             };
+        },
+        // Configurator v1 Phase 4A — als-opened bootstrap.
+        loadbang: loadbang,
+        alsOpenedAck: alsOpenedAck,
+        _getAlsPath: _getAlsPath,
+        ALS_OPENED_SEND: ALS_OPENED_SEND,
+        ALS_OPENED_ACK_RECV: ALS_OPENED_ACK_RECV,
+        setAlsPathForTest: function (path) {
+            _alsPathOverrideForTest = path == null ? null : String(path);
+        },
+        resetAlsOpenedFiredForTest: function () {
+            _alsOpenedFired = false;
         }
     };
 }


### PR DESCRIPTION
## Phase 4A — Phase 4B running in parallel

Sibling lane 4B (stale detection + strip deletion) is in flight against `main` simultaneously. This PR strictly stays inside its declared file scope: `stemforge/configurator/{state,server,intents}.py`, the two `stemforge_loader.v0.js` mirrors, the loader's L3 test file, and a new L2 test file. It does NOT touch `web/configurator/**`, `v0/src/m4l-devices/configurator-strip/**` (4B is deleting that), or any of the Phase 3 / 1.5 bridge handlers.

## Summary

- **Server reads `.stemforge_state.json` at startup** via new `load_state_with_recovery()` — corrupt files get archived to `.corrupt-<unix-ts>` so the server boots either way. `AppState.cached_stemforge_state` caches the result; `broadcast_curations_state` refreshes it on every mutation so subsequent bootstrap lookups see the latest map.
- **`POST /als-opened`** — device-driven bootstrap endpoint. Body: `{als_path: str}`. Response: `{ok, als_path, active_curation: str | null}`. Also broadcasts a typed `kind=bootstrap` SSE event so a connected popup mirrors the device's view.
- **Device JS `loadbang()`** — probes Live for the open `.als` path and emits `messnamed("sf-als-opened", path)`. `alsOpenedAck(name)` receives `messnamed("sf-als-opened-ack", name)` from the patcher's HTTP shim; on a non-null name it reads `~/stemforge/curations/<name>.yaml` and dispatches to `loadCuration()`. Idempotent (double-loadbang guard).
- **L2** — 10 tests for state round-trip + atomic write + corruption recovery + SSE broadcast + cache freshness.
- **L3** — 8 new tests for bootstrap emission, ack handling, LOM fallback chain, double-loadbang.
- **JS dual-location sync** — both `v0/src/m4l-js/` and `v0/src/m4l-package/StemForge/javascript/` updated byte-identically per `feedback_js_source_of_truth.md`.

## LOM-verb caveat

The exact LOM verb that returns the absolute path to the open `.als` is not yet field-verified — Live's published LOM advertises `live_app view get path_to_set_file` but builds differ. `_getAlsPath()` probes three variants in order:

1. `new LiveAPI("live_app view").get("path_to_set_file")` — documented verb.
2. `new LiveAPI("live_set").get("path")` — newer-build fallback.
3. `new LiveAPI("live_set").get("name")` — filename-only last resort.

Tests cover each level. Real-Live verification is deferred to Phase 5 (live-in-the-loop smoke suite), per the L4-deferred items in the execution plan.

## Test plan

- [x] `uv run pytest tests/test_configurator_*.py stemforge/configurator/` — 194 passing (10 new + 184 existing).
- [x] `npx vitest run --config web/configurator/vitest.harness.config.ts v0/src/m4l-js/stemforge_loader.v0.test.js` — 53 passing (8 new + 45 existing).
- [x] `cd web/configurator && npm test -- --run` — 37 passing (no regressions; no popup changes).
- [x] `uv run ruff format --check stemforge tests scripts` — clean.
- [x] `uv run ruff check stemforge tests scripts` — clean.
- [x] `.amxd` rebuilt via `v0/src/maxpat-builder/build_amxd.py` (byte-identical — JS lives outside the .amxd per Max Package distribution).
- [ ] Live-in-the-loop verification of the LOM-verb probe chain (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)