### PR TITLE
fix(popup): commit demo SSE patch + vite-proxy refresh

### DIFF
--- a/web/configurator/src/hooks/useProjectState.test.ts
+++ b/web/configurator/src/hooks/useProjectState.test.ts
@@ -114,4 +114,86 @@ describe("useProjectState", () => {
 
     expect(result.current.curation).toBeNull();
   });
+
+  // ── P0-4: Phase 4B broadcaster shape ──────────────────────────────────────
+  // The Phase 4B server emits `{kind: "curations", curations, active_curations,
+  // stale_by_curation}` rather than the legacy `{curation, active_curation_name}`
+  // snapshot. The handler must recognize both shapes and, when the popup is
+  // the active host, hydrate the full Curation via `fetchCuration(name)`.
+
+  it("handles kind:'curations' shape — resolves popup sentinel + fetches curation", async () => {
+    const { result } = renderWithMock();
+    await waitFor(() => expect(result.current.status).toBe("connected"));
+
+    act(() =>
+      MockEventSource.instances[0].emit("state", {
+        kind: "curations",
+        active_curations: { __popup__: "verse_swap_v1" },
+      }),
+    );
+
+    // Name updates synchronously.
+    await waitFor(() =>
+      expect(result.current.activeCurationName).toBe("verse_swap_v1"),
+    );
+    // Then the fetched curation lands (msw handler returns CURATION_FRESH).
+    await waitFor(() =>
+      expect(result.current.curation?.name).toBe("verse_swap_v1"),
+    );
+  });
+
+  it("handles kind:'curations' shape — empty active_curations clears state", async () => {
+    const { result } = renderWithMock();
+    await waitFor(() => expect(result.current.status).toBe("connected"));
+
+    // Seed some state so we can observe it being cleared.
+    act(() =>
+      MockEventSource.instances[0].emit("state", {
+        curation: {
+          name: "verse_swap_v1",
+          created_at: "2026-05-13T00:00:00Z",
+          modified_at: "2026-05-13T00:00:00Z",
+          target: { device: "ep133", groups: 4, pads_per_group: 12 },
+        } satisfies Curation,
+        active_curation_name: "verse_swap_v1",
+      }),
+    );
+    await waitFor(() =>
+      expect(result.current.activeCurationName).toBe("verse_swap_v1"),
+    );
+
+    // Phase 4B broadcaster with no active hosts clears the popup's view.
+    act(() =>
+      MockEventSource.instances[0].emit("state", {
+        kind: "curations",
+        active_curations: {},
+      }),
+    );
+
+    await waitFor(() => expect(result.current.curation).toBeNull());
+    expect(result.current.activeCurationName).toBeNull();
+  });
+
+  it("legacy snapshot shape still routes to curation state (backward compat)", async () => {
+    const { result } = renderWithMock();
+    await waitFor(() => expect(result.current.status).toBe("connected"));
+
+    const curation: Curation = {
+      name: "verse_swap_v1",
+      created_at: "2026-05-13T00:00:00Z",
+      modified_at: "2026-05-13T00:00:00Z",
+      target: { device: "ep133", groups: 4, pads_per_group: 12 },
+    };
+    act(() =>
+      MockEventSource.instances[0].emit("state", {
+        curation,
+        active_curation_name: "verse_swap_v1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.curation?.name).toBe("verse_swap_v1"),
+    );
+    expect(result.current.activeCurationName).toBe("verse_swap_v1");
+  });
 });

--- a/web/configurator/src/hooks/useProjectState.ts
+++ b/web/configurator/src/hooks/useProjectState.ts
@@ -24,7 +24,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { streamUrl } from "@/lib/api";
+import { fetchCuration, streamUrl } from "@/lib/api";
 import type { Curation } from "@/lib/api-types.generated";
 import type {
   ConnectionStatus,
@@ -32,6 +32,17 @@ import type {
   SseProgressPayload,
   SseStatePayload,
 } from "@/lib/popup-types";
+
+/**
+ * Sentinel `als_path` used by the popup when it has no Live host (i.e. the
+ * configurator was opened standalone via the browser, not via the [jweb] in
+ * Ableton). The Phase 4B server-side broadcaster keys per-host active
+ * curations on `als_path`, so the popup announces itself with this sentinel.
+ *
+ * Keep in lock-step with the same sentinel in `web/configurator/src/lib/api.ts`
+ * and the server's `Intent.open_curation` default.
+ */
+const POPUP_ALS_SENTINEL = "__popup__";
 
 export interface ProgressState {
   operation: string;
@@ -91,11 +102,40 @@ export function useProjectState(
   const reconnectTokenRef = useRef(0);
 
   const handleStateEvent = useCallback((evt: MessageEvent<string>) => {
-    const payload = safeParse<SseStatePayload>(evt.data);
+    const payload = safeParse<
+      SseStatePayload & {
+        kind?: string;
+        active_curations?: Record<string, string | null>;
+      }
+    >(evt.data);
     if (!payload) {
       setError("malformed SSE state payload");
       return;
     }
+
+    // Phase 4B broadcaster shape: `{kind: "curations", active_curations: {...}}`.
+    // Resolve the popup's curation by sentinel first, then fall back to any
+    // host that has an active curation set (covers the single-Live-host
+    // case). When nothing is active, clear local state.
+    if (payload.kind === "curations") {
+      const active = payload.active_curations ?? {};
+      const name =
+        active[POPUP_ALS_SENTINEL] ??
+        Object.values(active).find((v) => typeof v === "string") ??
+        null;
+      if (!name) {
+        setCuration(null);
+        setActiveCurationName(null);
+        return;
+      }
+      setActiveCurationName(name);
+      fetchCuration(name)
+        .then((c) => setCuration(c))
+        .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+      return;
+    }
+
+    // Legacy shape — `{curation, active_curation_name}` snapshot.
     setCuration(payload.curation ?? null);
     setActiveCurationName(
       payload.active_curation_name ?? payload.curation?.name ?? null,

--- a/web/configurator/src/lib/api.test.ts
+++ b/web/configurator/src/lib/api.test.ts
@@ -1,0 +1,100 @@
+/**
+ * api.ts — request-shape contract tests for the popup HTTP client.
+ *
+ * Coverage focus: the `__popup__` als_path sentinel that the popup must send
+ * on intent endpoints which key per-host state on `als_path`. Caught during
+ * the 2026-05-13 pre-UAT review (P0-4):
+ *   - `openCuration(name)` previously POSTed `{}` and 422'd against the
+ *     server that demanded `als_path`.
+ *   - `closeActiveCuration()` had the same bug on TopBar's Close button.
+ *
+ * The Phase 4B server now defaults the sentinel server-side, but the popup
+ * sends it explicitly anyway — both for forward compat with stricter
+ * builds and to declare intent ("this is the popup, not a Live host").
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeActiveCuration, openCuration } from "./api";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body: string;
+}
+
+function captureFetch(): { calls: CapturedRequest[]; restore: () => void } {
+  const calls: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  const stub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    calls.push({
+      url,
+      method: (init?.method ?? "GET").toUpperCase(),
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    return new Response(JSON.stringify({ ok: true, warnings: [], errors: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  globalThis.fetch = stub as unknown as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+describe("api — popup als_path sentinel", () => {
+  let captured: ReturnType<typeof captureFetch>;
+
+  beforeEach(() => {
+    captured = captureFetch();
+  });
+
+  afterEach(() => {
+    captured.restore();
+  });
+
+  it("openCuration POSTs {als_path: '__popup__'}", async () => {
+    await openCuration("verse_swap_v1");
+
+    expect(captured.calls).toHaveLength(1);
+    const call = captured.calls[0];
+    expect(call.method).toBe("POST");
+    expect(call.url).toContain("/curations/verse_swap_v1/open");
+    expect(call.body).toBe(JSON.stringify({ als_path: "__popup__" }));
+    // And the body must round-trip parse cleanly (i.e. not "{}" or empty).
+    const parsed = JSON.parse(call.body) as { als_path: string };
+    expect(parsed.als_path).toBe("__popup__");
+  });
+
+  it("openCuration URL-encodes curation names with special characters", async () => {
+    await openCuration("a curation/with weird chars");
+
+    const call = captured.calls[0];
+    expect(call.url).toContain(
+      `/curations/${encodeURIComponent("a curation/with weird chars")}/open`,
+    );
+    // Sentinel body is independent of the path.
+    expect(call.body).toBe(JSON.stringify({ als_path: "__popup__" }));
+  });
+
+  it("closeActiveCuration POSTs {als_path: '__popup__'}", async () => {
+    await closeActiveCuration();
+
+    expect(captured.calls).toHaveLength(1);
+    const call = captured.calls[0];
+    expect(call.method).toBe("POST");
+    expect(call.url).toContain("/curations/active/close");
+    expect(call.body).toBe(JSON.stringify({ als_path: "__popup__" }));
+    const parsed = JSON.parse(call.body) as { als_path: string };
+    expect(parsed.als_path).toBe("__popup__");
+  });
+});

--- a/web/configurator/src/lib/api.ts
+++ b/web/configurator/src/lib/api.ts
@@ -49,6 +49,17 @@ function url(path: string): string {
   return `${API_BASE}${path}`;
 }
 
+/**
+ * Sentinel `als_path` for popup-initiated curation intents.
+ *
+ * The Phase 4B server keys per-host active curations on `als_path` and
+ * accepts `__popup__` as the standalone-popup identifier. Sending it
+ * explicitly is a noop against the post-P0-3 server (which defaults missing
+ * `als_path` to this same sentinel) but ALSO unblocks the pre-fix server
+ * that 422'd on empty bodies. Keep both endpoints sending it.
+ */
+const POPUP_ALS_SENTINEL_BODY = JSON.stringify({ als_path: "__popup__" });
+
 export class ApiError extends Error {
   constructor(
     message: string,
@@ -183,7 +194,7 @@ export function createCuration(body: CreateCurationRequest): Promise<ApiResult> 
 export function openCuration(name: string): Promise<ApiResult> {
   return jsonRequest<ApiResult>(
     `/curations/${encodeURIComponent(name)}/open`,
-    { method: "POST", body: "{}" },
+    { method: "POST", body: POPUP_ALS_SENTINEL_BODY },
   );
 }
 
@@ -270,7 +281,7 @@ export function refreshCuration(name: string): Promise<Curation> {
 export function closeActiveCuration(): Promise<ApiResult> {
   return jsonRequest<ApiResult>("/curations/active/close", {
     method: "POST",
-    body: "{}",
+    body: POPUP_ALS_SENTINEL_BODY,
   });
 }
 

--- a/web/configurator/vite.config.ts
+++ b/web/configurator/vite.config.ts
@@ -14,11 +14,15 @@ export default defineConfig({
     port: 5173,
     strictPort: false,
     proxy: {
-      // Forward intent/state/preview/healthz to the local Python HTTP server
-      // when running `npm run dev`. The Lane A server picks its own port at
-      // startup; override via VITE_STEMFORGE_API or rely on relative URLs in
-      // production (the server itself serves the built bundle at /).
-      "^/(state|intent|preview|healthz)": {
+      // Forward server endpoints to the local Python HTTP server when running
+      // `npm run dev`. The Lane A server picks its own port at startup;
+      // override via VITE_STEMFORGE_API or rely on relative URLs in production
+      // (the server itself serves the built bundle at /).
+      //
+      // Keep this regex in lock-step with the endpoint catalog in
+      // `web/configurator/src/lib/api.ts`. The pre-UAT review (P0-6) caught
+      // /curations, /forges, /templates, and /als-opened being unproxied.
+      "^/(state|intent|preview|healthz|curations|forges|templates|als-opened)": {
         target: process.env.VITE_STEMFORGE_API || "http://127.0.0.1:8765",
         changeOrigin: true,
         secure: false,


### PR DESCRIPTION
## Summary

Lane B of the 3-lane pre-UAT remediation sprint for the StemForge Configurator v1. Owns P0-4 and P0-6 from `docs/configurator/PRE_UAT_REVIEW.md`.

**P0-4 — Demo-time popup SSE patch (commit + verify).**

The Phase 4B server broadcaster emits `{kind: "curations", curations, active_curations, stale_by_curation}` — `useProjectState.handleStateEvent` previously only knew the legacy `{curation, active_curation_name}` snapshot shape and silently dropped Phase 4B events. The new handler:

- routes the popup-keyed sentinel `__popup__` first (standalone-browser case),
- falls back to any host with an active curation (single-Live case),
- clears local state when `active_curations` is empty,
- preserves the legacy snapshot path for backward compat.

When the resolved name lands, `fetchCuration(name)` hydrates the YAML body — the broadcaster only carries names.

The matching `api.ts` half: `openCuration(name)` and `closeActiveCuration()` now POST `{als_path: "__popup__"}` instead of `{}`. The post-Lane-A server defaults the sentinel server-side (so the explicit body is a noop), but sending it explicitly is forward-safe and declares intent.

**P0-6 — Vite dev-mode proxy regex was stale.**

`web/configurator/vite.config.ts` proxy regex was frozen at `^/(state|intent|preview|healthz)`. Endpoints added in Phases 1B+ (`/curations`, `/forges`, `/templates`, `/als-opened`) 404'd in `npm run dev`. Extended the regex; production deploys (same-origin) are unaffected.

## Changes

- `web/configurator/src/hooks/useProjectState.ts` — kind-aware SSE handler + `__popup__` sentinel resolution.
- `web/configurator/src/lib/api.ts` — `openCuration` + `closeActiveCuration` send `{als_path: "__popup__"}`.
- `web/configurator/vite.config.ts` — proxy regex covers new endpoints.
- `web/configurator/src/hooks/useProjectState.test.ts` — +3 tests (Phase 4B shape, empty clear, legacy backcompat).
- `web/configurator/src/lib/api.test.ts` — new file, 3 tests (wire-shape contract).

## Commits

1. `fix(popup): SSE handler recognizes kind:curations shape (Phase 4B broadcaster)`
2. `fix(popup): openCuration + closeActiveCuration send __popup__ als_path sentinel`
3. `chore(popup): extend vite proxy regex for new endpoints`

## Scope discipline

- Did NOT touch `stemforge/configurator/**` (Lane A).
- Did NOT touch `web/configurator/src/components/**` (Lane C).
- Did NOT touch Pydantic schemas or generated TS types.
- Did NOT touch `v0/src/**`, `tools/test-harness/**`.

## Test plan

- [x] `cd web/configurator && npm test -- --run` — 49/49 passing (6 new).
- [x] `cd web/configurator && npm run lint` (typecheck) — clean.
- [x] `cd web/configurator && npm run build` — succeeds.
- [x] `cd web/configurator && npm run build:deploy` — succeeds (writes to `stemforge/configurator/static/`, gitignored).
- [ ] Manual: with the configurator server on `localhost:8765` and the popup served at `http://localhost:8765/`, hard-refresh and assert no `/curations`-shaped 404s in the dev console. (Cannot be exercised in agent shell; build success is the proxy regex's own integration test.)

## Lane B sign-off

Lane B complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
