### PR TITLE
fix(configurator-server): pick-manifest route + optional als_path + initial SSE snapshot

### DIFF
--- a/stemforge/configurator/__init__.py
+++ b/stemforge/configurator/__init__.py
@@ -26,4 +26,6 @@ Entry points:
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .intents import POPUP_ALS_SENTINEL
+
+__all__: list[str] = ["POPUP_ALS_SENTINEL"]

--- a/stemforge/configurator/intents.py
+++ b/stemforge/configurator/intents.py
@@ -28,9 +28,10 @@ Discipline (both families):
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, ValidationError
@@ -92,6 +93,18 @@ from .state import (
 
 DEFAULT_GROUPS = ("A", "B", "C", "D")
 PADS_PER_GROUP = 12
+
+# Sentinel ``als_path`` used by the standalone popup, which has no Live
+# context. Both the popup and the server need to share this exact value
+# so the active-curation map stays consistent across surfaces; popup
+# JS imports it (via the api shim) so a popup-only "Open" and a
+# Live-attached "Open" land in distinct entries of ``active_curations``.
+#
+# Pre-UAT P0-2: making ``als_path`` optional on Open/Close request
+# bodies (defaulting to this sentinel) unblocks the popup TopBar's
+# Close button, which previously POSTed ``{}`` and 422'd because the
+# field was required.
+POPUP_ALS_SENTINEL = "__popup__"
 
 # Group-letter sequence used to seed empty curations. Targeted at v1's
 # EP-133 4-group layout but extends to any ``target.groups`` up to 16.
@@ -440,12 +453,17 @@ class OpenCurationBody(BaseModel):
     """Body of ``POST /curations/{name}/open``.
 
     ``als_path`` keys the active-curation map (one per Live project). In
-    Phase 1B device-to-server wiring is deferred (Phase 4A); meanwhile
-    callers must pass it explicitly so the active-curation file stays a
-    real shared resource across surfaces.
+    Phase 1B device-to-server wiring is deferred (Phase 4A); Live-attached
+    callers pass the absolute ``.als`` path explicitly.
+
+    Pre-UAT P0-2: ``als_path`` is optional and defaults to
+    :data:`POPUP_ALS_SENTINEL` (``"__popup__"``) — use that when no real
+    Live context exists, e.g. when the popup is running standalone. This
+    lets the popup's TopBar "Close active" button work with an empty body
+    instead of 422-ing on a missing field.
     """
 
-    als_path: str
+    als_path: str = POPUP_ALS_SENTINEL
 
     model_config = {"extra": "forbid"}
 
@@ -479,9 +497,14 @@ class CloseActiveCurationBody(BaseModel):
 
     Clears the active curation for ``als_path`` (sets the map entry to
     ``None``, removing it from ``.stemforge_state.json``).
+
+    Pre-UAT P0-2: ``als_path`` is optional and defaults to
+    :data:`POPUP_ALS_SENTINEL` (``"__popup__"``) — use that when no real
+    Live context exists, e.g. when the popup is running standalone.
+    Live-attached flows still pass the actual ``.als`` path.
     """
 
-    als_path: str
+    als_path: str = POPUP_ALS_SENTINEL
 
     model_config = {"extra": "forbid"}
 
@@ -1343,6 +1366,238 @@ async def handle_bounce_complete(
     return merged
 
 
+# ── Pre-UAT P0-1 — POST /intent/pick-manifest ───────────────────────────────
+
+
+PickManifestFilter = Literal["audio", "manifest", "any"]
+SnifferKind = Literal[
+    "audio",
+    "forge_manifest",
+    "arrangement_manifest",
+    "curation",
+    "unknown",
+]
+
+# Audio extensions the popup's "add forge…" + sniffer recognise. Mirrors
+# the device-side ``SNIFFER_AUDIO_EXTS`` list in
+# ``v0/src/m4l-js/stemforge_loader.v0.js`` so popup + device classify
+# identically.
+_SNIFFER_AUDIO_EXTS = (".wav", ".aif", ".aiff", ".mp3", ".flac", ".m4a", ".ogg")
+_FILTER_TO_EXT_LIST: dict[str, tuple[str, ...]] = {
+    "audio": _SNIFFER_AUDIO_EXTS,
+    "manifest": (".json", ".yaml", ".yml"),
+    "any": (),
+}
+
+
+class PickManifestBody(BaseModel):
+    """Body of ``POST /intent/pick-manifest`` (Pre-UAT P0-1).
+
+    Drives a server-side osascript ``choose file`` dialog for the popup's
+    ForgeList "add forge…" button. Returns the chosen POSIX path plus
+    a sniffer ``kind`` classification (mirrors the device's pickSource
+    taxonomy in ``stemforge_loader.v0.js``).
+    """
+
+    filter: PickManifestFilter = Field(
+        default="any",
+        description=(
+            "Optional file-type filter. ``audio`` constrains to "
+            f"{_SNIFFER_AUDIO_EXTS!r}; ``manifest`` to .json/.yaml/.yml; "
+            "``any`` (default) lets the user pick anything and relies "
+            "on the sniffer for classification."
+        ),
+    )
+    prompt: str | None = Field(
+        default=None,
+        description="Optional title text for the macOS open dialog.",
+    )
+    default_dir: str | None = Field(
+        default=None,
+        description=(
+            "Optional directory to open the dialog in. Defaults to the user's home directory."
+        ),
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+def _native_file_dialog_pick_manifest(
+    *,
+    runner: Any,
+    filter_kind: PickManifestFilter = "any",
+    prompt: str | None = None,
+    default_dir: str | None = None,
+) -> str | None:
+    """Drive an ``osascript`` "choose file" dialog → POSIX path or None.
+
+    Mirrors :func:`stemforge.configurator.server._osascript_pick_save_path`
+    (the Phase 3C save-as helper) but uses AppleScript's ``choose file``
+    verb so the user picks an EXISTING file rather than naming a new one.
+
+    Subprocess invocation flows through ``runner`` (defaults to
+    :func:`subprocess.run`) so tests stub it cleanly. Returns ``None``
+    on:
+
+    * user cancel (osascript exits non-zero),
+    * missing ``osascript`` binary (``FileNotFoundError``),
+    * subprocess timeout.
+
+    All three cases must surface as 200 + ``{path: null, ...}`` at the
+    route layer; the popup handles the null path gracefully.
+    """
+    prompt_text = prompt or "Pick a forge manifest, curation, or audio file"
+    default_location_path = Path(default_dir).expanduser() if default_dir else Path.home()
+
+    of_clause = ""
+    ext_tuple = _FILTER_TO_EXT_LIST.get(filter_kind, ())
+    if ext_tuple:
+        # AppleScript: ``of type {"ext1", "ext2", ...}`` — strip leading dot.
+        quoted = ", ".join(f'"{ext.lstrip(".")}"' for ext in ext_tuple)
+        of_clause = f" of type {{{quoted}}}"
+
+    script = (
+        "set theFile to (choose file "
+        f'with prompt "{_applescript_escape(prompt_text)}"'
+        f"{of_clause} "
+        f'default location (POSIX file "{_applescript_escape(str(default_location_path))}"))\n'
+        "POSIX path of theFile"
+    )
+    cmd = ["osascript", "-e", script]
+    try:
+        proc = runner(cmd, capture_output=True, text=True, timeout=120, check=False)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    except OSError:
+        # Sandbox / permission errors — same null-result fallback.
+        return None
+    if getattr(proc, "returncode", 1) != 0:
+        return None
+    chosen = (getattr(proc, "stdout", "") or "").strip()
+    return chosen or None
+
+
+def _applescript_escape(value: str) -> str:
+    """Quote-escape a string for inline embedding in AppleScript source.
+
+    Mirrors :func:`stemforge.configurator.server._applescript_escape` —
+    duplicated here so :mod:`intents` doesn't import from :mod:`server`
+    (would be a cycle).
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def sniff_manifest_kind(path: str) -> SnifferKind:
+    """Classify ``path`` per the device-side sniffer taxonomy.
+
+    Resolution order (cheapest first), mirroring ``_snifferInspect`` in
+    ``v0/src/m4l-js/stemforge_loader.v0.js``:
+
+    1. Extension match → ``audio``.
+    2. ``.json``: parse + look for ``schema_version`` + (``pads`` →
+       ``forge_manifest``, ``chunks`` → ``arrangement_manifest``).
+    3. ``.yaml``/``.yml``: parse + look for top-level ``curation_version``
+       → ``curation``.
+
+    Anything that fails classification returns ``"unknown"`` — the
+    popup is expected to surface that as a soft warning, not an error.
+    """
+    if not path:
+        return "unknown"
+
+    lower = path.lower()
+    for ext in _SNIFFER_AUDIO_EXTS:
+        if lower.endswith(ext):
+            return "audio"
+
+    target = Path(path)
+    if not target.is_file():
+        return "unknown"
+
+    if lower.endswith(".json"):
+        try:
+            raw = target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return "unknown"
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return "unknown"
+        if not isinstance(parsed, dict):
+            return "unknown"
+        if "schema_version" not in parsed:
+            return "unknown"
+        if "pads" in parsed:
+            return "forge_manifest"
+        if "chunks" in parsed:
+            return "arrangement_manifest"
+        return "unknown"
+
+    if lower.endswith((".yaml", ".yml")):
+        try:
+            raw = target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return "unknown"
+        # Lightweight peek: look for a top-level ``curation_version:`` line.
+        # Avoids pulling pyyaml for what's a one-shot heuristic.
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith("curation_version"):
+                return "curation"
+            # First non-comment non-empty line — if it's not curation_version
+            # we still scan a few more in case the file has a leading
+            # ``---`` document marker. Cap at the first 50 non-trivial
+            # lines so a multi-MB YAML doesn't read in full.
+        # Try a more permissive search via line scan capped at 50 lines.
+        scanned = 0
+        for line in raw.splitlines():
+            scanned += 1
+            if scanned > 50:
+                break
+            if "curation_version" in line:
+                return "curation"
+        return "unknown"
+
+    return "unknown"
+
+
+async def handle_pick_manifest(
+    state: AppState,
+    body: PickManifestBody,
+    *,
+    runner: Any,
+) -> dict[str, Any]:
+    """``POST /intent/pick-manifest`` — open native picker + classify result.
+
+    Pre-UAT P0-1. The popup's ForgeList "add forge…" button POSTs to
+    this route. The previous code path 404'd against the production
+    server; the popup's msw mocks made vitest stay green even though
+    the production server lacked the route.
+
+    Always returns 200 with ``{path, kind}`` — user cancel, missing
+    osascript, and subprocess error all surface as ``{path: null,
+    kind: "unknown"}`` so the popup can render "no file picked" without
+    a thrown-error toast.
+    """
+    chosen = _native_file_dialog_pick_manifest(
+        runner=runner,
+        filter_kind=body.filter,
+        prompt=body.prompt,
+        default_dir=body.default_dir,
+    )
+    if chosen is None:
+        kind: SnifferKind = "unknown"
+    else:
+        kind = sniff_manifest_kind(chosen)
+    await state.log(
+        f"pick-manifest filter={body.filter!r} → path={chosen!r} kind={kind!r}",
+        "info",
+    )
+    return {"path": chosen, "kind": kind}
+
+
 __all__ = [
     "AlsOpenedBody",
     "BounceCompletion",
@@ -1356,8 +1611,11 @@ __all__ = [
     "OpenCurationBody",
     "PatchTargetBody",
     "PatchTemplateBody",
+    "PickManifestBody",
+    "POPUP_ALS_SENTINEL",
     "RenameCurationBody",
     "SaveAsBody",
+    "SnifferKind",
     "TriggerBounceBody",
     "handle_als_opened",
     "handle_assign_pad",
@@ -1376,10 +1634,12 @@ __all__ = [
     "handle_open_curation",
     "handle_patch_target",
     "handle_patch_template",
+    "handle_pick_manifest",
     "handle_recompute",
     "handle_refresh_curation",
     "handle_rename_curation",
     "handle_save_as",
+    "sniff_manifest_kind",
     "handle_set_group_format",
     "handle_trigger_bounce",
 ]

--- a/stemforge/configurator/server.py
+++ b/stemforge/configurator/server.py
@@ -64,6 +64,10 @@ Routes (Phase 3C — EXPORT via server):
 - ``POST /curations/{name}/export``
 - ``POST /intent/pick-save-path``
 
+Routes (Pre-UAT P0-1 — popup ForgeList "add forge…"):
+
+- ``POST /intent/pick-manifest``  (native open-file dialog + sniffer)
+
 Plus a static-files mount on ``/`` (configurable static dir; defaults to
 the package's ``static/`` directory). Lane B's frontend build output
 lands there.
@@ -72,7 +76,6 @@ lands there.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import socket
 import subprocess
@@ -103,6 +106,7 @@ from .intents import (
     OpenCurationBody,
     PatchTargetBody,
     PatchTemplateBody,
+    PickManifestBody,
     RenameCurationBody,
     SaveAsBody,
     TriggerBounceBody,
@@ -119,7 +123,7 @@ from .schemas import (
     RecomputeRequest,
     SetGroupFormatRequest,
 )
-from .state import AppState, SseEvent
+from .state import AppState, SseEvent, current_curations_state
 from .template_io import default_templates_dir, list_templates
 
 DEFAULT_HOST = "127.0.0.1"
@@ -430,9 +434,18 @@ def _register_routes(app: FastAPI, state: AppState) -> None:
             try:
                 # Send the current state immediately so a fresh subscriber
                 # has a baseline without waiting for the next mutation.
+                #
+                # Pre-UAT P0-3: emit the ``kind: "curations"`` shape that
+                # ``broadcast_curations_state`` uses for every subsequent
+                # mutation-driven event. Previously this route emitted the
+                # legacy ``Project`` shape on cold-start, which the popup's
+                # ``handleStateEvent`` mis-routed into the legacy branch
+                # (``payload.curation === undefined``) and rendered as
+                # "no curation active". The popup recovered after the next
+                # mutation; the first frame was wrong.
                 snapshot = SseEvent(
                     event="state",
-                    data=json.loads(state.project.model_dump_json(exclude_none=True)),
+                    data=current_curations_state(state),
                 )
                 yield snapshot.to_wire().encode("utf-8")
                 while True:
@@ -764,6 +777,25 @@ def _register_routes(app: FastAPI, state: AppState) -> None:
             prompt=body.prompt,
         )
         return {"ok": True, "path": chosen}
+
+    @app.post("/intent/pick-manifest")
+    async def pick_manifest_route(body: PickManifestBody) -> dict[str, Any]:
+        """Pre-UAT P0-1 — open-file dialog + sniffer for popup ForgeList.
+
+        Drives a native osascript ``choose file`` dialog and classifies
+        the result against the device-side sniffer taxonomy:
+        ``audio | forge_manifest | arrangement_manifest | curation |
+        unknown``. Always returns 200 with ``{path, kind}`` — user
+        cancel, missing osascript, or subprocess error all surface as
+        ``{path: null, kind: "unknown"}``.
+
+        Lives server-side because the popup runs inside Live's [jweb]
+        host without filesystem access. Subprocess invocation flows
+        through ``app.state.subprocess_runner`` so tests stub it
+        cleanly without spawning a real osascript dialog.
+        """
+        runner = app.state.subprocess_runner
+        return await intents.handle_pick_manifest(state, body, runner=runner)
 
     @app.post("/forges/{slug}/re-curate")
     async def re_curate_forge_route(slug: str, body: ReCurateBody) -> dict[str, Any]:

--- a/stemforge/configurator/state.py
+++ b/stemforge/configurator/state.py
@@ -154,41 +154,13 @@ class AppState:
         so the popup can render stale badges in ``ForgeList`` (per-forge
         stale count) and ``ActiveCuration`` (per-pad stale indicator)
         without re-resolving every forge in the browser.
+
+        Pre-UAT P0-3: payload-construction factored into
+        :func:`current_curations_state` so the cold-start SSE snapshot
+        path in ``server.py`` can emit the same shape without a
+        full mutation cycle.
         """
-        from .curation_io import list_curations, read_curation  # local: avoid cycle
-        from .stale_check import stale_summary
-
-        # Phase 4A: cache refresh keeps /als-opened lookups disk-free.
-        current_state = self.refresh_cached_stemforge_state()
-        active_curations = current_state.active_curations
-        curation_paths = list_curations(self.curations_dir)
-        names = [p.stem for p in curation_paths]
-
-        # Phase 4B: compute per-pad stale flags against current forges.
-        forges_by_slug = _load_forges_by_slug(self.processed_dir)
-        stale_by_curation: dict[str, dict[str, dict[str, object]]] = {}
-        for path in curation_paths:
-            try:
-                curation = read_curation(path)
-            except Exception:  # noqa: BLE001 - broadcaster mustn't crash on bad files
-                continue
-            entries = stale_summary(curation, forges_by_slug)
-            stale_by_curation[curation.name] = {
-                pad_id: entry.to_dict() for pad_id, entry in entries.items()
-            }
-
-        await self.broadcast(
-            SseEvent(
-                event="state",
-                data={
-                    "kind": "curations",
-                    "curations": names,
-                    "active_curations": active_curations,
-                    "stale_by_curation": stale_by_curation,
-                    "ts": time.time(),
-                },
-            )
-        )
+        await self.broadcast(SseEvent(event="state", data=current_curations_state(self)))
 
     async def log(self, message: str, level: str = "info") -> None:
         """Emit a ``log`` SSE event."""
@@ -221,6 +193,57 @@ class AppState:
                 data={"code": code, "message": message, "ts": time.time()},
             )
         )
+
+
+# ── Curation-state payload builder (Pre-UAT P0-3) ───────────────────────────
+
+
+def current_curations_state(state: AppState) -> dict[str, Any]:
+    """Build the ``kind: "curations"`` SSE payload for ``state``.
+
+    Pure function — no broadcasting, no SSE wrapping. Mirrors what
+    :meth:`AppState.broadcast_curations_state` would push, so the
+    cold-start SSE snapshot path in :mod:`server` can emit the same
+    shape as every subsequent mutation-driven event.
+
+    Side effect: refreshes the in-memory ``cached_stemforge_state``
+    so the result reflects the latest ``.stemforge_state.json`` on
+    disk. Matches the legacy behaviour the broadcaster used to
+    perform inline.
+
+    Returns:
+        Dict ready to drop into ``SseEvent(event="state", data=...)``
+        or into the ``GET /state/stream`` initial-snapshot wire.
+    """
+    from .curation_io import list_curations, read_curation  # local: avoid cycle
+    from .stale_check import stale_summary
+
+    # Phase 4A: cache refresh keeps /als-opened lookups disk-free.
+    current_state = state.refresh_cached_stemforge_state()
+    active_curations = current_state.active_curations
+    curation_paths = list_curations(state.curations_dir)
+    names = [p.stem for p in curation_paths]
+
+    # Phase 4B: compute per-pad stale flags against current forges.
+    forges_by_slug = _load_forges_by_slug(state.processed_dir)
+    stale_by_curation: dict[str, dict[str, dict[str, object]]] = {}
+    for path in curation_paths:
+        try:
+            curation = read_curation(path)
+        except Exception:  # noqa: BLE001 - mustn't crash on bad files
+            continue
+        entries = stale_summary(curation, forges_by_slug)
+        stale_by_curation[curation.name] = {
+            pad_id: entry.to_dict() for pad_id, entry in entries.items()
+        }
+
+    return {
+        "kind": "curations",
+        "curations": names,
+        "active_curations": active_curations,
+        "stale_by_curation": stale_by_curation,
+        "ts": time.time(),
+    }
 
 
 # ── Forge manifest loader (for Phase 4B stale-check) ────────────────────────
@@ -394,6 +417,7 @@ __all__ = [
     "AppState",
     "EventName",
     "SseEvent",
+    "current_curations_state",
     "get_active_curation",
     "load_state",
     "load_state_with_recovery",

--- a/tests/test_configurator_pick_manifest.py
+++ b/tests/test_configurator_pick_manifest.py
@@ -1,0 +1,446 @@
+"""Tests for the Pre-UAT P0 fixes (Lane A — server-only).
+
+Three independent slices live here:
+
+* **P0-1** — ``POST /intent/pick-manifest`` route + sniffer taxonomy.
+* **P0-2** — ``OpenCurationBody.als_path`` / ``CloseActiveCurationBody.als_path``
+  optional + ``POPUP_ALS_SENTINEL`` default.
+* **P0-3** — initial SSE snapshot on ``/state/stream`` emits the
+  ``kind: "curations"`` shape (not the legacy ``Project`` shape).
+
+See ``docs/configurator/PRE_UAT_REVIEW.md`` for the upstream findings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stemforge.configurator.curation_io import (
+    curation_path,
+    write_curation_atomic,
+)
+from stemforge.configurator.intents import (
+    POPUP_ALS_SENTINEL,
+    sniff_manifest_kind,
+)
+from stemforge.configurator.schemas import Curation, Group, Pad, Target
+from stemforge.configurator.server import create_app
+from stemforge.configurator.state import AppState, current_curations_state
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def configurator_paths(tmp_path: Path) -> dict[str, Path]:
+    curations_dir = tmp_path / "curations"
+    curations_dir.mkdir()
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    state_path = tmp_path / ".stemforge_state.json"
+    static_dir = tmp_path / "static"
+    return {
+        "curations_dir": curations_dir,
+        "processed_dir": processed_dir,
+        "state_path": state_path,
+        "static_dir": static_dir,
+    }
+
+
+def _make_client(
+    paths: dict[str, Path],
+    runner: Any | None = None,
+) -> TestClient:
+    app = create_app(
+        static_dir=paths["static_dir"],
+        curations_dir=paths["curations_dir"],
+        state_path=paths["state_path"],
+        processed_dir=paths["processed_dir"],
+        subprocess_runner=runner,
+    )
+    return TestClient(app)
+
+
+def _seed_curation(curations_dir: Path, name: str) -> Curation:
+    """Minimal curation YAML used as bait by the open/close/SSE tests."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    target = Target()
+    groups: dict[str, Group] = {}
+    for letter in ["A", "B", "C", "D"]:
+        pads = [Pad(pad_id=f"{letter}{i + 1:02d}") for i in range(12)]
+        groups[letter] = Group(label="", template=None, pads=pads)
+    curation = Curation(
+        name=name,
+        type="deck",
+        created_at=now,
+        modified_at=now,
+        target=target,
+        referenced_forges=[],
+        groups=groups,
+    )
+    write_curation_atomic(curation_path(curations_dir, name), curation)
+    return curation
+
+
+# ── P0-1: POST /intent/pick-manifest ────────────────────────────────────────
+
+
+def test_pick_manifest_returns_forge_manifest_kind(
+    configurator_paths: dict[str, Path], tmp_path: Path
+) -> None:
+    """Sniffer classifies a JSON with ``pads`` + ``schema_version`` correctly."""
+    manifest = tmp_path / "fixtures" / "snare_kit" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "pads": [{"pad_id": "A01", "clip_id": "abc"}],
+            }
+        )
+    )
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        # Mocked osascript stdout = chosen path.
+        assert cmd[0] == "osascript"
+        return SimpleNamespace(returncode=0, stdout=str(manifest) + "\n", stderr="")
+
+    client = _make_client(configurator_paths, runner=runner)
+    r = client.post("/intent/pick-manifest", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["path"] == str(manifest)
+    assert body["kind"] == "forge_manifest"
+
+
+def test_pick_manifest_classifies_audio_by_extension(
+    configurator_paths: dict[str, Path], tmp_path: Path
+) -> None:
+    """An ``.wav`` path resolves to ``kind=audio`` even if the file's empty."""
+    wav = tmp_path / "kick.wav"
+    wav.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        return SimpleNamespace(returncode=0, stdout=str(wav) + "\n", stderr="")
+
+    client = _make_client(configurator_paths, runner=runner)
+    r = client.post("/intent/pick-manifest", json={"filter": "audio"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["path"] == str(wav)
+    assert body["kind"] == "audio"
+
+
+def test_pick_manifest_classifies_curation_yaml(
+    configurator_paths: dict[str, Path], tmp_path: Path
+) -> None:
+    """A YAML with ``curation_version`` sniffs as ``curation``."""
+    yaml_path = tmp_path / "my_curation.yaml"
+    yaml_path.write_text("curation_version: 1\nname: test\n")
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        return SimpleNamespace(returncode=0, stdout=str(yaml_path) + "\n", stderr="")
+
+    client = _make_client(configurator_paths, runner=runner)
+    r = client.post("/intent/pick-manifest", json={"filter": "manifest"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kind"] == "curation"
+
+
+def test_pick_manifest_returns_null_kind_unknown_on_cancel(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """User cancel → ``{path: null, kind: "unknown"}`` (200, not 500)."""
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        # AppleScript user-cancel = exit code 1.
+        return SimpleNamespace(returncode=1, stdout="", stderr="User canceled.")
+
+    client = _make_client(configurator_paths, runner=runner)
+    r = client.post("/intent/pick-manifest", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["path"] is None
+    assert body["kind"] == "unknown"
+
+
+def test_pick_manifest_handles_missing_osascript(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Headless / non-mac runner without ``osascript`` doesn't 500."""
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        raise FileNotFoundError("osascript not found")
+
+    client = _make_client(configurator_paths, runner=runner)
+    r = client.post("/intent/pick-manifest", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["path"] is None
+    assert body["kind"] == "unknown"
+
+
+def test_pick_manifest_handles_subprocess_error_gracefully(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Other subprocess errors (timeout / OSError) also surface as 200 + null."""
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        import subprocess
+
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=120)
+
+    client = _make_client(configurator_paths, runner=runner)
+    r = client.post("/intent/pick-manifest", json={})
+    assert r.status_code == 200
+    assert r.json() == {"path": None, "kind": "unknown"}
+
+
+# ── Pure sniffer-helper tests ───────────────────────────────────────────────
+
+
+def test_sniff_manifest_kind_arrangement_manifest(tmp_path: Path) -> None:
+    """``chunks``-keyed JSON sniffs as arrangement_manifest."""
+    path = tmp_path / "arrangement.json"
+    path.write_text(json.dumps({"schema_version": 1, "chunks": []}))
+    assert sniff_manifest_kind(str(path)) == "arrangement_manifest"
+
+
+def test_sniff_manifest_kind_unknown_for_random_json(tmp_path: Path) -> None:
+    """JSON without pads/chunks falls through to ``unknown``."""
+    path = tmp_path / "random.json"
+    path.write_text(json.dumps({"schema_version": 1, "other": 42}))
+    assert sniff_manifest_kind(str(path)) == "unknown"
+
+
+def test_sniff_manifest_kind_unknown_for_empty_path() -> None:
+    """Empty / missing path is harmless."""
+    assert sniff_manifest_kind("") == "unknown"
+
+
+# ── P0-2: optional als_path + sentinel ──────────────────────────────────────
+
+
+def test_popup_als_sentinel_constant_value() -> None:
+    """The popup sentinel value is the public contract — pin it."""
+    assert POPUP_ALS_SENTINEL == "__popup__"
+
+
+def test_open_curation_with_empty_body_uses_popup_sentinel(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """POST /curations/{name}/open with no body → 200, sentinel keyed."""
+    _seed_curation(configurator_paths["curations_dir"], "partial")
+    client = _make_client(configurator_paths)
+    r = client.post("/curations/partial/open", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["active_curations"][POPUP_ALS_SENTINEL] == "partial"
+
+    # State file on disk also shows the sentinel mapping.
+    state_data = json.loads(configurator_paths["state_path"].read_text())
+    assert state_data["active_curations"][POPUP_ALS_SENTINEL] == "partial"
+
+
+def test_close_active_curation_with_empty_body_uses_popup_sentinel(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """POST /curations/active/close with ``{}`` → 200, sentinel removed."""
+    _seed_curation(configurator_paths["curations_dir"], "partial")
+    client = _make_client(configurator_paths)
+    # First open the popup-attached curation.
+    client.post("/curations/partial/open", json={})
+    state_before = json.loads(configurator_paths["state_path"].read_text())
+    assert state_before["active_curations"].get(POPUP_ALS_SENTINEL) == "partial"
+
+    r = client.post("/curations/active/close", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["als_path"] == POPUP_ALS_SENTINEL
+
+    state_after = json.loads(configurator_paths["state_path"].read_text())
+    assert POPUP_ALS_SENTINEL not in state_after["active_curations"]
+
+
+def test_open_curation_with_explicit_als_path_still_works(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Backward compat — Live-attached flows passing a real .als still work."""
+    _seed_curation(configurator_paths["curations_dir"], "partial")
+    client = _make_client(configurator_paths)
+    als = "/Users/zak/Music/Ableton/Verse Swap.als"
+    r = client.post("/curations/partial/open", json={"als_path": als})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active_curations"][als] == "partial"
+    # The popup sentinel is NOT used when a real path is supplied.
+    assert POPUP_ALS_SENTINEL not in body["active_curations"]
+
+
+# ── P0-3: initial SSE snapshot emits kind=curations ─────────────────────────
+
+
+def test_initial_sse_snapshot_emits_curations_shape(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """First frame on ``/state/stream`` is the ``kind: "curations"`` shape.
+
+    Previously the route emitted ``state.project`` (legacy Project shape)
+    which the popup misrouted into the no-curation branch. The fix sends
+    the same payload that ``broadcast_curations_state`` produces.
+
+    Implementation note: we don't drive a real SSE connection through
+    TestClient (the stream blocks forever waiting for keepalives).
+    Instead we exercise the exact code path the route uses to build the
+    first frame — ``current_curations_state(state)`` — and assert its
+    shape matches the contract the popup's ``handleStateEvent`` expects.
+    """
+    _seed_curation(configurator_paths["curations_dir"], "alpha")
+    _seed_curation(configurator_paths["curations_dir"], "beta")
+
+    state = AppState()
+    state.curations_dir = configurator_paths["curations_dir"]
+    state.state_path = configurator_paths["state_path"]
+    state.processed_dir = configurator_paths["processed_dir"]
+
+    payload = current_curations_state(state)
+    assert payload["kind"] == "curations"
+    assert set(payload["curations"]) == {"alpha", "beta"}
+    # The route wraps this in an ``SseEvent(event="state", data=...)``
+    # frame — verify the wire format is what subscribers actually see.
+    from stemforge.configurator.state import SseEvent
+
+    wire = SseEvent(event="state", data=payload).to_wire()
+    assert wire.startswith("event: state\n")
+    assert '"kind": "curations"' in wire
+
+
+def test_initial_sse_snapshot_reflects_active_curations(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """Cold-start payload mirrors current active_curations (POPUP sentinel).
+
+    Drives a mutation through the FastAPI app (POST /curations/{name}/open
+    with empty body — exercises P0-2 too) and then asks
+    :func:`current_curations_state` for what a fresh subscriber would
+    see on the next connection. Must reflect the popup-sentinel mapping.
+    """
+    _seed_curation(configurator_paths["curations_dir"], "partial")
+    client = _make_client(configurator_paths)
+    client.post("/curations/partial/open", json={})
+
+    state = AppState()
+    state.curations_dir = configurator_paths["curations_dir"]
+    state.state_path = configurator_paths["state_path"]
+    state.processed_dir = configurator_paths["processed_dir"]
+
+    payload = current_curations_state(state)
+    assert payload["kind"] == "curations"
+    assert payload["active_curations"].get(POPUP_ALS_SENTINEL) == "partial"
+
+
+def test_state_stream_route_imports_current_curations_state(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """The server module imports and uses ``current_curations_state``.
+
+    Source-grep contract pin: the legacy bug was that ``/state/stream``
+    built its first frame from ``state.project.model_dump_json(...)``;
+    the fix replaces that with ``current_curations_state(state)``.
+    We assert (a) the import is present at module scope, (b) the legacy
+    Project-shape construction is gone from the route, and (c) the
+    helper is wired into the event_source path.
+
+    Why source-grep instead of an end-to-end stream subscription:
+    Starlette/httpx TestClient hangs on context-manager exit when an
+    SSE response generator is parked on an asyncio queue, even after
+    a single chunk read. Source-grep is a sound proxy because the
+    helper itself is exercised by
+    ``test_current_curations_state_pure_helper`` and
+    ``test_current_curations_state_matches_broadcaster_payload``.
+    """
+    import inspect
+
+    import stemforge.configurator.server as server_module
+
+    # (a) helper is importable from the module
+    assert hasattr(server_module, "current_curations_state")
+
+    # (b) stream_state route no longer constructs the legacy Project shape
+    src = inspect.getsource(server_module)
+    # The exact phrase from the pre-fix code path. If this lands back in
+    # the file, the cold-start payload regression is back too.
+    assert "state.project.model_dump_json" not in src, (
+        "/state/stream's cold-start snapshot must NOT use the legacy "
+        "Project shape — popup boot-state will regress (P0-3)."
+    )
+
+    # (c) the new helper is called from the route
+    assert "current_curations_state(state)" in src
+
+
+def test_current_curations_state_pure_helper(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """``current_curations_state`` returns the same shape the broadcaster pushes."""
+    _seed_curation(configurator_paths["curations_dir"], "solo")
+    state = AppState()
+    state.curations_dir = configurator_paths["curations_dir"]
+    state.state_path = configurator_paths["state_path"]
+    state.processed_dir = configurator_paths["processed_dir"]
+
+    payload = current_curations_state(state)
+    assert payload["kind"] == "curations"
+    assert payload["curations"] == ["solo"]
+    assert isinstance(payload["active_curations"], dict)
+    assert isinstance(payload["stale_by_curation"], dict)
+    assert "ts" in payload
+
+
+def test_current_curations_state_matches_broadcaster_payload(
+    configurator_paths: dict[str, Path],
+) -> None:
+    """The broadcaster pushes the EXACT shape current_curations_state returns.
+
+    Pins the contract between the cold-start path and the mutation-driven
+    path: both must produce identical dicts (modulo ts).
+    """
+    from stemforge.configurator.intents import (
+        CreateCurationBody,
+        handle_create_curation,
+    )
+
+    state = AppState()
+    state.curations_dir = configurator_paths["curations_dir"]
+    state.state_path = configurator_paths["state_path"]
+    state.processed_dir = configurator_paths["processed_dir"]
+
+    async def _drive() -> tuple[dict[str, Any], dict[str, Any]]:
+        queue = state.subscribe()
+        try:
+            await handle_create_curation(state, CreateCurationBody(name="contract"))
+            broadcast_data: dict[str, Any] = {}
+            while not queue.empty():
+                ev = queue.get_nowait()
+                if ev.event == "state":
+                    broadcast_data = ev.data
+            return broadcast_data, current_curations_state(state)
+        finally:
+            state.unsubscribe(queue)
+
+    broadcast_payload, helper_payload = asyncio.run(_drive())
+    # Compare ignoring ts (always now()).
+    bp = {k: v for k, v in broadcast_payload.items() if k != "ts"}
+    hp = {k: v for k, v in helper_payload.items() if k != "ts"}
+    assert bp == hp


### PR DESCRIPTION
## Summary

Lane A of the pre-UAT remediation sprint for StemForge Configurator v1.
Owns three server-side P0s identified in
`docs/configurator/PRE_UAT_REVIEW.md`.

- **P0-1** — `POST /intent/pick-manifest` route added. The popup's
  ForgeList "add forge…" button was 404'ing on production; only msw
  mocks were keeping vitest green. The new route drives osascript
  `choose file` server-side and runs the result through a sniffer
  that mirrors the device-side taxonomy in
  `v0/src/m4l-js/stemforge_loader.v0.js`:
  `audio | forge_manifest | arrangement_manifest | curation | unknown`.
  User-cancel / missing-osascript / subprocess-error all surface as
  `{path: null, kind: "unknown"}` (200, never 500).

- **P0-2** — `OpenCurationBody.als_path` + `CloseActiveCurationBody.als_path`
  now optional and default to `POPUP_ALS_SENTINEL = "__popup__"`. The
  popup TopBar "Close active" button was POSTing `{}` and 422'ing.
  Standalone-popup flows key state under the sentinel; Live-attached
  flows keep passing the real `.als` path. Backward compat preserved
  for every existing caller.

- **P0-3** — Initial SSE snapshot on `/state/stream` now emits the
  `kind: "curations"` payload (factored out as `current_curations_state`
  in `state.py`). Previously the first frame was the legacy `Project`
  shape, which the popup misrouted into the no-curation branch.
  Mutation-driven broadcasts and the cold-start snapshot now share
  one source of truth.

The `POPUP_ALS_SENTINEL` constant is re-exported from
`stemforge.configurator` so popup JS / future SDK callers can import
the same canonical value.

See: `docs/configurator/PRE_UAT_REVIEW.md`.

Lane A of pre-UAT remediation. Lanes B (popup-wire) + C (popup-ux)
running in parallel.

## Test plan

- [x] `uv run pytest stemforge/configurator/ tests/test_configurator_*.py -v` — 229 passed (211 pre-existing + 18 new)
- [x] `uv run ruff format --check stemforge tests scripts` — clean (184 files already formatted)
- [x] `uv run ruff check stemforge tests` — clean (all checks passed)
- [x] `uv run mypy stemforge/configurator/` — no new errors (pre-existing baseline preserved)
- [x] Manual: `POST /curations/{name}/open -d '{}'` returns 200 with `__popup__` sentinel keyed
- [x] Manual: `POST /curations/active/close -d '{}'` returns 200, sentinel cleared
- [x] Manual: `POST /intent/pick-manifest -d '{}'` returns 200 with `{path, kind}` shape (path null in headless env, route exists)
- [x] Cold-start `/state/stream` first frame asserted as `kind: "curations"` via pure-helper test + source-grep regression guard

## Files touched

- `stemforge/configurator/server.py` — route + initial snapshot
- `stemforge/configurator/intents.py` — sentinel + handler + sniffer
- `stemforge/configurator/state.py` — `current_curations_state` helper
- `stemforge/configurator/__init__.py` — re-export sentinel
- `tests/test_configurator_pick_manifest.py` — 18 new tests

Generated with [Claude Code](https://claude.com/claude-code)
