### PR TITLE
chore: tools ruff-format + strip artifact cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ zak@mini
 # Each user provides their own — not checked in.
 tests/ep133/fixtures/reference.ppak
 
+# ConfiguratorStrip is fully deleted (Phase 4B, PR #112). Guard against
+# accidental re-introduction via stray build/source artifacts.
+ConfiguratorStrip.amxd
+ConfiguratorStrip.maxpat
+v0/src/m4l-devices/configurator-strip/
+
 # Local-only work trees, large binary outputs, IDE config, and the log/
 # directory pattern (kept gitignored so scripts can mkdir log/ cleanly —
 # the prior root `log` file was moved to docs/ep133-song-triage/).

--- a/tools/audit_resampling.py
+++ b/tools/audit_resampling.py
@@ -17,6 +17,7 @@ Usage:
     uv run python tools/audit_resampling.py <track_dir>
     uv run python tools/audit_resampling.py ~/stemforge/processed/UPDATE/definition_test
 """
+
 from __future__ import annotations
 
 import argparse

--- a/tools/beat_dashboard.py
+++ b/tools/beat_dashboard.py
@@ -11,6 +11,7 @@ Usage:
     uv run python tools/beat_dashboard.py --output dashboard.html
     uv run python tools/beat_dashboard.py --tracks the_champ_original_version benjamins
 """
+
 from __future__ import annotations
 
 import argparse
@@ -36,6 +37,7 @@ from stemforge.beat_align import (
 # beat-this is optional
 try:
     from stemforge.beat_detect import detect_beats_and_downbeats
+
     HAS_BEAT_THIS = True
 except ImportError:
     HAS_BEAT_THIS = False
@@ -70,7 +72,9 @@ def analyze_track(track_dir: Path, time_sig: int = 4) -> dict | None:
     bar_durs_orig = np.diff(bar_starts_orig)
     interior_orig = bar_durs_orig[:-1] if len(bar_durs_orig) > 1 else bar_durs_orig
     bar_median = float(np.median(interior_orig)) if len(interior_orig) > 0 else 0
-    bar_cv_orig = float(interior_orig.std() / interior_orig.mean() * 100) if len(interior_orig) > 1 else 0
+    bar_cv_orig = (
+        float(interior_orig.std() / interior_orig.mean() * 100) if len(interior_orig) > 1 else 0
+    )
 
     # Corrections
     cleaned, ghosts_removed = filter_ghost_beats(beat_times)
@@ -80,7 +84,9 @@ def analyze_track(track_dir: Path, time_sig: int = 4) -> dict | None:
     bar_starts_corr = corrected[::time_sig]
     bar_durs_corr = np.diff(bar_starts_corr)
     interior_corr = bar_durs_corr[:-1] if len(bar_durs_corr) > 1 else bar_durs_corr
-    bar_cv_corr = float(interior_corr.std() / interior_corr.mean() * 100) if len(interior_corr) > 1 else 0
+    bar_cv_corr = (
+        float(interior_corr.std() / interior_corr.mean() * 100) if len(interior_corr) > 1 else 0
+    )
 
     correction_applied = bar_cv_corr < bar_cv_orig and (ghosts_removed > 0 or offset > 0)
 
@@ -92,17 +98,16 @@ def analyze_track(track_dir: Path, time_sig: int = 4) -> dict | None:
     for off in range(time_sig):
         shifted = beat_times[off:]
         bs = shifted[::time_sig]
-        score = float(sum(
-            onset_env[min(np.searchsorted(onset_times_arr, t), len(onset_env) - 1)]
-            for t in bs
-        ))
+        score = float(
+            sum(onset_env[min(np.searchsorted(onset_times_arr, t), len(onset_env) - 1)] for t in bs)
+        )
         offset_scores.append(score)
 
     # Energy timeline (1-second windows)
     energy_timeline = []
     hop = sr
     for i in range(0, len(y) - hop, hop):
-        rms = float(np.sqrt(np.mean(y[i:i + hop] ** 2)))
+        rms = float(np.sqrt(np.mean(y[i : i + hop] ** 2)))
         energy_timeline.append(rms)
 
     # IBI histogram
@@ -120,12 +125,14 @@ def analyze_track(track_dir: Path, time_sig: int = 4) -> dict | None:
     for i in range(len(active_durs)):
         dev = (active_durs[i] - active_median) / active_median * 100 if active_median > 0 else 0
         if abs(dev) > 5:
-            deviant_bars.append({
-                "bar": i + 1,
-                "time": float(active_starts[i]),
-                "duration": float(active_durs[i]),
-                "deviation_pct": round(dev, 1),
-            })
+            deviant_bars.append(
+                {
+                    "bar": i + 1,
+                    "time": float(active_starts[i]),
+                    "duration": float(active_durs[i]),
+                    "deviation_pct": round(dev, 1),
+                }
+            )
 
     # Drift analysis
     drift = diagnose_drift(drums, n_segments=6)
@@ -148,7 +155,12 @@ def analyze_track(track_dir: Path, time_sig: int = 4) -> dict | None:
             if len(bd_db) > 2:
                 bd_durs = np.diff(bd_db)
                 bd_cv = float(bd_durs[:-1].std() / bd_durs[:-1].mean() * 100)
-                bt_drums = {"bpm": round(bd_bpm, 1), "bars": len(bd_durs), "cv": round(bd_cv, 2), "downbeats": len(bd_db)}
+                bt_drums = {
+                    "bpm": round(bd_bpm, 1),
+                    "bars": len(bd_durs),
+                    "cv": round(bd_cv, 2),
+                    "downbeats": len(bd_db),
+                }
         except Exception:
             pass
 
@@ -170,7 +182,12 @@ def analyze_track(track_dir: Path, time_sig: int = 4) -> dict | None:
                 if len(bm_db) > 2:
                     bm_durs = np.diff(bm_db)
                     bm_cv = float(bm_durs[:-1].std() / bm_durs[:-1].mean() * 100)
-                    bt_mix = {"bpm": round(bm_bpm, 1), "bars": len(bm_durs), "cv": round(bm_cv, 2), "downbeats": len(bm_db)}
+                    bt_mix = {
+                        "bpm": round(bm_bpm, 1),
+                        "bars": len(bm_durs),
+                        "cv": round(bm_cv, 2),
+                        "downbeats": len(bm_db),
+                    }
             except Exception:
                 pass
 
@@ -809,12 +826,13 @@ window.addEventListener('DOMContentLoaded', init);
 
 def main():
     ap = argparse.ArgumentParser(description="Generate beat analysis dashboard")
-    ap.add_argument("--output", "-o", type=Path,
-                    default=REPO_ROOT / "tools" / "beat_dashboard.html")
-    ap.add_argument("--processed-dir", type=Path,
-                    default=Path.home() / "stemforge" / "processed")
-    ap.add_argument("--tracks", nargs="*", default=None,
-                    help="Specific track names to analyze (default: all)")
+    ap.add_argument(
+        "--output", "-o", type=Path, default=REPO_ROOT / "tools" / "beat_dashboard.html"
+    )
+    ap.add_argument("--processed-dir", type=Path, default=Path.home() / "stemforge" / "processed")
+    ap.add_argument(
+        "--tracks", nargs="*", default=None, help="Specific track names to analyze (default: all)"
+    )
     args = ap.parse_args()
 
     processed = args.processed_dir
@@ -833,7 +851,7 @@ def main():
     for i, td in enumerate(track_dirs):
         name = td.name
         time_sig = 7 if "7_4" in name else 4
-        print(f"  [{i+1}/{len(track_dirs)}] {name}...", end=" ", flush=True)
+        print(f"  [{i + 1}/{len(track_dirs)}] {name}...", end=" ", flush=True)
         result = analyze_track(td, time_sig=time_sig)
         if result:
             if "error" in result:

--- a/tools/diag_definition_tempo.py
+++ b/tools/diag_definition_tempo.py
@@ -9,6 +9,7 @@ production path. Standalone: only depends on stemforge + librosa + beat-this
 Usage:
     uv run python tools/diag_definition_tempo.py
 """
+
 from __future__ import annotations
 
 import sys
@@ -53,9 +54,7 @@ def beat_this_detect(
     downbeats = np.asarray(downbeats, dtype=float)
 
     bpm = 60.0 / float(np.median(np.diff(beats))) if len(beats) > 1 else 0.0
-    db_period = (
-        float(np.median(np.diff(downbeats))) if len(downbeats) > 1 else None
-    )
+    db_period = float(np.median(np.diff(downbeats))) if len(downbeats) > 1 else None
     db_bpm = 60.0 * 4 / db_period if db_period else None  # 4 beats/bar assumption
 
     return {

--- a/tools/ep133/ep133_bpm_writer.py
+++ b/tools/ep133/ep133_bpm_writer.py
@@ -43,9 +43,14 @@ def encode_bpm_override(bpm: int) -> tuple[int, int, int, int]:
     return (0x00, 0x80, bpm, 0x80)
 
 
-def patch_pad_record(record: bytes, sample_slot: int, sample_length_frames: int,
-                     bpm: int | None = None, bpm_override: bool = False,
-                     time_mode: str = "off") -> bytes:
+def patch_pad_record(
+    record: bytes,
+    sample_slot: int,
+    sample_length_frames: int,
+    bpm: int | None = None,
+    bpm_override: bool = False,
+    time_mode: str = "off",
+) -> bytes:
     """Patch a 27-byte pad record using VERIFIED offsets (see
     `memory/project_ep133_pad_record_correct.md`).
 
@@ -86,7 +91,7 @@ def find_pad_record_offsets(tar_bytes: bytes) -> dict:
     offsets = {}
     pos = 0
     while pos + TAR_BLOCK <= len(tar_bytes):
-        header = tar_bytes[pos:pos + TAR_BLOCK]
+        header = tar_bytes[pos : pos + TAR_BLOCK]
         if header[:4] == b"\x00\x00\x00\x00":
             break
         name = header[:100].rstrip(b"\x00/").decode("ascii", errors="replace")
@@ -97,7 +102,11 @@ def find_pad_record_offsets(tar_bytes: bytes) -> dict:
         typeflag = chr(header[156]) if header[156] else "0"
 
         # Match pads/<group>/p<NN>
-        if typeflag in ("0", "\x00") and name.startswith("pads/") and len(name) == len("pads/x/pNN"):
+        if (
+            typeflag in ("0", "\x00")
+            and name.startswith("pads/")
+            and len(name) == len("pads/x/pNN")
+        ):
             group = name[5]
             try:
                 pad_num = int(name[8:10])
@@ -115,12 +124,37 @@ def find_pad_record_offsets(tar_bytes: bytes) -> dict:
 # Real default-blank pad bytes (verbatim from a fresh Sample Tool backup).
 # Used to reset all pads before applying the spec — ensures the output
 # contains ONLY what we specified, not stray bindings from the base.
-DEFAULT_BLANK_PAD = bytes([
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x42,
-    0x64, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00,
-    0x3c, 0x00, 0x00,
-])
+DEFAULT_BLANK_PAD = bytes(
+    [
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0xF0,
+        0x42,
+        0x64,
+        0x00,
+        0x00,
+        0x00,
+        0xFF,
+        0x00,
+        0x00,
+        0x00,
+        0x3C,
+        0x00,
+        0x00,
+    ]
+)
 assert len(DEFAULT_BLANK_PAD) == PAD_RECORD_SIZE
 
 
@@ -139,7 +173,7 @@ def patch_tar(tar_bytes: bytes, spec: dict, reset_others: bool = True) -> bytes:
     if reset_others:
         for key, off in offsets.items():
             if key not in spec:
-                out[off:off + PAD_RECORD_SIZE] = DEFAULT_BLANK_PAD
+                out[off : off + PAD_RECORD_SIZE] = DEFAULT_BLANK_PAD
 
     for (group, pad_num), cfg in spec.items():
         key = (group, pad_num)
@@ -156,7 +190,7 @@ def patch_tar(tar_bytes: bytes, spec: dict, reset_others: bool = True) -> bytes:
             bpm_override=cfg.get("bpm_override", False),
             time_mode=cfg.get("time_mode", "off"),
         )
-        out[off:off + PAD_RECORD_SIZE] = new
+        out[off : off + PAD_RECORD_SIZE] = new
 
     return bytes(out)
 
@@ -174,8 +208,11 @@ def preset_mvp_override(sample_length: int) -> dict:
     """Same as mvp but uses override-BPM encoding at bytes 13-15."""
     return {
         ("c", 1): {
-            "slot": 100, "length": sample_length, "bpm": 120,
-            "bpm_override": True, "time_mode": "bpm",
+            "slot": 100,
+            "length": sample_length,
+            "bpm": 120,
+            "bpm_override": True,
+            "time_mode": "bpm",
         },
     }
 
@@ -183,14 +220,26 @@ def preset_mvp_override(sample_length: int) -> dict:
 def preset_matrix(sample_length: int) -> dict:
     """12-pad BPM matrix using override encoding (BPMs 60-200)."""
     pads = [
-        (1,  60), (2,  80), (3, 100), (4, 120),
-        (5, 130), (6, 140), (7, 150), (8, 160),
-        (9, 170), (10, 180), (11, 190), (12, 200),
+        (1, 60),
+        (2, 80),
+        (3, 100),
+        (4, 120),
+        (5, 130),
+        (6, 140),
+        (7, 150),
+        (8, 160),
+        (9, 170),
+        (10, 180),
+        (11, 190),
+        (12, 200),
     ]
     return {
         ("c", n): {
-            "slot": 100, "length": sample_length, "bpm": bpm,
-            "bpm_override": True, "time_mode": "bpm",
+            "slot": 100,
+            "length": sample_length,
+            "bpm": bpm,
+            "bpm_override": True,
+            "time_mode": "bpm",
         }
         for n, bpm in pads
     }
@@ -200,14 +249,26 @@ def preset_matrix_tight(sample_length: int) -> dict:
     """12-pad BPM matrix in 120-180 range — avoids aggressive compression
     that produces 'blip' playback when source_bpm << project_bpm."""
     pads = [
-        (1, 120), (2, 125), (3, 130), (4, 135),
-        (5, 140), (6, 145), (7, 150), (8, 155),
-        (9, 160), (10, 165), (11, 170), (12, 180),
+        (1, 120),
+        (2, 125),
+        (3, 130),
+        (4, 135),
+        (5, 140),
+        (6, 145),
+        (7, 150),
+        (8, 155),
+        (9, 160),
+        (10, 165),
+        (11, 170),
+        (12, 180),
     ]
     return {
         ("c", n): {
-            "slot": 100, "length": sample_length, "bpm": bpm,
-            "bpm_override": True, "time_mode": "bpm",
+            "slot": 100,
+            "length": sample_length,
+            "bpm": bpm,
+            "bpm_override": True,
+            "time_mode": "bpm",
         }
         for n, bpm in pads
     }
@@ -226,6 +287,7 @@ def patch_meta_timestamp(meta_json_bytes: bytes) -> bytes:
     other fields untouched (so device_sku, base_sku, author, pak_type
     stay exactly as Sample Tool emitted them)."""
     import json
+
     meta = json.loads(meta_json_bytes.decode("utf-8"))
     now = datetime.now(timezone.utc)
     meta["generated_at"] = now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
@@ -235,8 +297,13 @@ def patch_meta_timestamp(meta_json_bytes: bytes) -> bytes:
 def get_sample_length_frames(base_path: str) -> int:
     """Read the WAV inside the base ppak and return its frame count."""
     import wave
+
     with zipfile.ZipFile(base_path, "r") as zf:
-        wav_entries = [i for i in zf.infolist() if i.filename.startswith("/sounds/") and i.filename.endswith(".wav")]
+        wav_entries = [
+            i
+            for i in zf.infolist()
+            if i.filename.startswith("/sounds/") and i.filename.endswith(".wav")
+        ]
         if not wav_entries:
             raise RuntimeError("base has no WAV in /sounds/")
         wav_data = zf.read(wav_entries[0].filename)
@@ -258,12 +325,16 @@ def build_from_base(base_path: str, output_path: str, spec: dict, refresh_meta: 
     with zipfile.ZipFile(base_path, "r") as base_zf:
         info_list = base_zf.infolist()
         # Find the project TAR
-        project_entries = [i for i in info_list if "/projects/" in i.filename and i.filename.endswith(".tar")]
+        project_entries = [
+            i for i in info_list if "/projects/" in i.filename and i.filename.endswith(".tar")
+        ]
         if not project_entries:
             print("Error: base has no /projects/*.tar entry", file=sys.stderr)
             sys.exit(1)
         if len(project_entries) > 1:
-            print(f"Warning: base has {len(project_entries)} project TARs; patching the first one ({project_entries[0].filename})")
+            print(
+                f"Warning: base has {len(project_entries)} project TARs; patching the first one ({project_entries[0].filename})"
+            )
         project_info = project_entries[0]
 
         # Read everything
@@ -283,8 +354,7 @@ def build_from_base(base_path: str, output_path: str, spec: dict, refresh_meta: 
                 now = datetime.now()
                 new_info = zipfile.ZipInfo(
                     filename=info.filename,
-                    date_time=(now.year, now.month, now.day,
-                               now.hour, now.minute, now.second),
+                    date_time=(now.year, now.month, now.day, now.hour, now.minute, now.second),
                 )
                 new_info.compress_type = info.compress_type
                 new_info.external_attr = info.external_attr
@@ -304,11 +374,16 @@ def build_from_base(base_path: str, output_path: str, spec: dict, refresh_meta: 
 
 def main():
     p = argparse.ArgumentParser(description="EP-133 .ppak generator (v3, patch-from-real-backup)")
-    p.add_argument("--base", required=True, help="Real .ppak from Sample Tool Backup (used as format-clean base)")
+    p.add_argument(
+        "--base",
+        required=True,
+        help="Real .ppak from Sample Tool Backup (used as format-clean base)",
+    )
     p.add_argument("--preset", choices=PRESETS.keys(), default="mvp")
     p.add_argument("--out", default=os.path.expanduser("~/Desktop/ep133_v3.ppak"))
-    p.add_argument("--no-refresh-meta", action="store_true",
-                   help="Skip refreshing the generated_at timestamp")
+    p.add_argument(
+        "--no-refresh-meta", action="store_true", help="Skip refreshing the generated_at timestamp"
+    )
     args = p.parse_args()
 
     sample_length = get_sample_length_frames(args.base)

--- a/tools/ep133_bpm_matrix.py
+++ b/tools/ep133_bpm_matrix.py
@@ -44,7 +44,7 @@ from pathlib import Path
 # Bar index (0-based) → pad_num (visual position, 1-indexed top-to-bottom left-to-right).
 # Same convention as tools/ep133_load_project.py.
 BAR_INDEX_TO_PAD_NUM = [10, 11, 12, 7, 8, 9, 4, 5, 6, 1, 2, 3]
-BAR_INDEX_TO_LABEL   = [".", "0", "ENTER", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+BAR_INDEX_TO_LABEL = [".", "0", "ENTER", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 
 DEFAULT_BPMS = [60, 80, 100, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 
@@ -56,14 +56,16 @@ def main() -> None:
         epilog=__doc__,
     )
     p.add_argument("wav", type=Path, help="WAV file to replicate across slots")
-    p.add_argument("--project",    "-P", type=int, default=7)
-    p.add_argument("--group",      "-g", default="C", choices=list("ABCD"))
+    p.add_argument("--project", "-P", type=int, default=7)
+    p.add_argument("--group", "-g", default="C", choices=list("ABCD"))
     p.add_argument("--start-slot", "-s", type=int, default=100)
-    p.add_argument("--bpms",       default=",".join(str(b) for b in DEFAULT_BPMS),
-                   help="Comma-separated BPM list (1-12 values, default: 60..200 matrix)")
-    p.add_argument("--delay-ms",   type=int, default=10)
-    p.add_argument("--dry-run",    action="store_true",
-                   help="Print plan without sending anything")
+    p.add_argument(
+        "--bpms",
+        default=",".join(str(b) for b in DEFAULT_BPMS),
+        help="Comma-separated BPM list (1-12 values, default: 60..200 matrix)",
+    )
+    p.add_argument("--delay-ms", type=int, default=10)
+    p.add_argument("--dry-run", action="store_true", help="Print plan without sending anything")
     args = p.parse_args()
 
     if not args.wav.exists():
@@ -82,12 +84,12 @@ def main() -> None:
     # Plan
     print(f"\n  EP-133 BPM matrix — {args.wav.name} → P{args.project} {args.group}")
     print(f"  {'idx':<5} {'pad':<7} {'pad_num':<8} {'slot':<6} {'sound.bpm':<10}")
-    print(f"  {'-'*4} {'-'*6} {'-'*7} {'-'*5} {'-'*9}")
+    print(f"  {'-' * 4} {'-' * 6} {'-' * 7} {'-' * 5} {'-' * 9}")
     for i, bpm in enumerate(bpms):
         pad_num = BAR_INDEX_TO_PAD_NUM[i]
         label = BAR_INDEX_TO_LABEL[i]
         slot = args.start_slot + i
-        print(f"  {i+1:<5} {label:<7} {pad_num:<8} {slot:<6} {bpm:<10}")
+        print(f"  {i + 1:<5} {label:<7} {pad_num:<8} {slot:<6} {bpm:<10}")
     print()
 
     if args.dry_run:
@@ -98,7 +100,9 @@ def main() -> None:
     from stemforge.exporters.ep133 import EP133Client
     from stemforge.exporters.ep133.commands import TE_SYSEX_FILE
     from stemforge.exporters.ep133.payloads import (
-        PadParams, SampleParams, build_slot_metadata_set,
+        PadParams,
+        SampleParams,
+        build_slot_metadata_set,
     )
 
     with EP133Client.open(inter_message_delay_s=args.delay_ms / 1000.0) as client:
@@ -109,9 +113,9 @@ def main() -> None:
 
             # 1. Upload sample to slot
             t0 = time.monotonic()
-            print(f"  [{i+1:>2}/{len(bpms)}] upload  → slot {slot}    ", end="", flush=True)
+            print(f"  [{i + 1:>2}/{len(bpms)}] upload  → slot {slot}    ", end="", flush=True)
             client.upload_sample(args.wav, slot=slot)
-            print(f"({time.monotonic()-t0:.1f}s)")
+            print(f"({time.monotonic() - t0:.1f}s)")
 
             # 2. Set sound.bpm + time.mode=bpm on the slot's metadata
             t0 = time.monotonic()
@@ -120,26 +124,30 @@ def main() -> None:
             payload = build_slot_metadata_set(slot, params)
             request_id = client._send(TE_SYSEX_FILE, payload)
             client._await_response(request_id, timeout=5.0)
-            print(f"({time.monotonic()-t0:.2f}s)")
+            print(f"({time.monotonic() - t0:.2f}s)")
 
             # 3. Assign pad to slot, with pad-level time.mode=bpm too
             t0 = time.monotonic()
             print(
                 f"           assign  P{args.project} {args.group}-{label} (pad_num={pad_num}) → slot {slot}",
-                end="", flush=True,
+                end="",
+                flush=True,
             )
             pad_params = PadParams(time_mode="bpm")
             client.assign_pad(
-                project=args.project, group=args.group, pad_num=pad_num,
-                slot=slot, params=pad_params,
+                project=args.project,
+                group=args.group,
+                pad_num=pad_num,
+                slot=slot,
+                params=pad_params,
             )
-            print(f"  ({time.monotonic()-t0:.2f}s)")
+            print(f"  ({time.monotonic() - t0:.2f}s)")
 
     print()
     print("  ✓ All slots loaded + pads assigned.")
     print(f"    On the device: hit Project {args.project}, Group {args.group}, then tap pads.")
-    print( "    Lowest-BPM pad should sound fastest; highest-BPM should sound slowest.")
-    print( "    (because stretch_ratio = project_bpm / sound.bpm)")
+    print("    Lowest-BPM pad should sound fastest; highest-BPM should sound slowest.")
+    print("    (because stretch_ratio = project_bpm / sound.bpm)")
 
 
 if __name__ == "__main__":

--- a/tools/ep133_capture_reference.py
+++ b/tools/ep133_capture_reference.py
@@ -172,9 +172,7 @@ def wrap_tar_as_ppak(
         # The on-device project picker only exposes slots 1..9 for `.ppak`
         # imports; we keep the file inside that range to avoid surprises
         # at upload time even though the SysEx layer supports 1..99.
-        raise ValueError(
-            f"project_num {project_num} out of range for .ppak container (1..9)"
-        )
+        raise ValueError(f"project_num {project_num} out of range for .ppak container (1..9)")
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tools/ep133_load_hybrid_session.py
+++ b/tools/ep133_load_hybrid_session.py
@@ -26,6 +26,7 @@ Usage:
         /Users/zak/stemforge/processed/smack_my_bitch_up/curated/manifest.json \\
         [--project 1] [--dry-run] [--delay-ms 50]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -57,15 +58,25 @@ LAYOUT = {
         # rootnote=60 (C4) so when KEYS is engaged on a B pad, the natural-
         # pitch pad (bottom-left per device convention) plays the chop
         # untransposed; pads ascend chromatically up the grid.
-        "default_rule": {"time_mode": "off", "time_bars": None, "mute_group": True,
-                         "kind": "key", "rootnote": 60},
+        "default_rule": {
+            "time_mode": "off",
+            "time_bars": None,
+            "mute_group": True,
+            "kind": "key",
+            "rootnote": 60,
+        },
     },
     "C": {
         "group": "C",
         "slot_base": 140,
         # All slots = vocal key chops, time.mode=off, no mute group (let them stack).
-        "default_rule": {"time_mode": "off", "time_bars": None, "mute_group": False,
-                         "kind": "key", "rootnote": 60},
+        "default_rule": {
+            "time_mode": "off",
+            "time_bars": None,
+            "mute_group": False,
+            "kind": "key",
+            "rootnote": 60,
+        },
     },
     "D": {
         "group": "D",
@@ -83,7 +94,9 @@ def rule_for_slot(letter: str, slot_idx: int) -> dict:
         if slot_idx < cfg["hits_until_pad"]:
             return cfg["hit_rule"]
         return cfg["loop_rule"]
-    return cfg.get("default_rule", {"time_mode": "off", "time_bars": None, "mute_group": False, "kind": "key"})
+    return cfg.get(
+        "default_rule", {"time_mode": "off", "time_bars": None, "mute_group": False, "kind": "key"}
+    )
 
 
 def bottom_up_pad_num(n: int) -> int:
@@ -104,8 +117,8 @@ def bottom_up_pad_num(n: int) -> int:
     """
     if n < 1 or n > 12:
         return n  # leave out-of-range alone — caller should validate
-    row_from_bottom = (n - 1) // 3   # 0..3
-    col = (n - 1) % 3                # 0..2
+    row_from_bottom = (n - 1) // 3  # 0..3
+    col = (n - 1) % 3  # 0..2
     return 10 - 3 * row_from_bottom + col
 
 
@@ -192,8 +205,7 @@ def bake_clip(src_wav: Path, dst_wav: Path, entry: dict, rule: dict, bpm: float)
         # If we ran out of source, pad the tail with silence so the
         # output is exactly N bars long.
         if data.shape[0] < target_frames:
-            pad = np.zeros((target_frames - data.shape[0], data.shape[1]),
-                           dtype=data.dtype)
+            pad = np.zeros((target_frames - data.shape[0], data.shape[1]), dtype=data.dtype)
             data = np.concatenate([data, pad], axis=0)
         out = data
     elif mode == "rotate":
@@ -235,27 +247,31 @@ def build_plan(manifest: dict, manifest_path: Path) -> list[dict]:
             rule = rule_for_slot(letter, k_idx)
             src = Path(e["file"])
             if not src.exists():
-                print(f"  SKIP {letter}{k_idx+1}: source missing {src}")
+                print(f"  SKIP {letter}{k_idx + 1}: source missing {src}")
                 continue
             slot = cfg["slot_base"] + k_idx
-            dst = bake_root / letter / f"pad_{k_idx+1:02d}_{rule['kind']}.wav"
-            plan.append({
-                "letter": letter,
-                "group": cfg["group"],
-                "pad_num": k_idx + 1,
-                "slot": slot,
-                "src": src,
-                "dst": dst,
-                "entry": e,
-                "rule": rule,
-                "bpm": bpm,
-            })
+            dst = bake_root / letter / f"pad_{k_idx + 1:02d}_{rule['kind']}.wav"
+            plan.append(
+                {
+                    "letter": letter,
+                    "group": cfg["group"],
+                    "pad_num": k_idx + 1,
+                    "slot": slot,
+                    "src": src,
+                    "dst": dst,
+                    "entry": e,
+                    "rule": rule,
+                    "bpm": bpm,
+                }
+            )
     return plan
 
 
 def print_plan(plan: list[dict]) -> None:
-    print(f"\n{'pad':>5} {'slot':>5} {'kind':>5} {'mode':>7} {'baked':>7} "
-          f"{'tmode':>5} {'bars':>5} {'mute':>5}  src")
+    print(
+        f"\n{'pad':>5} {'slot':>5} {'kind':>5} {'mode':>7} {'baked':>7} "
+        f"{'tmode':>5} {'bars':>5} {'mute':>5}  src"
+    )
     print("-" * 95)
     for p in plan:
         r = p["rule"]
@@ -273,20 +289,26 @@ def print_plan(plan: list[dict]) -> None:
             est_dur = max(0.0, e["end_offset_sec"] - e["start_offset_sec"])
         eff_tmode, eff_bars = per_clip_time_mode(r, est_dur, bpm)
         bars_str = f"{eff_bars:.0f}" if eff_bars is not None else "-"
-        print(f"{p['group']}{p['pad_num']:<4} {p['slot']:>5} {r['kind']:>5} "
-              f"{e['mode']:>7} {est_dur:>6.3f}s {eff_tmode:>5} {bars_str:>5} "
-              f"{('yes' if r['mute_group'] else 'no'):>5}  {p['src'].name}")
+        print(
+            f"{p['group']}{p['pad_num']:<4} {p['slot']:>5} {r['kind']:>5} "
+            f"{e['mode']:>7} {est_dur:>6.3f}s {eff_tmode:>5} {bars_str:>5} "
+            f"{('yes' if r['mute_group'] else 'no'):>5}  {p['src'].name}"
+        )
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("manifest", type=Path)
     ap.add_argument("--project", type=int, default=1)
     ap.add_argument("--delay-ms", type=int, default=50)
     ap.add_argument("--dry-run", action="store_true")
-    ap.add_argument("--skip-upload", action="store_true",
-                    help="Bake WAVs but skip device upload (for inspection)")
+    ap.add_argument(
+        "--skip-upload",
+        action="store_true",
+        help="Bake WAVs but skip device upload (for inspection)",
+    )
     args = ap.parse_args()
 
     if not args.manifest.exists():
@@ -294,8 +316,10 @@ def main() -> None:
     mf = json.loads(args.manifest.read_text())
 
     if "session_tracks" not in mf:
-        raise SystemExit("manifest has no session_tracks block — did you "
-                         "click COMMIT in the device with clips on tracks A/B/C/D?")
+        raise SystemExit(
+            "manifest has no session_tracks block — did you "
+            "click COMMIT in the device with clips on tracks A/B/C/D?"
+        )
 
     plan = build_plan(mf, args.manifest)
     print_plan(plan)
@@ -309,8 +333,10 @@ def main() -> None:
     for p in plan:
         in_n, out_n = bake_clip(p["src"], p["dst"], p["entry"], p["rule"], p["bpm"])
         out_dur = out_n / sf.info(str(p["dst"])).samplerate
-        print(f"  {p['group']}{p['pad_num']:<4} {p['entry']['mode']:>7}  "
-              f"{out_dur:.3f}s ({out_n}/{in_n} frames)  → {p['dst'].name}")
+        print(
+            f"  {p['group']}{p['pad_num']:<4} {p['entry']['mode']:>7}  "
+            f"{out_dur:.3f}s ({out_n}/{in_n} frames)  → {p['dst'].name}"
+        )
 
     if args.dry_run or args.skip_upload:
         msg = "--dry-run" if args.dry_run else "--skip-upload"
@@ -322,21 +348,23 @@ def main() -> None:
     from stemforge.exporters.ep133 import EP133Client
     from stemforge.exporters.ep133.commands import TE_SYSEX_FILE
     from stemforge.exporters.ep133.payloads import (
-        PadParams, SampleParams, build_slot_metadata_set,
+        PadParams,
+        SampleParams,
+        build_slot_metadata_set,
     )
 
     print(f"\nconnecting to EP-133 (delay {args.delay_ms}ms)...")
     with EP133Client.open(inter_message_delay_s=args.delay_ms / 1000.0) as client:
         print("connected.\n")
         for i, p in enumerate(plan):
-            tag = f"[{i+1:>2}/{len(plan)}] {p['group']}{p['pad_num']}"
+            tag = f"[{i + 1:>2}/{len(plan)}] {p['group']}{p['pad_num']}"
             print(f"\n{tag}  →  slot {p['slot']}")
 
             # 1. Upload baked WAV
             t0 = time.monotonic()
             print(f"  upload {p['dst'].name}...", end=" ", flush=True)
             client.upload_sample(p["dst"], slot=p["slot"])
-            print(f"done ({time.monotonic()-t0:.1f}s)")
+            print(f"done ({time.monotonic() - t0:.1f}s)")
 
             # 2. Slot-level meta: bpm + time.mode + bars (per-clip resolved)
             #    Use the baked WAV's actual duration to pick time.mode, so
@@ -355,25 +383,31 @@ def main() -> None:
             # key) when KEYS is engaged.
             if r.get("rootnote") is not None:
                 slot_kwargs["rootnote"] = int(r["rootnote"])
-            print(f"  slot meta: time.mode={eff_tmode}"
-                  + (f" bars={eff_bars:.0f}" if eff_bars else "")
-                  + (f" rootnote={r['rootnote']}" if r.get("rootnote") is not None else "")
-                  + "...",
-                  end=" ", flush=True)
+            print(
+                f"  slot meta: time.mode={eff_tmode}"
+                + (f" bars={eff_bars:.0f}" if eff_bars else "")
+                + (f" rootnote={r['rootnote']}" if r.get("rootnote") is not None else "")
+                + "...",
+                end=" ",
+                flush=True,
+            )
             slot_params = SampleParams(**slot_kwargs)
             payload = build_slot_metadata_set(p["slot"], slot_params)
             request_id = client._send(TE_SYSEX_FILE, payload)
             client._await_response(request_id, timeout=5.0)
-            print(f"done ({time.monotonic()-t1:.2f}s)")
+            print(f"done ({time.monotonic() - t1:.2f}s)")
 
             # 3. Pad assign: playmode=oneshot, time.mode mirror, mutegroup.
             # Remap user-friendly pad_num (1..12, fills bottom-left first)
             # to the device's internal pad_num (1=top-left, 10=bottom-left).
             t2 = time.monotonic()
             device_pad = bottom_up_pad_num(p["pad_num"])
-            print(f"  assign P{args.project} {p['group']}-pad{p['pad_num']} "
-                  f"(device pad {device_pad}, playmode=oneshot, mute={r['mute_group']})...",
-                  end=" ", flush=True)
+            print(
+                f"  assign P{args.project} {p['group']}-pad{p['pad_num']} "
+                f"(device pad {device_pad}, playmode=oneshot, mute={r['mute_group']})...",
+                end=" ",
+                flush=True,
+            )
             pad_params = PadParams(
                 playmode="oneshot",
                 sample_start=0,
@@ -388,7 +422,7 @@ def main() -> None:
                 slot=p["slot"],
                 params=pad_params,
             )
-            print(f"done ({time.monotonic()-t2:.1f}s)")
+            print(f"done ({time.monotonic() - t2:.1f}s)")
 
     print(f"\n✓ Loaded {len(plan)} pads to project {args.project}.")
 

--- a/tools/ep133_load_project.py
+++ b/tools/ep133_load_project.py
@@ -41,7 +41,7 @@ from pathlib import Path
 #   row 1:          4=4   5=5   6=6
 #   row 0 (top):    7=1   8=2   9=3
 BAR_INDEX_TO_PAD_NUM = [10, 11, 12, 7, 8, 9, 4, 5, 6, 1, 2, 3]
-BAR_INDEX_TO_LABEL   = [".", "0", "ENTER", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+BAR_INDEX_TO_LABEL = [".", "0", "ENTER", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 
 
 def parse_groups(group_args: list[str]) -> list[tuple[str, str]]:
@@ -104,26 +104,28 @@ def plan_load(
             )
         for bar_i, loop in enumerate(loops_sorted):
             slot = start_slot + g_idx * n_pads + bar_i
-            ops.append({
-                "group":     group,
-                "stem":      stem_name,
-                "bar_index": bar_i,
-                "pad_num":   BAR_INDEX_TO_PAD_NUM[bar_i],
-                "pad_label": BAR_INDEX_TO_LABEL[bar_i],
-                "slot":      slot,
-                "wav_path":  Path(loop["file"]),
-            })
+            ops.append(
+                {
+                    "group": group,
+                    "stem": stem_name,
+                    "bar_index": bar_i,
+                    "pad_num": BAR_INDEX_TO_PAD_NUM[bar_i],
+                    "pad_label": BAR_INDEX_TO_LABEL[bar_i],
+                    "slot": slot,
+                    "wav_path": Path(loop["file"]),
+                }
+            )
     return ops
 
 
 def print_plan(ops: list[dict], project: int, track: str) -> None:
     print(f"\n  EP-133 load plan — {track!r}  →  Project {project}")
     print(f"  {'Group':<6} {'Stem':<10} {'Bar':<6} {'Pad':<7} {'Slot':<6} {'File'}")
-    print(f"  {'-'*5} {'-'*9} {'-'*5} {'-'*6} {'-'*5} {'-'*30}")
+    print(f"  {'-' * 5} {'-' * 9} {'-' * 5} {'-' * 6} {'-' * 5} {'-' * 30}")
     for op in ops:
         print(
             f"  {op['group']:<6} {op['stem']:<10} "
-            f"bar_{op['bar_index']+1:03d}  "
+            f"bar_{op['bar_index'] + 1:03d}  "
             f"{op['pad_label']:<7} "
             f"{op['slot']:<6} "
             f"{op['wav_path'].name}"
@@ -153,7 +155,9 @@ def run_load(
     from stemforge.exporters.ep133 import EP133Client
     from stemforge.exporters.ep133.commands import TE_SYSEX_FILE
     from stemforge.exporters.ep133.payloads import (
-        PadParams, SampleParams, build_slot_metadata_set,
+        PadParams,
+        SampleParams,
+        build_slot_metadata_set,
     )
 
     results = []
@@ -167,13 +171,12 @@ def run_load(
             t0 = time.monotonic()
 
             print(
-                f"  [{i+1:>2}/{len(ops)}] uploading {wav.name}"
-                f"  →  slot {slot} ...",
+                f"  [{i + 1:>2}/{len(ops)}] uploading {wav.name}  →  slot {slot} ...",
                 end=" ",
                 flush=True,
             )
             client.upload_sample(wav, slot=slot)
-            print(f"done  ({time.monotonic()-t0:.1f}s)", flush=True)
+            print(f"done  ({time.monotonic() - t0:.1f}s)", flush=True)
 
             if source_bpm is not None:
                 t_bpm = time.monotonic()
@@ -186,7 +189,7 @@ def run_load(
                 payload = build_slot_metadata_set(slot, params)
                 request_id = client._send(TE_SYSEX_FILE, payload)
                 client._await_response(request_id, timeout=5.0)
-                print(f"done  ({time.monotonic()-t_bpm:.2f}s)", flush=True)
+                print(f"done  ({time.monotonic() - t_bpm:.2f}s)", flush=True)
 
             print(
                 f"           assigning  P{project} {group}-{op['pad_label']}"
@@ -196,9 +199,10 @@ def run_load(
             )
             t1 = time.monotonic()
             pad_params = PadParams(time_mode="bpm") if source_bpm is not None else None
-            client.assign_pad(project=project, group=group, pad_num=pad_num,
-                              slot=slot, params=pad_params)
-            print(f"done  ({time.monotonic()-t1:.1f}s)", flush=True)
+            client.assign_pad(
+                project=project, group=group, pad_num=pad_num, slot=slot, params=pad_params
+            )
+            print(f"done  ({time.monotonic() - t1:.1f}s)", flush=True)
 
             results.append({**op, "wav_path": str(op["wav_path"]), "ok": True})
 
@@ -221,10 +225,13 @@ def run_update_params(
     if playmode is not None:
         kwargs["playmode"] = playmode
 
-    desc = "  ".join(
-        ([f"playmode={playmode}"] if playmode else [])
-        + ([f"time_mode=bpm  {bpm:.2f} BPM"] if bpm else [])
-    ) or "no changes"
+    desc = (
+        "  ".join(
+            ([f"playmode={playmode}"] if playmode else [])
+            + ([f"time_mode=bpm  {bpm:.2f} BPM"] if bpm else [])
+        )
+        or "no changes"
+    )
 
     if dry_run:
         print(f"  DRY RUN — would set {desc} on {len(ops)} pads\n")
@@ -243,7 +250,7 @@ def run_update_params(
             pad_num = op["pad_num"]
 
             print(
-                f"  [{i+1:>2}/{len(ops)}] P{project} {group}-{op['pad_label']}"
+                f"  [{i + 1:>2}/{len(ops)}] P{project} {group}-{op['pad_label']}"
                 f"  (pad_num={pad_num})  slot {slot}  →  {desc} ...",
                 end=" ",
                 flush=True,
@@ -252,7 +259,7 @@ def run_update_params(
             client.assign_pad(
                 project=project, group=group, pad_num=pad_num, slot=slot, params=params
             )
-            print(f"done  ({time.monotonic()-t0:.2f}s)", flush=True)
+            print(f"done  ({time.monotonic() - t0:.2f}s)", flush=True)
             results.append({**op, "wav_path": str(op["wav_path"]), "ok": True})
 
     return results
@@ -266,14 +273,11 @@ def write_report(
     dry_run: bool,
 ) -> Path:
     report = {
-        "track":     track,
-        "project":   project,
-        "dry_run":   dry_run,
+        "track": track,
+        "project": project,
+        "dry_run": dry_run,
         "loaded_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
-        "ops": [
-            {k: str(v) if isinstance(v, Path) else v for k, v in op.items()}
-            for op in ops
-        ],
+        "ops": [{k: str(v) if isinstance(v, Path) else v for k, v in op.items()} for op in ops],
     }
     stem = f"ep133_p{project}_{track}"
     report_path = manifest_path.parent / f"{stem}_load_report.json"
@@ -288,25 +292,45 @@ def main() -> None:
         epilog=__doc__,
     )
     parser.add_argument("manifest", type=Path, help="Path to curated manifest.json")
-    parser.add_argument("--project",    "-P", type=int, default=8,
-                        help="EP-133 project number (default: 8)")
-    parser.add_argument("--groups",     "-g", nargs="+", required=True,
-                        metavar="GROUP=stem",
-                        help="Group→stem mappings, e.g. A=drums B=bass C=other D=vocals")
-    parser.add_argument("--start-slot", "-s", type=int, default=701,
-                        help="First library slot (default: 701)")
-    parser.add_argument("--pads",       "-n", type=int, default=12,
-                        help="Bars/pads to load per group (1-12, default: 12)")
-    parser.add_argument("--delay-ms",      type=int, default=10,
-                        help="Inter-message delay in ms (default: 10)")
-    parser.add_argument("--dry-run",       action="store_true",
-                        help="Print the plan without touching the device")
-    parser.add_argument("--update-params", action="store_true",
-                        help="Skip uploads; only push pad metadata to already-loaded slots")
-    parser.add_argument("--playmode", choices=["oneshot", "key", "legato"], default=None,
-                        help="Set playback mode on all pads (key=gate, stops when finger lifts)")
-    parser.add_argument("--no-bpm", action="store_true",
-                        help="Skip writing sound.bpm + time.mode=bpm to slots (default: writes manifest's bpm)")
+    parser.add_argument(
+        "--project", "-P", type=int, default=8, help="EP-133 project number (default: 8)"
+    )
+    parser.add_argument(
+        "--groups",
+        "-g",
+        nargs="+",
+        required=True,
+        metavar="GROUP=stem",
+        help="Group→stem mappings, e.g. A=drums B=bass C=other D=vocals",
+    )
+    parser.add_argument(
+        "--start-slot", "-s", type=int, default=701, help="First library slot (default: 701)"
+    )
+    parser.add_argument(
+        "--pads", "-n", type=int, default=12, help="Bars/pads to load per group (1-12, default: 12)"
+    )
+    parser.add_argument(
+        "--delay-ms", type=int, default=10, help="Inter-message delay in ms (default: 10)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print the plan without touching the device"
+    )
+    parser.add_argument(
+        "--update-params",
+        action="store_true",
+        help="Skip uploads; only push pad metadata to already-loaded slots",
+    )
+    parser.add_argument(
+        "--playmode",
+        choices=["oneshot", "key", "legato"],
+        default=None,
+        help="Set playback mode on all pads (key=gate, stops when finger lifts)",
+    )
+    parser.add_argument(
+        "--no-bpm",
+        action="store_true",
+        help="Skip writing sound.bpm + time.mode=bpm to slots (default: writes manifest's bpm)",
+    )
     args = parser.parse_args()
 
     if not (1 <= args.pads <= 12):
@@ -347,8 +371,9 @@ def main() -> None:
             source_bpm = None if args.no_bpm else bpm
             if source_bpm is not None:
                 print(f"  Tagging slots with sound.bpm={source_bpm:.2f} + time.mode=bpm\n")
-            results = run_load(ops, args.project, args.delay_ms, args.dry_run,
-                               source_bpm=source_bpm)
+            results = run_load(
+                ops, args.project, args.delay_ms, args.dry_run, source_bpm=source_bpm
+            )
     except Exception as e:
         print(f"\nERROR: {e}", file=sys.stderr)
         sys.exit(1)

--- a/tools/export_koala_all.py
+++ b/tools/export_koala_all.py
@@ -13,6 +13,7 @@ Skips tracks without curated/. Continues on per-track errors.
 Usage:
     uv run python tools/export_koala_all.py
 """
+
 from __future__ import annotations
 
 import argparse
@@ -112,7 +113,7 @@ def main() -> int:
     print(f"Full log: {log}")
 
     total_size = sum(r.get("size_mb", 0) for r in results if r["status"] == "ok")
-    print(f"Total: {len([r for r in results if r['status']=='ok'])} zips, {total_size:.1f} MB")
+    print(f"Total: {len([r for r in results if r['status'] == 'ok'])} zips, {total_size:.1f} MB")
 
     return 0 if not fails else 1
 

--- a/tools/extract_loop_test.py
+++ b/tools/extract_loop_test.py
@@ -9,6 +9,7 @@ Pulls the loop directly from the SOURCE mix at the chunk's `source_offset_sec`
 so we test the actual prechop math (BPM + first_downbeat), not the chunk WAV
 extraction itself.
 """
+
 from __future__ import annotations
 
 import json
@@ -46,7 +47,7 @@ def extract(track_dir: Path, source_mix: Path, chunk_index: int, out_path: Path)
     print(f"    BPM:                {bpm:.4f}")
     print(f"    source_offset_sec:  {source_offset_sec:.4f}")
     print(f"    loop duration:      {loop_duration_sec:.4f}s ({bars} bars × {beats_per_bar} beats)")
-    print(f"    frames extracted:   {loop.shape[0]} @ {sr} Hz = {loop.shape[0]/sr:.4f}s")
+    print(f"    frames extracted:   {loop.shape[0]} @ {sr} Hz = {loop.shape[0] / sr:.4f}s")
     print(f"    written to:         {out_path}")
 
 

--- a/tools/find_first_drum_cut.py
+++ b/tools/find_first_drum_cut.py
@@ -21,6 +21,7 @@ Usage:
     uv run python tools/find_first_drum_cut.py TRACK_DIR --bpm 85.11 \\
         --candidates 0.1 2.92 5.74 8.56 11.38
 """
+
 from __future__ import annotations
 
 import argparse
@@ -46,16 +47,13 @@ def get_kick_onset_envelope(audio_path: Path) -> tuple[np.ndarray, np.ndarray]:
                 from stemforge.drum_separator import is_available, separate_drums
 
                 if is_available():
-                    kick_path = (
-                        separate_drums(drums, audio_path / "find_drum_cut_substems")
-                        .get("kick")
+                    kick_path = separate_drums(drums, audio_path / "find_drum_cut_substems").get(
+                        "kick"
                     )
         if kick_path and kick_path.exists():
             y, sr = librosa.load(str(kick_path), sr=None, mono=True)
             onset_env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=512)
-            onset_times = librosa.frames_to_time(
-                np.arange(len(onset_env)), sr=sr, hop_length=512
-            )
+            onset_times = librosa.frames_to_time(np.arange(len(onset_env)), sr=sr, hop_length=512)
             return onset_env, onset_times
 
     # Fallback path — kick-band onset on the audio file itself
@@ -63,13 +61,9 @@ def get_kick_onset_envelope(audio_path: Path) -> tuple[np.ndarray, np.ndarray]:
     if audio_path.is_dir():
         target = audio_path / "drums.wav"
     y, sr = librosa.load(str(target), sr=None, mono=True)
-    onset_multi = librosa.onset.onset_strength_multi(
-        y=y, sr=sr, channels=[0, 32, 64, 96, 128]
-    )
+    onset_multi = librosa.onset.onset_strength_multi(y=y, sr=sr, channels=[0, 32, 64, 96, 128])
     kick_onset = onset_multi[0]
-    onset_times = librosa.frames_to_time(
-        np.arange(len(kick_onset)), sr=sr, hop_length=512
-    )
+    onset_times = librosa.frames_to_time(np.arange(len(kick_onset)), sr=sr, hop_length=512)
     return kick_onset, onset_times
 
 
@@ -134,8 +128,7 @@ def main() -> int:
     print()
 
     print(
-        f"{'candidate':>12s}  {'total score':>12s}  {'avg/bar':>10s}  "
-        f"  per-bar strengths (first 8)"
+        f"{'candidate':>12s}  {'total score':>12s}  {'avg/bar':>10s}    per-bar strengths (first 8)"
     )
     print("-" * 88)
     results = []
@@ -145,9 +138,7 @@ def main() -> int:
         )
         avg = total / len(strengths) if strengths else 0
         first8 = " ".join(f"{s:5.1f}" for s in strengths[:8])
-        print(
-            f"  {candidate:>10.4f}  {total:>12.2f}  {avg:>10.3f}  {first8}"
-        )
+        print(f"  {candidate:>10.4f}  {total:>12.2f}  {avg:>10.3f}  {first8}")
         results.append((candidate, total, avg, strengths))
 
     # Two musical interpretations of "bar 1":
@@ -177,10 +168,7 @@ def main() -> int:
         if first_audible is not None
         else "FIRST AUDIBLE drum cut: no candidate above audible threshold"
     )
-    print(
-        f"  (= first candidate where bar-1 strength >= "
-        f"15% of max ({audible_threshold:.2f}))"
-    )
+    print(f"  (= first candidate where bar-1 strength >= 15% of max ({audible_threshold:.2f}))")
     print(
         f"MAIN BEAT DROP:         first_downbeat={main_beat[0]:.4f}s  "
         f"(bar-1 strength {main_beat[3][0]:.2f})"

--- a/tools/find_main_beat_drop.py
+++ b/tools/find_main_beat_drop.py
@@ -17,6 +17,7 @@ Usage:
     uv run python tools/find_main_beat_drop.py SONG.wav --bpm 85.11
     uv run python tools/find_main_beat_drop.py TRACK_DIR --bpm 85.11
 """
+
 from __future__ import annotations
 
 import argparse
@@ -38,13 +39,9 @@ def detect_strong_kicks(
         target = audio_path / "drums.wav"
 
     y, sr = librosa.load(str(target), sr=None, mono=True)
-    onset_multi = librosa.onset.onset_strength_multi(
-        y=y, sr=sr, channels=[0, 32, 64, 96, 128]
-    )
+    onset_multi = librosa.onset.onset_strength_multi(y=y, sr=sr, channels=[0, 32, 64, 96, 128])
     kick_env = onset_multi[0]
-    times = librosa.frames_to_time(
-        np.arange(len(kick_env)), sr=sr, hop_length=512
-    )
+    times = librosa.frames_to_time(np.arange(len(kick_env)), sr=sr, hop_length=512)
 
     peaks = librosa.util.peak_pick(
         kick_env, pre_max=3, post_max=3, pre_avg=3, post_avg=5, delta=0.5, wait=10
@@ -113,9 +110,7 @@ def main() -> int:
         args.source, threshold_quantile=args.quantile
     )
     print(f"Bar period: {bar_period:.4f}s @ {args.bpm} BPM")
-    print(
-        f"Strong-onset threshold: {threshold:.2f} (top {(1-args.quantile)*100:.0f}%)"
-    )
+    print(f"Strong-onset threshold: {threshold:.2f} (top {(1 - args.quantile) * 100:.0f}%)")
     print(f"Detected {len(onset_times)} strong onsets")
     print()
 

--- a/tools/m4l_export_clips.py
+++ b/tools/m4l_export_clips.py
@@ -125,7 +125,7 @@ def slice_clip(
     if le_frame <= ls_frame:
         raise ValueError(
             f"empty loop region: ls={loop_start_seconds:.3f}s "
-            f"le={loop_end_seconds:.3f}s src={source_frames/sr:.3f}s"
+            f"le={loop_end_seconds:.3f}s src={source_frames / sr:.3f}s"
         )
 
     # Clamp start into the loop region — if the user dragged the play-triangle
@@ -140,8 +140,9 @@ def slice_clip(
     while remaining > 0:
         available = le_frame - position
         n = min(available, remaining)
-        chunk, _ = sf.read(str(source_path), start=position, frames=n,
-                           always_2d=True, dtype="float32")
+        chunk, _ = sf.read(
+            str(source_path), start=position, frames=n, always_2d=True, dtype="float32"
+        )
         chunks.append(chunk)
         remaining -= n
         position = ls_frame  # subsequent passes start at loop_start
@@ -264,7 +265,8 @@ def slice_and_write_one(
     out_path = export_dir / out_filename
 
     duration, _sr = slice_clip(
-        source_path, out_path,
+        source_path,
+        out_path,
         start_seconds=start_marker_beats * seconds_per_beat,
         length_seconds=loop_length_beats * seconds_per_beat,
         loop_start_seconds=loop_start_beats * seconds_per_beat,
@@ -285,8 +287,8 @@ def slice_and_write_one(
 
 
 _STALE_OUTPUT_GLOBS = (
-    ".manifest.json",     # batch manifest
-    ".manifest_*.json",   # per-WAV sidecars (filename uses content hash)
+    ".manifest.json",  # batch manifest
+    ".manifest_*.json",  # per-WAV sidecars (filename uses content hash)
     "[ABCD][0-9][0-9].wav",  # bounced WAVs (e.g. A00.wav, D11.wav)
 )
 
@@ -363,11 +365,15 @@ def run(spec_path: Path, *, json_events: bool = False) -> Path:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("spec", type=Path, help="Path to spec.json written by sf_clip_export.js")
-    ap.add_argument("--json-events", action="store_true",
-                    help="Emit NDJSON progress events on stdout for the M4L parser")
+    ap.add_argument(
+        "--json-events",
+        action="store_true",
+        help="Emit NDJSON progress events on stdout for the M4L parser",
+    )
     args = ap.parse_args(argv)
 
     if not args.spec.exists():

--- a/tools/m4l_locator_anchor.py
+++ b/tools/m4l_locator_anchor.py
@@ -70,14 +70,18 @@ def _run_re_anchor(track_dir: Path, bpm: float, first_downbeat: float) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--track-dir", required=True, type=Path)
     ap.add_argument("--bpm", required=True, type=float)
     ap.add_argument("--first-downbeat", required=True, type=float)
-    ap.add_argument("--manifest-out", required=True, type=Path,
-                    help="Path the JS will reload after success "
-                         "(typically <track-dir>/prechop_manifest.json).")
+    ap.add_argument(
+        "--manifest-out",
+        required=True,
+        type=Path,
+        help="Path the JS will reload after success (typically <track-dir>/prechop_manifest.json).",
+    )
     args = ap.parse_args(argv)
 
     if not args.track_dir.exists():
@@ -87,14 +91,15 @@ def main(argv: list[str] | None = None) -> int:
         _emit("anchor_error", message=f"bpm must be > 0, got {args.bpm}")
         return 2
     if args.first_downbeat < 0:
-        _emit("anchor_error",
-              message=f"first-downbeat must be >= 0, got {args.first_downbeat}")
+        _emit("anchor_error", message=f"first-downbeat must be >= 0, got {args.first_downbeat}")
         return 2
 
-    _emit("anchor_started",
-          track_dir=str(args.track_dir),
-          bpm=args.bpm,
-          first_downbeat=args.first_downbeat)
+    _emit(
+        "anchor_started",
+        track_dir=str(args.track_dir),
+        bpm=args.bpm,
+        first_downbeat=args.first_downbeat,
+    )
 
     try:
         _run_re_anchor(args.track_dir, args.bpm, args.first_downbeat)
@@ -103,14 +108,15 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if not args.manifest_out.exists():
-        _emit("anchor_error",
-              message=f"re-anchor finished but manifest not at {args.manifest_out}")
+        _emit("anchor_error", message=f"re-anchor finished but manifest not at {args.manifest_out}")
         return 2
 
-    _emit("anchor_complete",
-          manifest=str(args.manifest_out),
-          bpm=args.bpm,
-          first_downbeat=args.first_downbeat)
+    _emit(
+        "anchor_complete",
+        manifest=str(args.manifest_out),
+        bpm=args.bpm,
+        first_downbeat=args.first_downbeat,
+    )
     return 0
 
 

--- a/tools/probe_loop.py
+++ b/tools/probe_loop.py
@@ -14,6 +14,7 @@ Usage:
     uv run python tools/probe_loop.py <source_wav> --bpm 85.11 --first-downbeat 0.5 \\
         --start-bar 28 --bars 4
 """
+
 from __future__ import annotations
 
 import argparse
@@ -28,24 +29,26 @@ def main() -> int:
     p.add_argument("source", type=Path, help="Source mix WAV")
     p.add_argument("--bpm", type=float, required=True, help="Tempo in BPM")
     p.add_argument(
-        "--first-downbeat", type=float, default=0.0,
-        help="Seconds from start of file to musical bar 1 (default 0)"
+        "--first-downbeat",
+        type=float,
+        default=0.0,
+        help="Seconds from start of file to musical bar 1 (default 0)",
     )
     p.add_argument(
-        "--start-bar", type=int, default=1,
-        help="Which musical bar to start the loop on (1-indexed, default 1)"
+        "--start-bar",
+        type=int,
+        default=1,
+        help="Which musical bar to start the loop on (1-indexed, default 1)",
+    )
+    p.add_argument("--bars", type=int, default=4, help="Loop length in bars (default 4)")
+    p.add_argument(
+        "--beats-per-bar", type=int, default=4, help="4 for 4/4 (default), 3 for 3/4, etc."
     )
     p.add_argument(
-        "--bars", type=int, default=4,
-        help="Loop length in bars (default 4)"
-    )
-    p.add_argument(
-        "--beats-per-bar", type=int, default=4,
-        help="4 for 4/4 (default), 3 for 3/4, etc."
-    )
-    p.add_argument(
-        "--out", type=Path, default=None,
-        help="Output WAV path (default: ./probe_<bpm>_<downbeat>_<bar>.wav)"
+        "--out",
+        type=Path,
+        default=None,
+        help="Output WAV path (default: ./probe_<bpm>_<downbeat>_<bar>.wav)",
     )
     args = p.parse_args()
 
@@ -80,7 +83,7 @@ def main() -> int:
     print(f"start_bar:        {args.start_bar} ({args.bars} bars × {args.beats_per_bar} beats)")
     print(f"computed offset:  {bar_offset_sec:.4f}s in source")
     print(f"loop duration:    {loop_duration_sec:.4f}s")
-    print(f"frames extracted: {loop.shape[0]} @ {sr} Hz = {loop.shape[0]/sr:.4f}s")
+    print(f"frames extracted: {loop.shape[0]} @ {sr} Hz = {loop.shape[0] / sr:.4f}s")
     print(f"Wrote:            {out}")
     return 0
 

--- a/tools/reanchor_all_processed.py
+++ b/tools/reanchor_all_processed.py
@@ -16,6 +16,7 @@ Continues on per-track errors and reports a summary at the end.
 Usage:
     uv run python tools/reanchor_all_processed.py [--dry-run]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -118,7 +119,12 @@ def reanchor_one(track_dir: Path, *, dry_run: bool = False) -> dict:
             "bpm": 120.0,
             "beat_count": 0,
             "stems": [
-                {"name": s, "wav_path": str(p), "beats_dir": str(track_dir / f"{s}_beats"), "beat_count": 0}
+                {
+                    "name": s,
+                    "wav_path": str(p),
+                    "beats_dir": str(track_dir / f"{s}_beats"),
+                    "beat_count": 0,
+                }
                 for s, p in stem_paths.items()
             ],
             "pipeline": "arrangement",
@@ -130,7 +136,11 @@ def reanchor_one(track_dir: Path, *, dry_run: bool = False) -> dict:
     source_mix = find_source_mix(track_dir, sj)
 
     if dry_run:
-        return {"track": name, "status": "dry-run", "would_use": "mix" if source_mix else "drums-only"}
+        return {
+            "track": name,
+            "status": "dry-run",
+            "would_use": "mix" if source_mix else "drums-only",
+        }
 
     try:
         reconciled = reconcile_tempo(
@@ -160,7 +170,11 @@ def reanchor_one(track_dir: Path, *, dry_run: bool = False) -> dict:
     # Resolve pre_bars: auto-fill the intro
     pipeline_cfg = get_pipeline_cfg()
     if pipeline_cfg is None or pipeline_cfg.prechop is None:
-        return {"track": name, "status": "fail", "reason": "pipeline 'arrangement' missing or no prechop"}
+        return {
+            "track": name,
+            "status": "fail",
+            "reason": "pipeline 'arrangement' missing or no prechop",
+        }
 
     bars_per_chunk = pipeline_cfg.prechop.bars
     bar_period = bars_per_chunk * pipeline_cfg.prechop.beats_per_bar * 60.0 / bpm
@@ -195,7 +209,11 @@ def reanchor_one(track_dir: Path, *, dry_run: bool = False) -> dict:
         warning=(
             f"bulk re-anchor 2026-05-02; prior bpm={sj.get('bpm')} "
             f"prior_source={(sj.get('tempo') or {}).get('source', 'unknown')}"
-            + (f" | prior: {sj['tempo']['warning']}" if (sj.get('tempo') or {}).get('warning') else '')
+            + (
+                f" | prior: {sj['tempo']['warning']}"
+                if (sj.get("tempo") or {}).get("warning")
+                else ""
+            )
         ),
         all_estimates=[e.to_dict() for e in reconciled.all_estimates],
     )

--- a/tools/run_plans.py
+++ b/tools/run_plans.py
@@ -5,14 +5,22 @@ Each plan produces a curated set of 12-16 beats optimized for IDM chopping.
 """
 
 import sys
+
 sys.path.insert(0, "/Users/zak/zacharysbrown/stemforge")
 
 from pathlib import Path
 from tools.beat_curator import (
-    analyze_all_beats, BeatProfile,
-    greedy_diverse_select, cluster_by_rhythm, select_variants_from_cluster,
-    composite_distance, rhythm_distance, spectral_distance, energy_distance,
-    format_beat_report, export_curated_set,
+    analyze_all_beats,
+    BeatProfile,
+    greedy_diverse_select,
+    cluster_by_rhythm,
+    select_variants_from_cluster,
+    composite_distance,
+    rhythm_distance,
+    spectral_distance,
+    energy_distance,
+    format_beat_report,
+    export_curated_set,
 )
 import numpy as np
 import json
@@ -30,7 +38,9 @@ print(f"  {len(profiles)} total, {len(active)} active (non-silent)")
 onset_counts = [p.onset_count for p in active]
 centroids = [p.spectral_centroid for p in active]
 crests = [p.crest_factor for p in active]
-print(f"  Onset count range: {min(onset_counts)}-{max(onset_counts)} (mean {np.mean(onset_counts):.1f})")
+print(
+    f"  Onset count range: {min(onset_counts)}-{max(onset_counts)} (mean {np.mean(onset_counts):.1f})"
+)
 print(f"  Spectral centroid range: {min(centroids):.0f}-{max(centroids):.0f}Hz")
 print(f"  Crest factor range: {min(crests):.1f}-{max(crests):.1f}")
 
@@ -45,9 +55,9 @@ print(f"  Unique rhythm patterns: {len(unique_patterns)}")
 # that are as different from each other as possible across ALL dimensions.
 # Good for: varied chop palettes where every hit feels distinct.
 # ══════════════════════════════════════════════════════════════════════
-print("\n" + "="*60)
+print("\n" + "=" * 60)
 print("  PLAN A: Maximum Diversity (greedy farthest-point)")
-print("="*60)
+print("=" * 60)
 
 plan_a = greedy_diverse_select(active, n=14, dist_fn=composite_distance)
 plan_a.sort(key=lambda p: p.index)  # sort by position in track
@@ -63,8 +73,12 @@ print("\n  LEARNINGS — Plan A:")
 print(f"  - Selected beats span indices {plan_a[0].index}-{plan_a[-1].index} (of 267)")
 coverage = len(set(p.rhythm_fingerprint for p in plan_a))
 print(f"  - Covers {coverage} unique rhythm patterns")
-print(f"  - Onset count range in selection: {min(p.onset_count for p in plan_a)}-{max(p.onset_count for p in plan_a)}")
-print(f"  - Centroid range: {min(p.spectral_centroid for p in plan_a):.0f}-{max(p.spectral_centroid for p in plan_a):.0f}Hz")
+print(
+    f"  - Onset count range in selection: {min(p.onset_count for p in plan_a)}-{max(p.onset_count for p in plan_a)}"
+)
+print(
+    f"  - Centroid range: {min(p.spectral_centroid for p in plan_a):.0f}-{max(p.spectral_centroid for p in plan_a):.0f}Hz"
+)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -75,9 +89,9 @@ print(f"  - Centroid range: {min(p.spectral_centroid for p in plan_a):.0f}-{max(
 # Good for: understanding the song's rhythmic vocabulary, getting
 # one "canonical" version of each pattern plus variations.
 # ══════════════════════════════════════════════════════════════════════
-print("\n" + "="*60)
+print("\n" + "=" * 60)
 print("  PLAN B: Rhythm Taxonomy (cluster + variant selection)")
-print("="*60)
+print("=" * 60)
 
 clusters = cluster_by_rhythm(active, threshold=0.25)
 print(f"  Found {len(clusters)} rhythm clusters")
@@ -89,19 +103,21 @@ plan_b = []
 cluster_report = []
 
 for i, (pattern, members) in enumerate(sorted_clusters):
-    pat_str = ''.join(['x' if b else '.' for b in pattern])
+    pat_str = "".join(["x" if b else "." for b in pattern])
     size = len(members)
 
     if size >= 3:
         # Large cluster: pick up to 2 variants (canonical + interesting alt)
         variants = select_variants_from_cluster(members, max_variants=2)
         plan_b.extend(variants)
-        cluster_report.append(f"  Cluster {i+1}: [{pat_str}] ({size} beats) → picked {len(variants)} variants")
+        cluster_report.append(
+            f"  Cluster {i + 1}: [{pat_str}] ({size} beats) → picked {len(variants)} variants"
+        )
     elif size >= 1:
         # Small cluster or singleton: pick the punchiest one
         best = max(members, key=lambda p: p.crest_factor)
         plan_b.append(best)
-        cluster_report.append(f"  Cluster {i+1}: [{pat_str}] ({size} beats) → picked 1 best")
+        cluster_report.append(f"  Cluster {i + 1}: [{pat_str}] ({size} beats) → picked 1 best")
 
     if len(plan_b) >= 16:
         break
@@ -129,8 +145,12 @@ print(f"  Exported to: {out_b}")
 print("\n  LEARNINGS — Plan B:")
 print(f"  - {len(clusters)} distinct rhythm patterns found in 267 beats")
 print(f"  - Largest cluster has {len(sorted_clusters[0][1])} beats (most common pattern)")
-print(f"  - {sum(1 for _,m in sorted_clusters if len(m)==1)} singleton patterns (unique one-off rhythms)")
-print(f"  - Selected {len(plan_b)} beats covering {len(set(p.rhythm_fingerprint for p in plan_b))} patterns")
+print(
+    f"  - {sum(1 for _, m in sorted_clusters if len(m) == 1)} singleton patterns (unique one-off rhythms)"
+)
+print(
+    f"  - Selected {len(plan_b)} beats covering {len(set(p.rhythm_fingerprint for p in plan_b))} patterns"
+)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -142,9 +162,9 @@ print(f"  - Selected {len(plan_b)} beats covering {len(set(p.rhythm_fingerprint 
 # Good for: capturing the feel of different song sections,
 # great for IDM where you want to "tell a story" with chops.
 # ══════════════════════════════════════════════════════════════════════
-print("\n" + "="*60)
+print("\n" + "=" * 60)
 print("  PLAN C: Sectional Narrative (positional + outlier selection)")
-print("="*60)
+print("=" * 60)
 
 # Divide 267 beats into ~8 sections (roughly 33 beats each, ~16 bars)
 n_sections = 8
@@ -170,7 +190,7 @@ for s in range(n_sections):
     best = max(scored, key=lambda x: x[1])[0]
     plan_c.append(best)
     section_report.append(
-        f"  Section {s+1} (beats {section[0].index}-{section[-1].index}): "
+        f"  Section {s + 1} (beats {section[0].index}-{section[-1].index}): "
         f"picked beat_{best.index:03d} (crest={best.crest_factor:.1f}, onsets={best.onset_count})"
     )
 
@@ -181,17 +201,20 @@ mean_density = np.mean([p.onset_density for p in active])
 std_density = np.std([p.onset_density for p in active])
 
 outliers = [
-    p for p in active
-    if p not in plan_c and (
-        abs(p.spectral_centroid - mean_centroid) > 1.5 * std_centroid or
-        abs(p.onset_density - mean_density) > 1.5 * std_density
+    p
+    for p in active
+    if p not in plan_c
+    and (
+        abs(p.spectral_centroid - mean_centroid) > 1.5 * std_centroid
+        or abs(p.onset_density - mean_density) > 1.5 * std_density
     )
 ]
 
 # Pick the most diverse outliers
 if outliers:
-    outlier_picks = greedy_diverse_select(outliers, n=min(6, 16 - len(plan_c)),
-                                          dist_fn=composite_distance)
+    outlier_picks = greedy_diverse_select(
+        outliers, n=min(6, 16 - len(plan_c)), dist_fn=composite_distance
+    )
     plan_c.extend(outlier_picks)
     section_report.append(f"  + {len(outlier_picks)} outliers (spectrally/rhythmically unusual)")
 
@@ -223,19 +246,23 @@ print(f"  - Unique patterns: {len(set(p.rhythm_fingerprint for p in plan_c))}")
 # ══════════════════════════════════════════════════════════════════════
 # SUMMARY COMPARISON
 # ══════════════════════════════════════════════════════════════════════
-print("\n" + "="*60)
+print("\n" + "=" * 60)
 print("  COMPARISON SUMMARY")
-print("="*60)
+print("=" * 60)
 
 for label, picks in [("Plan A", plan_a), ("Plan B", plan_b), ("Plan C", plan_c)]:
     patterns = len(set(p.rhythm_fingerprint for p in picks))
     avg_crest = np.mean([p.crest_factor for p in picks])
-    centroid_range = max(p.spectral_centroid for p in picks) - min(p.spectral_centroid for p in picks)
+    centroid_range = max(p.spectral_centroid for p in picks) - min(
+        p.spectral_centroid for p in picks
+    )
     idx_spread = picks[-1].index - picks[0].index
     avg_density = np.mean([p.onset_density for p in picks])
-    print(f"  {label}: {len(picks)} beats, {patterns} patterns, "
-          f"avg_crest={avg_crest:.1f}, centroid_span={centroid_range:.0f}Hz, "
-          f"idx_spread={idx_spread}, avg_density={avg_density:.1f}/s")
+    print(
+        f"  {label}: {len(picks)} beats, {patterns} patterns, "
+        f"avg_crest={avg_crest:.1f}, centroid_span={centroid_range:.0f}Hz, "
+        f"idx_spread={idx_spread}, avg_density={avg_density:.1f}/s"
+    )
 
 print(f"\n  All outputs in: {OUTPUT_DIR}")
 print("  Each folder contains WAVs + manifest.json")

--- a/tools/sf_deploy.py
+++ b/tools/sf_deploy.py
@@ -41,8 +41,7 @@ LIVE_PKG_JS_DIR = HOME / "Documents" / "Max 9" / "Packages" / "StemForge" / "jav
 LIVE_PKG_PRESETS_DIR = HOME / "Documents" / "Max 9" / "Packages" / "StemForge" / "presets"
 # Ableton User Library path — standard on macOS. Override with --ableton-lib.
 DEFAULT_ABLETON_LIB = (
-    HOME / "Music" / "Ableton" / "User Library" / "Presets" / "Audio Effects"
-    / "Max Audio Effect"
+    HOME / "Music" / "Ableton" / "User Library" / "Presets" / "Audio Effects" / "Max Audio Effect"
 )
 
 
@@ -136,7 +135,8 @@ def rebuild_amxd(dry_run: bool) -> int:
     print(f"→ rebuild: python {BUILD_AMXD}")
     r = subprocess.run(
         [sys.executable, str(BUILD_AMXD)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     if r.returncode != 0:
         print("build_amxd failed:", file=sys.stderr)
@@ -165,12 +165,11 @@ def main(argv: list[str] | None = None) -> int:
         prog="sf-deploy",
         description="Sync StemForge JS + rebuild/install .amxd.",
     )
-    ap.add_argument("--js-only", action="store_true",
-                    help="Only sync JS files.")
-    ap.add_argument("--amxd-only", action="store_true",
-                    help="Only rebuild + install the .amxd.")
-    ap.add_argument("--dry-run", action="store_true",
-                    help="Print what would happen but make no changes.")
+    ap.add_argument("--js-only", action="store_true", help="Only sync JS files.")
+    ap.add_argument("--amxd-only", action="store_true", help="Only rebuild + install the .amxd.")
+    ap.add_argument(
+        "--dry-run", action="store_true", help="Print what would happen but make no changes."
+    )
     ap.add_argument(
         "--skip-live",
         action="store_true",

--- a/tools/validate_audio.py
+++ b/tools/validate_audio.py
@@ -203,10 +203,14 @@ def validate_manifest(
 
             except Exception as e:
                 print(f"ERROR: {e}")
-                stem_results.append({
-                    "file": file_path.name, "type": item_type,
-                    "error": str(e), "quality_score": 0,
-                })
+                stem_results.append(
+                    {
+                        "file": file_path.name,
+                        "type": item_type,
+                        "error": str(e),
+                        "quality_score": 0,
+                    }
+                )
 
         results["stems"][stem_name] = stem_results
 
@@ -244,8 +248,7 @@ def validate_manifest(
 # ── Reference evaluation ─────────────────────────────────────────────────────
 
 CORE_LIBRARY = Path(
-    "/Applications/Ableton Live 12 Suite.app/Contents/App-Resources"
-    "/Core Library/Samples"
+    "/Applications/Ableton Live 12 Suite.app/Contents/App-Resources/Core Library/Samples"
 )
 
 REFERENCE_SAMPLES = {
@@ -258,13 +261,25 @@ REFERENCE_SAMPLES = {
         ("oneshot", CORE_LIBRARY / "One Shots/Drums/Snare/Snare Taka Natural.wav", "snare"),
     ],
     "hihat": [
-        ("oneshot", CORE_LIBRARY / "One Shots/Drums/Hihat/Hihat Closed Pointy Hat.wav", "hat_closed"),
+        (
+            "oneshot",
+            CORE_LIBRARY / "One Shots/Drums/Hihat/Hihat Closed Pointy Hat.wav",
+            "hat_closed",
+        ),
     ],
     "loop": [
-        ("loop", Path.home() / "Music/Ableton/User Library/Indie Drums Vol.1 Plus by Bram Inscore"
-         "/IDV1 Ableton Live Instruments/Samples/drum loops/Bram_2020_113BPM_1.wav", ""),
-        ("loop", Path.home() / "Music/Ableton/User Library/Indie Drums Vol.1 Plus by Bram Inscore"
-         "/IDV1 Ableton Live Instruments/Samples/drum loops/Bram_2020_113BPM_2.wav", ""),
+        (
+            "loop",
+            Path.home() / "Music/Ableton/User Library/Indie Drums Vol.1 Plus by Bram Inscore"
+            "/IDV1 Ableton Live Instruments/Samples/drum loops/Bram_2020_113BPM_1.wav",
+            "",
+        ),
+        (
+            "loop",
+            Path.home() / "Music/Ableton/User Library/Indie Drums Vol.1 Plus by Bram Inscore"
+            "/IDV1 Ableton Live Instruments/Samples/drum loops/Bram_2020_113BPM_2.wav",
+            "",
+        ),
     ],
 }
 
@@ -360,7 +375,8 @@ def validate_reference(dry_run: bool = False) -> dict:
                     uploaded = client.files.get(name=uploaded.name)
 
                 response = client.models.generate_content(
-                    model=model, contents=[uploaded, prompt],
+                    model=model,
+                    contents=[uploaded, prompt],
                 )
 
                 text = response.text.strip()
@@ -427,16 +443,25 @@ def main():
     ap.add_argument("manifest", nargs="?", type=Path, help="Path to curated manifest.json")
     ap.add_argument("--stems", nargs="+", default=None, help="Only validate these stems")
     ap.add_argument("--dry-run", action="store_true", help="Show plan without calling API")
-    ap.add_argument("--max-per-stem", type=int, default=4, help="Max samples to check per stem per type")
-    ap.add_argument("--reference", action="store_true",
-                    help="Validate Ableton factory samples as a scoring baseline")
+    ap.add_argument(
+        "--max-per-stem", type=int, default=4, help="Max samples to check per stem per type"
+    )
+    ap.add_argument(
+        "--reference",
+        action="store_true",
+        help="Validate Ableton factory samples as a scoring baseline",
+    )
     args = ap.parse_args()
 
     if args.reference:
         validate_reference(dry_run=args.dry_run)
     elif args.manifest:
-        validate_manifest(args.manifest, stems_filter=args.stems,
-                         dry_run=args.dry_run, max_per_stem=args.max_per_stem)
+        validate_manifest(
+            args.manifest,
+            stems_filter=args.stems,
+            dry_run=args.dry_run,
+            max_per_stem=args.max_per_stem,
+        )
     else:
         ap.error("either manifest path or --reference is required")
 

--- a/tools/verify_tempo.py
+++ b/tools/verify_tempo.py
@@ -14,6 +14,7 @@ Runs:
 Usage:
     uv run python tools/verify_tempo.py <track_dir> [--mix PATH]
 """
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary

Lane E of the Configurator v1 pre-UAT remediation sprint. Two hygiene fixes from `docs/configurator/PRE_UAT_REVIEW.md`.

### P1-5 (review line 264) — `tools/` ruff-format sweep

20 tool scripts were flagged by `uv run ruff format --check stemforge tests scripts tools`. Applied `uv run ruff format tools/` — pure formatter changes (whitespace, line wrapping, trailing commas, blank lines after docstrings). No logic edits.

Files reformatted:
- `tools/audit_resampling.py`, `tools/beat_dashboard.py`, `tools/diag_definition_tempo.py`
- `tools/ep133/ep133_bpm_writer.py`, `tools/ep133_bpm_matrix.py`, `tools/ep133_capture_reference.py`
- `tools/ep133_load_hybrid_session.py`, `tools/ep133_load_project.py`
- `tools/export_koala_all.py`, `tools/extract_loop_test.py`
- `tools/find_first_drum_cut.py`, `tools/find_main_beat_drop.py`
- `tools/m4l_export_clips.py`, `tools/m4l_locator_anchor.py`
- `tools/probe_loop.py`, `tools/reanchor_all_processed.py`, `tools/run_plans.py`
- `tools/sf_deploy.py`, `tools/validate_audio.py`, `tools/verify_tempo.py`

### P1-6 (review line 270) — ConfiguratorStrip artifact cleanup

Phase 4B (PR #112) already fully removed the strip device. Audit confirmed:
- `git ls-files | grep ConfiguratorStrip` → empty (nothing tracked).
- `find v0 -name "ConfiguratorStrip*"` → empty (no on-disk files).
- `find v0/src/m4l-devices -type d -name "configurator-strip"` → empty.

Remaining work: added defensive `.gitignore` patterns to prevent a future stray build from silently re-introducing artifacts at `ConfiguratorStrip.amxd`, `ConfiguratorStrip.maxpat`, or `v0/src/m4l-devices/configurator-strip/`.

## Test plan

- [x] `uv run ruff format --check stemforge tests scripts tools` → clean (207 files formatted, 0 would-reformat).
- [x] `uv run pytest tests/ --ignore=tests/configurator ...` → 921 passed, 11 skipped. 6 pre-existing failures in `test_canonical_tempos.py` confirmed to pre-exist on `main` (require `native` extras / demucs; environment-dependent, not regression).
- [x] `git ls-files | grep ConfiguratorStrip` → empty.
- [x] `find v0 -name "ConfiguratorStrip*"` → empty.
- [ ] CI: 10 workflows pass on the PR.

## Sign-off

Lane E (hygiene): complete. Two logical commits, both conventional, both signed by Claude co-author.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
