### PR TITLE
polish(popup): bounce spec feedback + tooltips + dead-module cleanup

### DIFF
--- a/web/configurator/src/components/ActiveCuration.test.tsx
+++ b/web/configurator/src/components/ActiveCuration.test.tsx
@@ -247,6 +247,132 @@ describe("ActiveCuration — EXPORT button (Phase 3C)", () => {
   });
 });
 
+describe("ActiveCuration — BOUNCE spec feedback (P1-8)", () => {
+  // The server's POST /curations/{name}/trigger-bounce returns the full
+  // BounceSpec the M4L device will execute. Before this lane the popup
+  // ignored the response, so operators had no visibility into what got
+  // dispatched. These tests assert the inline panel renders the pad
+  // list + output dir, and that the empty / error paths surface a toast.
+
+  const okSpec = {
+    curation_name: "verse_swap_v1",
+    bounce_dir: "bounced/verse_swap_v1/",
+    manifest_path: "bounced/verse_swap_v1/bounce_manifest.json",
+    pads: [
+      {
+        pad_id: "A01",
+        group: "A",
+        slot: 1,
+        template: "VOCAL_HI_KEY",
+        output_path: "bounced/verse_swap_v1/A01.wav",
+      },
+      {
+        pad_id: "A02",
+        group: "A",
+        slot: 2,
+        template: "VOCAL_HI_KEY",
+        output_path: "bounced/verse_swap_v1/A02.wav",
+      },
+      {
+        pad_id: "B01",
+        group: "B",
+        slot: 1,
+        template: null,
+        output_path: "bounced/verse_swap_v1/B01.wav",
+      },
+    ],
+  };
+
+  it("renders the inline bounce-spec panel after a successful trigger", async () => {
+    server.use(
+      http.post("/curations/:name/trigger-bounce", () =>
+        HttpResponse.json({ ok: true, spec: okSpec }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ActiveCuration curation={CURATION_FRESH} />);
+
+    // No panel before the bounce fires.
+    expect(screen.queryByTestId("bounce-spec-panel")).toBeNull();
+
+    await user.click(screen.getByTestId("trigger-bounce"));
+
+    const panel = await screen.findByTestId("bounce-spec-panel");
+    expect(panel).toBeInTheDocument();
+    // Pad count line:
+    expect(screen.getByText(/bouncing 3 pads/i)).toBeInTheDocument();
+    // Output directory line shows the relative bounce_dir under ~/stemforge/.
+    expect(screen.getByTestId("bounce-spec-dir").textContent).toMatch(
+      /~\/stemforge\/bounced\/verse_swap_v1\//,
+    );
+    // Pad list renders one row per spec pad.
+    const padRows = screen.getAllByTestId("bounce-spec-pad");
+    expect(padRows).toHaveLength(3);
+    expect(padRows[0].getAttribute("data-pad-id")).toBe("A01");
+  });
+
+  it("collapses the pad list when the toggle is clicked", async () => {
+    server.use(
+      http.post("/curations/:name/trigger-bounce", () =>
+        HttpResponse.json({ ok: true, spec: okSpec }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ActiveCuration curation={CURATION_FRESH} />);
+    await user.click(screen.getByTestId("trigger-bounce"));
+    await screen.findByTestId("bounce-spec-panel");
+
+    // Pad list is expanded by default.
+    expect(screen.getByTestId("bounce-spec-pad-list")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("bounce-spec-toggle"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("bounce-spec-pad-list")).toBeNull(),
+    );
+  });
+
+  it("dismiss button clears the panel", async () => {
+    server.use(
+      http.post("/curations/:name/trigger-bounce", () =>
+        HttpResponse.json({ ok: true, spec: okSpec }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ActiveCuration curation={CURATION_FRESH} />);
+    await user.click(screen.getByTestId("trigger-bounce"));
+    await screen.findByTestId("bounce-spec-panel");
+    await user.click(screen.getByTestId("bounce-spec-dismiss"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("bounce-spec-panel")).toBeNull(),
+    );
+  });
+
+  it("toasts an error when the server returns 0 pads", async () => {
+    server.use(
+      http.post("/curations/:name/trigger-bounce", () =>
+        HttpResponse.json({
+          ok: true,
+          spec: { ...okSpec, pads: [] },
+        }),
+      ),
+    );
+    const toastErrorSpy = vi.spyOn(toast, "error");
+
+    const user = userEvent.setup();
+    renderWithProviders(<ActiveCuration curation={CURATION_FRESH} />);
+    await user.click(screen.getByTestId("trigger-bounce"));
+
+    await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
+    expect(toastErrorSpy.mock.calls.at(-1)?.[0]).toMatch(/0 pads/i);
+    // No panel rendered for the empty case.
+    expect(screen.queryByTestId("bounce-spec-panel")).toBeNull();
+    toastErrorSpy.mockRestore();
+  });
+});
+
 describe("ActiveCuration — Refresh from forge (Phase 4B)", () => {
   it("hides the Refresh button when no forge is stale", async () => {
     renderWithProviders(<ActiveCuration curation={CURATION_FRESH} />);

--- a/web/configurator/src/components/ActiveCuration.tsx
+++ b/web/configurator/src/components/ActiveCuration.tsx
@@ -1,7 +1,10 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   Circle,
   Download,
   FileMusic,
@@ -9,6 +12,7 @@ import {
   Loader2,
   Play,
   RefreshCw,
+  X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -38,6 +42,34 @@ import { cn } from "@/lib/utils";
 
 interface ActiveCurationProps {
   curation: Curation | null;
+}
+
+// ── BOUNCE spec response (P1-8) ────────────────────────────────────────────
+//
+// Mirrors stemforge.configurator.bounce_handler.BounceSpec. The server's
+// POST /curations/{name}/trigger-bounce route returns
+// `{ok: true, spec: BounceSpec}` but the `useTriggerBounce` hook in
+// `@/hooks/useIntent` types the response as the generic `ApiResult`. We
+// cast in the onSuccess handler below and surface the spec inline so
+// operators can see what the bounce kicked off.
+interface BounceSpecPadWire {
+  pad_id: string;
+  group: string;
+  slot: number;
+  template: string | null;
+  output_path: string;
+}
+interface BounceSpecWire {
+  curation_name: string;
+  bounce_dir: string;
+  manifest_path: string;
+  pads: BounceSpecPadWire[];
+}
+interface TriggerBounceResponse {
+  ok: boolean;
+  spec?: BounceSpecWire;
+  warnings?: string[];
+  errors?: string[];
 }
 
 interface PadCellProps {
@@ -309,6 +341,14 @@ export function ActiveCuration({ curation }: ActiveCurationProps) {
   const pickSavePath = usePickSavePath();
   const refreshCuration = useRefreshCuration();
 
+  // P1-8: surface the BounceSpec the server returns from
+  // POST /curations/{name}/trigger-bounce. Previously the popup
+  // fired the mutation and dropped the response on the floor — operators
+  // had zero visibility into what got dispatched. We stash the spec here
+  // so the inline panel below can render the pad list + output dir.
+  const [bounceSpec, setBounceSpec] = useState<BounceSpecWire | null>(null);
+  const [bounceSpecCollapsed, setBounceSpecCollapsed] = useState(false);
+
   const forgeStaleSet = useMemo(() => {
     if (!curation || !forges.data) return new Set<string>();
     const out = new Set<string>();
@@ -397,6 +437,83 @@ export function ActiveCuration({ curation }: ActiveCurationProps) {
         )}
       </div>
 
+      <AnimatePresence>
+        {bounceSpec && (
+          <motion.div
+            key="bounce-spec"
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.18 }}
+            className="mt-auto rounded-lg border border-[hsl(var(--accent)/0.3)] bg-accent-muted p-2.5"
+            data-testid="bounce-spec-panel"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <button
+                type="button"
+                onClick={() => setBounceSpecCollapsed((v) => !v)}
+                className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                aria-expanded={!bounceSpecCollapsed}
+                aria-label="Toggle bounce spec details"
+                data-testid="bounce-spec-toggle"
+              >
+                {bounceSpecCollapsed ? (
+                  <ChevronRight className="h-3 w-3 shrink-0 text-[hsl(var(--accent))]" />
+                ) : (
+                  <ChevronDown className="h-3 w-3 shrink-0 text-[hsl(var(--accent))]" />
+                )}
+                <span className="text-[11px] font-medium text-foreground">
+                  bouncing {bounceSpec.pads.length} pad
+                  {bounceSpec.pads.length === 1 ? "" : "s"}
+                </span>
+                <span
+                  className="truncate text-[10px] font-mono text-muted-foreground"
+                  data-testid="bounce-spec-dir"
+                >
+                  → ~/stemforge/{bounceSpec.bounce_dir}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setBounceSpec(null)}
+                className="shrink-0 rounded-md p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Dismiss bounce spec"
+                data-testid="bounce-spec-dismiss"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+            {!bounceSpecCollapsed && (
+              <ul
+                className="mt-1.5 max-h-32 space-y-0.5 overflow-y-auto pl-4 text-[10px] font-mono text-muted-foreground"
+                data-testid="bounce-spec-pad-list"
+              >
+                {bounceSpec.pads.map((p) => (
+                  <li
+                    key={p.pad_id}
+                    className="flex items-center gap-1.5 tabular"
+                    data-testid="bounce-spec-pad"
+                    data-pad-id={p.pad_id}
+                  >
+                    <span className="text-foreground/90">{p.pad_id}</span>
+                    <span className="text-muted-foreground/40">·</span>
+                    <span className="truncate">{p.output_path}</span>
+                    {p.template && (
+                      <Badge
+                        variant="muted"
+                        className="!text-[9px] !px-1 !py-0"
+                      >
+                        {p.template}
+                      </Badge>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <div className="mt-auto flex items-center justify-between gap-3 border-t border-border/40 pt-3">
         <div className="flex items-center gap-3 text-[11px] text-muted-foreground tabular">
           <span className={cn(hasBounce && "text-foreground")}>
@@ -415,7 +532,29 @@ export function ActiveCuration({ curation }: ActiveCurationProps) {
           <Button
             size="sm"
             variant="secondary"
-            onClick={() => triggerBounce.mutate(curation.name)}
+            onClick={() =>
+              triggerBounce.mutate(curation.name, {
+                onSuccess: (resp) => {
+                  // The hook types the response as ApiResult but the server
+                  // actually returns `{ok: true, spec: BounceSpec}` —
+                  // see stemforge.configurator.intents.handle_trigger_bounce.
+                  // Cast and surface the spec inline so the operator sees
+                  // what got dispatched to the M4L device.
+                  const wire = resp as TriggerBounceResponse;
+                  const spec = wire?.spec ?? null;
+                  if (!spec || !spec.pads || spec.pads.length === 0) {
+                    toast.error("bounce dispatched with 0 pads", {
+                      description:
+                        "the spec came back empty — nothing for Live to render",
+                    });
+                    setBounceSpec(null);
+                    return;
+                  }
+                  setBounceSpec(spec);
+                  setBounceSpecCollapsed(false);
+                },
+              })
+            }
             disabled={triggerBounce.isPending}
             data-testid="trigger-bounce"
           >

--- a/web/configurator/src/components/ConnectionStatus.test.tsx
+++ b/web/configurator/src/components/ConnectionStatus.test.tsx
@@ -1,0 +1,68 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "@/test/render";
+import { ConnectionStatus } from "./ConnectionStatus";
+
+describe("ConnectionStatus", () => {
+  it("renders the status copy for each connection state", () => {
+    const { rerender } = renderWithProviders(
+      <ConnectionStatus status="connected" error={null} />,
+    );
+    expect(screen.getByText("live")).toBeInTheDocument();
+
+    rerender(<ConnectionStatus status="connecting" error={null} />);
+    expect(screen.getByText("connecting…")).toBeInTheDocument();
+
+    rerender(<ConnectionStatus status="disconnected" error={null} />);
+    expect(screen.getByText("reconnecting")).toBeInTheDocument();
+
+    rerender(<ConnectionStatus status="error" error="oops" />);
+    expect(screen.getByText("stream error")).toBeInTheDocument();
+
+    rerender(<ConnectionStatus status="idle" error={null} />);
+    expect(screen.getByText("idle")).toBeInTheDocument();
+  });
+
+  // P2-1: hovering the dot must surface the actual server URL so operators
+  // can confirm which endpoint the popup is bound to (matters in dev when
+  // multiple Live instances + ports float around).
+  //
+  // Note: Radix Tooltip renders its content twice (the visible popper +
+  // a hidden a11y span), so we use getAllByTestId and assert against the
+  // first match.
+  it("tooltip surfaces the active server URL when hovered", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConnectionStatus status="connected" error={null} />);
+
+    // The TooltipProvider in renderWithProviders has delayDuration=0, so a
+    // hover should reveal the tooltip immediately.
+    await user.hover(screen.getByText("live"));
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("connection-status-tooltip").length).toBeGreaterThan(0),
+    );
+
+    // jsdom defaults window.location.origin to "http://localhost:3000" so
+    // the resolver falls back to that (no API_BASE in this env). The
+    // test asserts the tooltip renders *some* URL; the exact host is
+    // environment-defined but must include the protocol so operators can
+    // copy/paste.
+    const urlNodes = screen.getAllByTestId("connection-status-url");
+    expect(urlNodes[0].textContent).toMatch(/^https?:\/\//);
+  });
+
+  it("tooltip surfaces last error when one is present", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ConnectionStatus status="error" error="ECONNREFUSED" />,
+    );
+
+    await user.hover(screen.getByText("stream error"));
+    await waitFor(() => {
+      const tooltips = screen.getAllByTestId("connection-status-tooltip");
+      expect(tooltips.length).toBeGreaterThan(0);
+      expect(tooltips[0].textContent).toMatch(/ECONNREFUSED/);
+    });
+  });
+});

--- a/web/configurator/src/components/ConnectionStatus.tsx
+++ b/web/configurator/src/components/ConnectionStatus.tsx
@@ -4,12 +4,27 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { API_BASE } from "@/lib/api";
 import type { ConnectionStatus as ConnStatus } from "@/lib/popup-types";
 import { cn } from "@/lib/utils";
 
 interface ConnectionStatusProps {
   status: ConnStatus;
   error: string | null;
+}
+
+/** Resolve the URL the popup is actually talking to. `API_BASE` is empty
+ *  when same-origin requests are used (the typical case when the popup is
+ *  served by the configurator server); in that case we fall back to
+ *  `window.location.origin` so the tooltip still surfaces a concrete URL.
+ *  Defaults to the documented dev port when neither is available
+ *  (test/jsdom environments without a real location). */
+function resolveServerUrl(): string {
+  if (API_BASE) return API_BASE;
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin;
+  }
+  return "http://localhost:8765";
 }
 
 const STATUS_COPY: Record<ConnStatus, string> = {
@@ -63,17 +78,27 @@ export function ConnectionStatus({ status, error }: ConnectionStatusProps) {
         </div>
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        {error
-          ? `last error: ${error}`
-          : status === "connected"
-            ? "SSE stream open · receiving project state in real time"
-            : status === "connecting"
-              ? "establishing SSE stream to the configurator server"
-              : status === "disconnected"
-                ? "stream dropped; auto-reconnecting"
-                : status === "error"
-                  ? "stream error — check the server logs"
-                  : "idle"}
+        <div className="space-y-0.5" data-testid="connection-status-tooltip">
+          <div>
+            {error
+              ? `last error: ${error}`
+              : status === "connected"
+                ? "SSE stream open · receiving project state in real time"
+                : status === "connecting"
+                  ? "establishing SSE stream to the configurator server"
+                  : status === "disconnected"
+                    ? "stream dropped; auto-reconnecting"
+                    : status === "error"
+                      ? "stream error — check the server logs"
+                      : "idle"}
+          </div>
+          <div
+            className="font-mono text-[10px] text-muted-foreground"
+            data-testid="connection-status-url"
+          >
+            {resolveServerUrl()}
+          </div>
+        </div>
       </TooltipContent>
     </Tooltip>
   );

--- a/web/configurator/src/components/ForgeList.tsx
+++ b/web/configurator/src/components/ForgeList.tsx
@@ -347,6 +347,20 @@ export function ForgeList({ curation }: ForgeListProps) {
         </div>
       </div>
 
+      {/*
+       * TODO(P2-3): virtualize this list once ~35+ forges are common.
+       *
+       * The pre-UAT review flagged that 35 ForgeRow components mounted at
+       * once may stutter on slower hardware (each row carries 5 Radix
+       * Tooltips + 5 Buttons + framer-motion layout animation). The fix is
+       * to render only the rows in the visible window via either
+       * `react-window` or `@tanstack/react-virtual`.
+       *
+       * Skipped in this lane because neither package is currently a
+       * dependency and the brief explicitly forbade adding new deps. Pick
+       * up post-UAT once we have a real-world forge count that triggers
+       * the regression.
+       */}
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-0.5">
         {isLoading ? (
           <ForgeListSkeleton />

--- a/web/configurator/src/components/StatusBar.test.tsx
+++ b/web/configurator/src/components/StatusBar.test.tsx
@@ -1,0 +1,66 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "@/test/render";
+import { CURATION_FRESH } from "@/test/fixtures";
+import { StatusBar } from "./StatusBar";
+
+describe("StatusBar", () => {
+  it("renders the no-curation placeholder when curation is null", () => {
+    renderWithProviders(<StatusBar curation={null} progress={null} />);
+    expect(screen.getByTestId("status-bar")).toBeInTheDocument();
+    expect(screen.getByText(/no curation active/i)).toBeInTheDocument();
+  });
+
+  it("renders the active curation name + filled/total pads", () => {
+    renderWithProviders(
+      <StatusBar curation={CURATION_FRESH} progress={null} />,
+    );
+    expect(screen.getByText(/verse_swap_v1/)).toBeInTheDocument();
+    // The fixture has at least one filled pad; the summary line carries it.
+    expect(
+      screen.getByText(/pads filled/i),
+    ).toBeInTheDocument();
+  });
+
+  // P2-2: progress empty-state coverage. Two cases land here:
+  //   (a) progress === null  → idle UI renders, no progress bar.
+  //   (b) progress.fraction === 0 → progress UI renders but shows 0%
+  //       without crashing on the Progress component's edge case.
+
+  it("shows the idle indicator when progress is null", () => {
+    renderWithProviders(<StatusBar curation={null} progress={null} />);
+    expect(screen.queryByTestId("status-progress")).toBeNull();
+    expect(screen.getByText(/idle/i)).toBeInTheDocument();
+  });
+
+  it("renders the progress bar at 0% without crashing when fraction is 0", () => {
+    renderWithProviders(
+      <StatusBar
+        curation={null}
+        progress={{ operation: "bounce:verse_swap_v1", fraction: 0 }}
+      />,
+    );
+    // The progress block is present (it replaces the idle pill).
+    expect(screen.getByTestId("status-progress")).toBeInTheDocument();
+    // Operation name renders even with no `message`.
+    expect(screen.getByText("bounce:verse_swap_v1")).toBeInTheDocument();
+    // Idle pill is gone.
+    expect(screen.queryByText(/^idle$/i)).toBeNull();
+  });
+
+  it("prefers the message string over the operation key when both are set", () => {
+    renderWithProviders(
+      <StatusBar
+        curation={null}
+        progress={{
+          operation: "bounce:foo",
+          fraction: 0.5,
+          message: "rendered A02 (1/2)",
+        }}
+      />,
+    );
+    expect(screen.getByText("rendered A02 (1/2)")).toBeInTheDocument();
+    // The raw operation key should NOT be shown when the message is set.
+    expect(screen.queryByText("bounce:foo")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Lane F of the Configurator v1 pre-UAT remediation sprint. Scope: P1-8 (bounce-spec feedback) + the P2 polish batch.

### P1-8 — `triggerBounce` returns a spec the popup never shows

`POST /curations/{name}/trigger-bounce` returns the full `BounceSpec` (output paths, per-pad sources, baked templates). The popup was ignoring the response. Now `ActiveCuration` renders an inline panel above the toolbar showing pad count, output directory, and a collapsible list of per-pad output paths + templates. Empty/zero-pad responses toast an error.

### P2 polish

- **P2-1**: `ConnectionStatus` tooltip now surfaces the active server URL (resolved from `API_BASE` → `window.location.origin` → documented dev default).
- **P2-2**: New `StatusBar.test.tsx` covers `progress === null` (idle pill) and `progress.fraction === 0` (renders 0% without crashing).
- **P2-3**: ForgeList virtualization left as `TODO(P2-3)` comment — `react-window` / `@tanstack/react-virtual` are not deps and the brief forbade adding new ones.
- **P2-4**: `intent_wire.py` audit: **module is NOT dead**. Two test files (`tests/configurator/test_schemas.py`, `tests/configurator/test_intents.py`) import 8 symbols re-exported via `stemforge/configurator/schemas/__init__.py`; all 22 tests still pass. Left in place per the remediation brief's fallback path.

### Skipped per brief

P2-5 (CurationList tooltip — Lane C), P2-6 (new UI surface, post-UAT), P2-7 (`useProjectState` reconnect — Lane B).

## Files touched

- `web/configurator/src/components/ActiveCuration.tsx` (+ test)
- `web/configurator/src/components/ConnectionStatus.tsx` (+ new test)
- `web/configurator/src/components/StatusBar.test.tsx` (new)
- `web/configurator/src/components/ForgeList.tsx` (TODO comment only)

No files outside the Lane F scope were modified.

## Test plan

- [x] `npm test -- --run` → 55 passed (8 files); +12 new tests on top of 43 baseline
- [x] `npm run lint` (tsc -b --noEmit) → clean
- [x] `npm run build` → clean
- [x] `npm run build:deploy` → clean
- [x] `uv run pytest stemforge/configurator/schemas/ -q` → 24 passed (intent_wire stays)

Lane F sign-off: complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
