### PR TITLE
fix(popup): clickable curation row + Save-button semantics

### DIFF
--- a/web/configurator/src/components/CurationList.test.tsx
+++ b/web/configurator/src/components/CurationList.test.tsx
@@ -1,5 +1,7 @@
-import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
 import { server } from "@/test/server";
 import { emptyHandlers, failingHandlers } from "@/test/handlers";
 import { renderWithProviders } from "@/test/render";
@@ -45,5 +47,148 @@ describe("CurationList", () => {
       expect(screen.getByTestId("curation-list-error")).toBeInTheDocument(),
     );
     expect(screen.getByTestId("curation-list-retry")).toBeInTheDocument();
+  });
+
+  // ── P0-7 — Clickable row body ───────────────────────────────────────────
+
+  it("clicking the row body fires the open-curation intent", async () => {
+    const opens: string[] = [];
+    server.use(
+      http.post("/curations/:name/open", ({ params }) => {
+        opens.push(String(params.name));
+        return HttpResponse.json({ ok: true, warnings: [], errors: [] });
+      }),
+    );
+
+    // Mount with NO active curation so the inactive row is clickable.
+    renderWithProviders(<CurationList activeCurationName={null} />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId("curation-row")).toHaveLength(2),
+    );
+
+    const inactiveRow = screen
+      .getAllByTestId("curation-row")
+      .find((r) => r.getAttribute("data-curation-name") === "live_set_oct_2026");
+    expect(inactiveRow).toBeDefined();
+    const body = within(inactiveRow!).getByTestId("curation-row-body");
+
+    const user = userEvent.setup();
+    await user.click(body);
+
+    await waitFor(() => expect(opens).toContain("live_set_oct_2026"));
+  });
+
+  it("clicking the BookOpen icon still fires the open-curation intent", async () => {
+    const opens: string[] = [];
+    server.use(
+      http.post("/curations/:name/open", ({ params }) => {
+        opens.push(String(params.name));
+        return HttpResponse.json({ ok: true, warnings: [], errors: [] });
+      }),
+    );
+
+    renderWithProviders(<CurationList activeCurationName={null} />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId("curation-row")).toHaveLength(2),
+    );
+
+    const inactiveRow = screen
+      .getAllByTestId("curation-row")
+      .find((r) => r.getAttribute("data-curation-name") === "live_set_oct_2026");
+    const bookOpenBtn = within(inactiveRow!).getByRole("button", {
+      name: /^Open live_set_oct_2026$/,
+    });
+
+    const user = userEvent.setup();
+    await user.click(bookOpenBtn);
+
+    await waitFor(() => expect(opens).toContain("live_set_oct_2026"));
+  });
+
+  it("clicking the Duplicate icon does NOT fire the open-curation intent", async () => {
+    const opens: string[] = [];
+    server.use(
+      http.post("/curations/:name/open", ({ params }) => {
+        opens.push(String(params.name));
+        return HttpResponse.json({ ok: true, warnings: [], errors: [] });
+      }),
+    );
+    // Duplicate prompts the user — make it cancel so it doesn't fire either.
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
+
+    renderWithProviders(<CurationList activeCurationName={null} />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId("curation-row")).toHaveLength(2),
+    );
+
+    const inactiveRow = screen
+      .getAllByTestId("curation-row")
+      .find((r) => r.getAttribute("data-curation-name") === "live_set_oct_2026");
+    const dupeBtn = within(inactiveRow!).getByRole("button", {
+      name: /^Duplicate live_set_oct_2026$/,
+    });
+
+    const user = userEvent.setup();
+    await user.click(dupeBtn);
+
+    // Allow any pending mutation to settle.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(opens).toHaveLength(0);
+    expect(promptSpy).toHaveBeenCalled();
+    promptSpy.mockRestore();
+  });
+
+  it("already-active row does NOT fire the open-curation intent on click", async () => {
+    const opens: string[] = [];
+    server.use(
+      http.post("/curations/:name/open", ({ params }) => {
+        opens.push(String(params.name));
+        return HttpResponse.json({ ok: true, warnings: [], errors: [] });
+      }),
+    );
+
+    renderWithProviders(<CurationList activeCurationName="verse_swap_v1" />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId("curation-row")).toHaveLength(2),
+    );
+
+    const activeRow = screen
+      .getAllByTestId("curation-row")
+      .find((r) => r.getAttribute("data-curation-name") === "verse_swap_v1");
+    expect(activeRow?.getAttribute("data-active")).toBe("true");
+    const body = within(activeRow!).getByTestId("curation-row-body");
+    expect(body.getAttribute("aria-disabled")).toBe("true");
+
+    const user = userEvent.setup();
+    await user.click(body);
+
+    await new Promise((r) => setTimeout(r, 25));
+    expect(opens).toHaveLength(0);
+  });
+
+  it("pressing Enter on a focused row fires the open-curation intent", async () => {
+    const opens: string[] = [];
+    server.use(
+      http.post("/curations/:name/open", ({ params }) => {
+        opens.push(String(params.name));
+        return HttpResponse.json({ ok: true, warnings: [], errors: [] });
+      }),
+    );
+
+    renderWithProviders(<CurationList activeCurationName={null} />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId("curation-row")).toHaveLength(2),
+    );
+
+    const inactiveRow = screen
+      .getAllByTestId("curation-row")
+      .find((r) => r.getAttribute("data-curation-name") === "live_set_oct_2026");
+    const body = within(inactiveRow!).getByTestId("curation-row-body") as HTMLElement;
+
+    body.focus();
+    const user = userEvent.setup();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(opens).toContain("live_set_oct_2026"));
   });
 });

--- a/web/configurator/src/components/CurationList.tsx
+++ b/web/configurator/src/components/CurationList.tsx
@@ -59,6 +59,16 @@ function CurationRow({ entry, active }: CurationRowProps) {
 
   const busy = open.isPending || dupe.isPending || rename.isPending || del.isPending;
 
+  // P0-7 — Whole-tile click affordance. The row body (everything above the
+  // 4 icon-button toolbar) is a button that fires the same "open as active"
+  // mutation as the BookOpen icon. Already-active rows skip the mutation
+  // (open is a no-op when nothing changes) but stay focusable for a11y.
+  const canOpen = !busy && !active;
+  function handleRowOpen() {
+    if (!canOpen) return;
+    open.mutate(entry.name);
+  }
+
   return (
     <motion.div
       layout
@@ -75,50 +85,75 @@ function CurationRow({ entry, active }: CurationRowProps) {
       data-curation-name={entry.name}
       data-active={active ? "true" : "false"}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            <div className="truncate text-[12px] font-semibold tracking-tightish text-foreground">
-              {entry.name}
-            </div>
-            {active && (
-              <Badge
-                variant="default"
-                className="!text-[9px] !px-1.5 !py-0"
-                data-testid="active-badge"
-              >
-                active
-              </Badge>
-            )}
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground tabular">
-            {entry.target_device && (
-              <span className="uppercase">{entry.target_device}</span>
-            )}
-            {entry.target_groups && entry.target_pads_per_group && (
-              <>
-                <span className="text-muted-foreground/40">·</span>
-                <span>
-                  {entry.target_groups}×{entry.target_pads_per_group}
-                </span>
-              </>
-            )}
-            <span className="text-muted-foreground/40">·</span>
-            <span>modified {timeAgo(entry.modified_at)}</span>
-          </div>
-          {(entry.last_bounced_at || entry.last_exported_at) && (
-            <div className="mt-0.5 text-[10px] text-muted-foreground/70 tabular">
-              {entry.last_bounced_at && (
-                <span>bounced {timeAgo(entry.last_bounced_at)}</span>
-              )}
-              {entry.last_bounced_at && entry.last_exported_at && (
-                <span className="text-muted-foreground/40"> · </span>
-              )}
-              {entry.last_exported_at && (
-                <span>exported {timeAgo(entry.last_exported_at)}</span>
+      <div
+        role="button"
+        tabIndex={canOpen ? 0 : -1}
+        aria-disabled={!canOpen}
+        aria-label={
+          active
+            ? `${entry.name} (already active)`
+            : `Open ${entry.name} as active`
+        }
+        data-testid="curation-row-body"
+        onClick={handleRowOpen}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleRowOpen();
+          }
+        }}
+        className={cn(
+          "-m-0.5 rounded-md p-0.5 outline-none transition-colors",
+          "focus-visible:ring-1 focus-visible:ring-[hsl(var(--accent)/0.55)]",
+          canOpen && "cursor-pointer hover:bg-accent-muted/15",
+          !canOpen && "cursor-default",
+        )}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <div className="truncate text-[12px] font-semibold tracking-tightish text-foreground">
+                {entry.name}
+              </div>
+              {active && (
+                <Badge
+                  variant="default"
+                  className="!text-[9px] !px-1.5 !py-0"
+                  data-testid="active-badge"
+                >
+                  active
+                </Badge>
               )}
             </div>
-          )}
+            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground tabular">
+              {entry.target_device && (
+                <span className="uppercase">{entry.target_device}</span>
+              )}
+              {entry.target_groups && entry.target_pads_per_group && (
+                <>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span>
+                    {entry.target_groups}×{entry.target_pads_per_group}
+                  </span>
+                </>
+              )}
+              <span className="text-muted-foreground/40">·</span>
+              <span>modified {timeAgo(entry.modified_at)}</span>
+            </div>
+            {(entry.last_bounced_at || entry.last_exported_at) && (
+              <div className="mt-0.5 text-[10px] text-muted-foreground/70 tabular">
+                {entry.last_bounced_at && (
+                  <span>bounced {timeAgo(entry.last_bounced_at)}</span>
+                )}
+                {entry.last_bounced_at && entry.last_exported_at && (
+                  <span className="text-muted-foreground/40"> · </span>
+                )}
+                {entry.last_exported_at && (
+                  <span>exported {timeAgo(entry.last_exported_at)}</span>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/web/configurator/src/components/TopBar.test.tsx
+++ b/web/configurator/src/components/TopBar.test.tsx
@@ -112,4 +112,57 @@ describe("TopBar", () => {
     expect(screen.getByTestId("top-bar-save-as")).toBeDisabled();
     expect(screen.getByTestId("top-bar-close")).toBeDisabled();
   });
+
+  // ── P0-8 — Save button is always disabled, tooltip explains why ────────
+
+  it("Save button is rendered", () => {
+    renderWithProviders(
+      <TopBar
+        curation={CURATION_FRESH}
+        activeCurationName="verse_swap_v1"
+        status="connected"
+        error={null}
+      />,
+    );
+    expect(screen.getByTestId("top-bar-save")).toBeInTheDocument();
+  });
+
+  it("Save button is disabled even when a curation is active", () => {
+    renderWithProviders(
+      <TopBar
+        curation={CURATION_FRESH}
+        activeCurationName="verse_swap_v1"
+        status="connected"
+        error={null}
+      />,
+    );
+    // P0-8: Save has no popup-side endpoint in v1; always disabled so users
+    // don't expect the popup to write.
+    expect(screen.getByTestId("top-bar-save")).toBeDisabled();
+  });
+
+  it("hovering Save surfaces the COMMIT-action tooltip", async () => {
+    renderWithProviders(
+      <TopBar
+        curation={CURATION_FRESH}
+        activeCurationName="verse_swap_v1"
+        status="connected"
+        error={null}
+      />,
+    );
+
+    const user = userEvent.setup();
+    // The disabled <button> swallows pointer events, so we hover the wrapper.
+    await user.hover(screen.getByTestId("top-bar-save-wrap"));
+
+    // Radix renders the tooltip body twice (visible + sr-only). At least
+    // one copy must be present — assert non-empty match.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText(
+          /Curation files are written by the device's COMMIT action\. The popup doesn't save directly\./,
+        ).length,
+      ).toBeGreaterThan(0),
+    );
+  });
 });

--- a/web/configurator/src/components/TopBar.tsx
+++ b/web/configurator/src/components/TopBar.tsx
@@ -69,15 +69,6 @@ export function TopBar({
     );
   }
 
-  function handleSave() {
-    // For v1 there is no explicit "save" intent — committing happens on
-    // the device (COMMIT button). The Save button surfaces in the
-    // TopBar to remind the user that the device is the writer. We
-    // surface a tooltip and noop.
-    // Lane 1B may eventually add /intent/save-active for popup-side
-    // metadata writes; we shim with a stale-info toast until then.
-  }
-
   function handleSaveAs() {
     if (!name) return;
     const newName = window.prompt(
@@ -145,23 +136,44 @@ export function TopBar({
       </div>
 
       <div className="flex items-center gap-1.5">
+        {/*
+         * P0-8 — Save is permanently disabled. v1 has no popup-side save
+         * intent: curation files are written exclusively by the device's
+         * COMMIT action. The button stays visible so users who instinctively
+         * look for "save" find it (and the tooltip teaches them where saves
+         * really happen). When/if a popup-side save endpoint lands, this is
+         * the wire point.
+         */}
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={handleSave}
-              disabled={!name}
-              data-testid="top-bar-save"
-              aria-label="Save"
+            {/*
+             * Radix Tooltip won't open on a `disabled` <button> because the
+             * browser swallows pointer events. Wrap in a span so hover still
+             * works; the inner Button stays `disabled` for keyboard + a11y.
+             */}
+            <span
+              tabIndex={0}
+              data-testid="top-bar-save-wrap"
+              aria-label="Save (disabled)"
+              className="inline-flex"
             >
-              <Save className="h-3.5 w-3.5" />
-              save
-            </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled
+                data-testid="top-bar-save"
+                aria-label="Save"
+                tabIndex={-1}
+                className="pointer-events-none"
+              >
+                <Save className="h-3.5 w-3.5" />
+                save
+              </Button>
+            </span>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            curation writes happen on device COMMIT — this is a status
-            indicator only
+            Curation files are written by the device's COMMIT action. The
+            popup doesn't save directly.
           </TooltipContent>
         </Tooltip>
 


### PR DESCRIPTION
## Summary

Lane C of the pre-UAT remediation sprint — addresses P0-7 and P0-8 from the Staff SWE review.

- **P0-7 — Clickable curation row body.** The CurationList tile used to render a card with 4 small icon buttons; only the BookOpen icon fired `useOpenCuration`. User feedback: "clicking on the tile doesn't make anything happen." The row body (everything above the icon toolbar) is now a `role="button"` element with click + keyboard (Enter/Space) handlers that fire the same mutation. Already-active rows are `aria-disabled` and skip the mutation. The 4 icon buttons remain for keyboard a11y and discoverability.
- **P0-8 — TopBar Save button semantics.** The Save button had an empty handler with a TODO. It is now permanently `disabled` with a Radix Tooltip explaining "Curation files are written by the device's COMMIT action. The popup doesn't save directly." A `<span tabIndex=0>` wraps the disabled Button so Tooltip hover still works (browsers swallow pointer events on disabled buttons).

## Files touched (lane-scoped)

- `web/configurator/src/components/CurationList.tsx` — clickable row body.
- `web/configurator/src/components/CurationList.test.tsx` — 5 new cases.
- `web/configurator/src/components/TopBar.tsx` — disabled Save + tooltip.
- `web/configurator/src/components/TopBar.test.tsx` — 3 new cases.

No hooks, types, lib, or server code touched. Lane A and Lane B are untouched.

## Test plan

- [x] `cd web/configurator && npm test -- --run` → 51 tests pass (43 baseline + 8 new).
- [x] `cd web/configurator && npm run lint` (`tsc -b --noEmit`) → clean.
- [x] `cd web/configurator && npm run build` → succeeds.
- [x] `cd web/configurator && npm run build:deploy` → succeeds.
- [ ] Manual UAT in popup: click any inactive curation tile → opens as active.
- [ ] Manual UAT: hover the Save button → tooltip explains COMMIT.

## Lane C sign-off

Lane C complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)