### PR TITLE
harden(configurator): popup contract tests + sentinel encapsulation + SSE shape lock + mypy delta

### DIFF
--- a/stemforge/configurator/intents.py
+++ b/stemforge/configurator/intents.py
@@ -86,9 +86,10 @@ from .schemas import (
 from .state import (
     AppState,
     SseEvent,
+    clear_active_curation_for_host,
     load_state,
     save_state,
-    set_active_curation,
+    set_active_curation_for_host,
 )
 
 DEFAULT_GROUPS = ("A", "B", "C", "D")
@@ -104,6 +105,29 @@ PADS_PER_GROUP = 12
 # bodies (defaulting to this sentinel) unblocks the popup TopBar's
 # Close button, which previously POSTed ``{}`` and 422'd because the
 # field was required.
+#
+# Pre-UAT P1-3 design call: the sentinel stays a "glorified namespace
+# prefix" inside ``StemforgeState.active_curations`` — we explicitly
+# chose NOT to add a parallel ``headless_active_curation`` slot on the
+# schema (option (a) in the lane plan) to avoid two sources of truth.
+# Every server-side writer instead routes through
+# :func:`set_active_curation_for_host` /
+# :func:`clear_active_curation_for_host` (state.py), which normalize
+# ``None`` / empty / sentinel into the same dict key. Tests that read
+# ``active_curations[some_als_path]`` directly keep working unchanged.
+#
+# When to use the sentinel from popup code:
+#
+# - Standalone popup (browser, no Live attached): every Open/Close call
+#   sends ``{"als_path": "__popup__"}`` so the server keys writes off
+#   the same namespace the SSE broadcaster keys reads off of.
+# - Live-attached popup (jweb inside Live): pass the absolute ``.als``
+#   path so popup + device + future "what does Live see right now"
+#   queries all key off the same identity.
+#
+# The string value MUST stay ``"__popup__"`` — the popup's TS shim
+# (``web/configurator/src/lib/api.ts``) hard-codes the same constant.
+# Drift between the two would silently scramble active-curation lookups.
 POPUP_ALS_SENTINEL = "__popup__"
 
 # Group-letter sequence used to seed empty curations. Targeted at v1's
@@ -444,7 +468,7 @@ class CreateCurationBody(BaseModel):
     """Body of ``POST /curations``."""
 
     name: str
-    target: Target = Field(default_factory=Target)
+    target: Target = Field(default_factory=lambda: Target())
 
     model_config = {"extra": "forbid"}
 
@@ -703,7 +727,10 @@ async def handle_open_curation(
     """
     curation = _load_curation_or_404(state, name)
     async with state.mutation_lock:
-        sf_state = set_active_curation(body.als_path, curation.name, state.state_path)
+        # P1-3: route through the helper so sentinel handling stays in
+        # one place. ``body.als_path`` is already the sentinel default
+        # for popup-only callers; the helper normalizes None/empty too.
+        sf_state = set_active_curation_for_host(state, body.als_path, curation.name)
     await state.log(f"opened curation {name} for {body.als_path}", "info")
     await state.broadcast_curations_state()
     return {
@@ -740,7 +767,11 @@ async def handle_save_as(
         with lock_curation(dst):
             write_curation_atomic(dst, cloned)
         if body.als_path:
-            set_active_curation(body.als_path, body.new_name, state.state_path)
+            # P1-3: route through the helper so cache + disk write stay
+            # in sync. ``body.als_path`` is the caller-supplied path
+            # (``SaveAsBody`` doesn't default to the sentinel — the
+            # save-as flow is Live-attached by design).
+            set_active_curation_for_host(state, body.als_path, body.new_name)
     await state.log(f"saved {name} as {body.new_name}", "info")
     await state.broadcast_curations_state()
     return cloned
@@ -831,7 +862,10 @@ async def handle_close_active_curation(
     when no entry exists. Always broadcasts so the popup re-renders.
     """
     async with state.mutation_lock:
-        sf_state = set_active_curation(body.als_path, None, state.state_path)
+        # P1-3: route through the helper so sentinel handling stays in
+        # one place. ``body.als_path`` is already the sentinel default
+        # for popup-only callers; the helper normalizes None/empty too.
+        sf_state = clear_active_curation_for_host(state, body.als_path)
     await state.log(f"closed active curation for {body.als_path}", "info")
     await state.broadcast_curations_state()
     return {

--- a/stemforge/configurator/schemas/curation.py
+++ b/stemforge/configurator/schemas/curation.py
@@ -85,7 +85,7 @@ class PadSource(BaseModel):
         """Build an external-path :class:`PadSource`."""
         return cls(external_path=external_path)
 
-    def model_post_init(self, __context: object) -> None:  # type: ignore[override]
+    def model_post_init(self, __context: object) -> None:
         """Enforce mutual exclusion of forge-owned vs external shapes."""
         if self.external_path is not None:
             if any((self.forge, self.clip_id, self.audio_path)):
@@ -134,9 +134,9 @@ class Target(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=False)
 
-    device: str = Field("ep133", description="Target device identifier (ep133 only in v1)")
-    groups: int = Field(4, ge=1, le=16, description="Number of groups")
-    pads_per_group: int = Field(12, ge=1, le=32, description="Pads per group")
+    device: str = Field(default="ep133", description="Target device identifier (ep133 only in v1)")
+    groups: int = Field(default=4, ge=1, le=16, description="Number of groups")
+    pads_per_group: int = Field(default=12, ge=1, le=32, description="Pads per group")
     label: str | None = Field(
         default=None,
         description=(

--- a/stemforge/configurator/schemas/state.py
+++ b/stemforge/configurator/schemas/state.py
@@ -29,7 +29,7 @@ class StemforgeState(BaseModel):
         description="Map of .als absolute path → active curation name",
     )
     last_known_port: int | None = Field(
-        None,
+        default=None,
         ge=1,
         le=65535,
         description="Most recent server port (mirrors .configurator_port)",

--- a/stemforge/configurator/stale_check.py
+++ b/stemforge/configurator/stale_check.py
@@ -218,7 +218,11 @@ def _refresh_pad(pad: Pad, forges: dict[str, ForgeManifest | None]) -> Pad:
         # Can't resolve; leave pad untouched, broadcaster will surface
         # the dangling reference.
         return pad
-    clip = next((c for c in forge.clips if c.clip_id == pad.source.clip_id), None)
+    clip_id = pad.source.clip_id
+    if clip_id is None:
+        # No clip_id to match against — bail.
+        return pad
+    clip = next((c for c in forge.clips if c.clip_id == clip_id), None)
     if clip is None:
         # clip_id missing in current manifest — leave audio_path untouched
         # so the loader's LOAD path surfaces a "missing clip" rather than
@@ -226,7 +230,7 @@ def _refresh_pad(pad: Pad, forges: dict[str, ForgeManifest | None]) -> Pad:
         return pad
     new_source = PadSource.for_forge(
         forge=pad.source.forge,
-        clip_id=pad.source.clip_id,
+        clip_id=clip_id,
         audio_path=clip.audio_path,
     )
     return pad.model_copy(update={"source": new_source})

--- a/stemforge/configurator/state.py
+++ b/stemforge/configurator/state.py
@@ -88,7 +88,7 @@ class AppState:
     # cache is refreshed lazily by readers (``load_state`` always reads
     # disk) and replaced atomically by writers via
     # :meth:`refresh_cached_stemforge_state`.
-    cached_stemforge_state: StemforgeState = field(default_factory=StemforgeState)
+    cached_stemforge_state: StemforgeState = field(default_factory=lambda: StemforgeState())
     # Phase 4B: the broadcaster needs to read forge manifests to compute
     # per-pad stale flags. Mirrors ``app.state.processed_dir`` so the
     # broadcaster can run without reaching into FastAPI state.
@@ -133,9 +133,33 @@ class AppState:
                 pass
 
     async def broadcast_state(self) -> None:
-        """Convenience: emit a ``state`` event with the current project."""
+        """Convenience: emit a ``state`` event with the current project.
+
+        Pre-UAT P1-9 (belt-and-suspenders): the payload now carries an
+        explicit ``kind: "project"`` discriminator alongside the legacy
+        ``Project`` shape. The popup's ``handleStateEvent`` already
+        dispatches on ``payload.kind === "curations"`` first; tagging
+        legacy project broadcasts keeps the discrimination uniform and
+        unblocks future regression tests that assert every emitted
+        ``state`` frame carries a recognized kind.
+
+        Wire shape (was a bare ``Project`` JSON object):
+        ``{"kind": "project", "project": {...}}``. The popup's legacy
+        fall-through still reads ``payload.curation`` / ``payload
+        .active_curation_name``, neither of which exists on the legacy
+        Project shape we emit here — so the popup will simply clear its
+        curation state, which is the right behaviour for these scene-
+        model intents.
+        """
         await self.broadcast(
-            SseEvent(event="state", data=json.loads(project_to_json(self.project)))
+            SseEvent(
+                event="state",
+                data={
+                    "kind": "project",
+                    "project": json.loads(project_to_json(self.project)),
+                    "ts": time.time(),
+                },
+            )
         )
 
     async def broadcast_curations_state(self) -> None:
@@ -215,6 +239,10 @@ def current_curations_state(state: AppState) -> dict[str, Any]:
         Dict ready to drop into ``SseEvent(event="state", data=...)``
         or into the ``GET /state/stream`` initial-snapshot wire.
     """
+    from typing import cast
+
+    from stemforge.forge.manifest_io import ForgeManifest
+
     from .curation_io import list_curations, read_curation  # local: avoid cycle
     from .stale_check import stale_summary
 
@@ -225,7 +253,10 @@ def current_curations_state(state: AppState) -> dict[str, Any]:
     names = [p.stem for p in curation_paths]
 
     # Phase 4B: compute per-pad stale flags against current forges.
-    forges_by_slug = _load_forges_by_slug(state.processed_dir)
+    forges_by_slug = cast(
+        "dict[str, ForgeManifest | None]",
+        _load_forges_by_slug(state.processed_dir),
+    )
     stale_by_curation: dict[str, dict[str, dict[str, object]]] = {}
     for path in curation_paths:
         try:
@@ -413,14 +444,102 @@ def set_active_curation(
     return state
 
 
+# ── Sentinel-aware helpers (Pre-UAT P1-3) ────────────────────────────────────
+#
+# Every call site that previously did
+# ``state.active_curations[als_path] = name`` should funnel through these
+# helpers. They encapsulate the ``None``→sentinel coercion so the rest of
+# the codebase never has to reason about ``POPUP_ALS_SENTINEL`` ("__popup__")
+# directly. Two-source-of-truth risks (e.g. a parallel
+# ``headless_active_curation`` slot on :class:`StemforgeState`) are
+# explicitly avoided — the sentinel is just a glorified namespace prefix
+# on the ``active_curations`` dict and tests that read
+# ``active_curations[some_als_path]`` keep working unchanged.
+
+
+def _normalize_host_key(als_path: str | None) -> str:
+    """Coerce ``None`` / empty / sentinel into the popup sentinel key.
+
+    The on-wire shape (``OpenCurationBody.als_path``,
+    ``CloseActiveCurationBody.als_path``) defaults to the sentinel at the
+    pydantic layer, so by the time a value reaches a handler it should
+    already be ``POPUP_ALS_SENTINEL`` for popup-only intents. The
+    coercion here is a belt-and-suspenders for callers that go through
+    the helper API directly (tests, programmatic seeds, etc.).
+    """
+    # Local import keeps state.py independent of the body-model module.
+    from .intents import POPUP_ALS_SENTINEL
+
+    if als_path is None or als_path == "":
+        return POPUP_ALS_SENTINEL
+    return als_path
+
+
+def set_active_curation_for_host(
+    app_state: AppState,
+    als_path: str | None,
+    curation_name: str,
+) -> StemforgeState:
+    """Record ``curation_name`` as the active curation for ``als_path``.
+
+    Wraps :func:`set_active_curation` with sentinel normalization and
+    refreshes :attr:`AppState.cached_stemforge_state` so subsequent
+    ``GET /als-opened`` lookups see the new value without an extra disk
+    read.
+
+    Returns the newly-persisted :class:`StemforgeState`.
+    """
+    key = _normalize_host_key(als_path)
+    sf_state = set_active_curation(key, curation_name, app_state.state_path)
+    # Mirror the disk write into the in-memory cache so /als-opened sees
+    # it without re-reading disk. ``refresh_cached_stemforge_state``
+    # would reach disk again — assigning directly is cheaper.
+    app_state.cached_stemforge_state = sf_state
+    return sf_state
+
+
+def clear_active_curation_for_host(
+    app_state: AppState,
+    als_path: str | None,
+) -> StemforgeState:
+    """Remove the active-curation entry for ``als_path``.
+
+    Idempotent — clearing an unset host returns the loaded state
+    unchanged. Normalizes ``None`` / empty / sentinel through
+    :func:`_normalize_host_key`.
+    """
+    key = _normalize_host_key(als_path)
+    sf_state = set_active_curation(key, None, app_state.state_path)
+    app_state.cached_stemforge_state = sf_state
+    return sf_state
+
+
+def get_active_curation_for_host(
+    app_state: AppState,
+    als_path: str | None,
+) -> str | None:
+    """Return the active curation name for ``als_path``, or ``None``.
+
+    Reads from :attr:`AppState.cached_stemforge_state` — disk-free,
+    matches the read path of ``POST /als-opened``. Callers wanting a
+    fresh disk read should ``app_state.refresh_cached_stemforge_state()``
+    first.
+    """
+    key = _normalize_host_key(als_path)
+    return app_state.cached_stemforge_state.active_curations.get(key)
+
+
 __all__ = [
     "AppState",
     "EventName",
     "SseEvent",
+    "clear_active_curation_for_host",
     "current_curations_state",
     "get_active_curation",
+    "get_active_curation_for_host",
     "load_state",
     "load_state_with_recovery",
     "save_state",
     "set_active_curation",
+    "set_active_curation_for_host",
 ]

--- a/tests/test_configurator_sse_shape.py
+++ b/tests/test_configurator_sse_shape.py
@@ -1,0 +1,281 @@
+"""SSE state-event shape regression tests (Pre-UAT P1-9).
+
+Every ``state`` SSE frame emitted by the server MUST carry an explicit
+``kind`` discriminator. Lane G locked this contract to unblock the
+popup's ``handleStateEvent``, which now dispatches on ``kind`` first and
+falls back to the legacy ``Project`` shape only when no recognized kind
+is set.
+
+The recognized kinds today are:
+
+* ``curations`` — emitted on every curation CRUD mutation +
+  ``/state/stream`` cold-start snapshot. Carries
+  ``{curations, active_curations, stale_by_curation, ts}``.
+* ``forges`` — emitted on forge load/unload/re-anchor/re-curate.
+* ``bootstrap`` — emitted by ``POST /als-opened``.
+* ``bounce-start`` — emitted by ``POST /curations/{name}/trigger-bounce``.
+* ``project`` — Lane G's belt-and-suspenders kind for the legacy
+  scene-model ``/intent/*`` broadcasts (``load-manifest``, ``commit``,
+  ``assign-pad``, ``clear-pad``, ``set-group-format``, ``recompute``).
+
+The test below subscribes to ``state.subscribers`` directly (no
+TestClient SSE plumbing needed) and drives the broadcasters from the
+public API, asserting every emitted ``state`` event has a kind in the
+allowlist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from stemforge.configurator.intents import (
+    AssignPadRequest,
+    ClearPadRequest,
+    CreateCurationBody,
+    LoadManifestRequest,
+    OpenCurationBody,
+    RecomputeRequest,
+    SetGroupFormatRequest,
+    handle_assign_pad,
+    handle_clear_pad,
+    handle_create_curation,
+    handle_load_manifest,
+    handle_open_curation,
+    handle_recompute,
+    handle_set_group_format,
+)
+from stemforge.configurator.schemas import Target
+from stemforge.configurator.state import AppState, SseEvent
+
+# Every state-kind the server is allowed to emit today. Adding a new
+# kind requires adding it here AND documenting it in the module docstring.
+ALLOWED_STATE_KINDS = frozenset(
+    {
+        "curations",
+        "forges",
+        "bootstrap",
+        "bounce-start",
+        "project",
+    }
+)
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> AppState:
+    s = AppState()
+    s.curations_dir = tmp_path / "curations"
+    s.curations_dir.mkdir()
+    s.state_path = tmp_path / ".stemforge_state.json"
+    s.processed_dir = tmp_path / "processed"
+    s.processed_dir.mkdir()
+    return s
+
+
+def _drain(state: AppState, coro_factory) -> list[SseEvent]:
+    """Subscribe, run ``coro_factory()``, collect all events, unsubscribe."""
+
+    async def _run() -> list[SseEvent]:
+        q = state.subscribe()
+        try:
+            await coro_factory()
+            collected: list[SseEvent] = []
+            while not q.empty():
+                collected.append(q.get_nowait())
+            return collected
+        finally:
+            state.unsubscribe(q)
+
+    return asyncio.run(_run())
+
+
+def _state_events(events: list[SseEvent]) -> list[SseEvent]:
+    return [e for e in events if e.event == "state"]
+
+
+# ── New shape lock: legacy /intent/* broadcasts now carry kind:"project" ───
+
+
+def test_recompute_broadcast_carries_kind_project(state: AppState) -> None:
+    """``POST /intent/recompute`` — legacy scene-model broadcast.
+
+    Pre-P1-9 this emitted a bare ``Project`` JSON shape with no
+    ``kind`` field, which the popup mis-routed into its legacy
+    fallback. Lane G's belt-and-suspenders wraps the project shape in
+    ``{"kind": "project", "project": {...}, "ts": ...}`` so the popup
+    discriminates uniformly.
+    """
+    events = _drain(state, lambda: handle_recompute(state, RecomputeRequest()))
+    state_events = _state_events(events)
+    assert state_events, f"no state events emitted; got {[e.event for e in events]}"
+    for evt in state_events:
+        assert evt.data.get("kind") in ALLOWED_STATE_KINDS, (
+            f"state event missing/unknown kind={evt.data.get('kind')!r}: {evt.data!r}"
+        )
+
+
+def test_assign_pad_broadcast_carries_kind_project(state: AppState) -> None:
+    """``POST /intent/assign-pad`` legacy broadcast → kind:"project"."""
+    events = _drain(
+        state,
+        lambda: handle_assign_pad(
+            state,
+            AssignPadRequest(group="A", pad=1, clip_id="abc123", clip_path=None),
+        ),
+    )
+    state_events = _state_events(events)
+    assert state_events
+    for evt in state_events:
+        assert evt.data.get("kind") in ALLOWED_STATE_KINDS, evt.data
+
+
+def test_clear_pad_broadcast_carries_kind_project(state: AppState) -> None:
+    """``POST /intent/clear-pad`` legacy broadcast → kind:"project"."""
+    events = _drain(
+        state,
+        lambda: handle_clear_pad(state, ClearPadRequest(group="A", pad=1)),
+    )
+    state_events = _state_events(events)
+    assert state_events
+    for evt in state_events:
+        assert evt.data.get("kind") in ALLOWED_STATE_KINDS, evt.data
+
+
+def test_set_group_format_broadcast_carries_kind_project(state: AppState) -> None:
+    """``POST /intent/set-group-format`` legacy broadcast → kind:"project"."""
+    events = _drain(
+        state,
+        lambda: handle_set_group_format(state, SetGroupFormatRequest(group="A", format="drum")),
+    )
+    state_events = _state_events(events)
+    assert state_events
+    for evt in state_events:
+        assert evt.data.get("kind") in ALLOWED_STATE_KINDS, evt.data
+
+
+def test_load_manifest_failure_broadcast_carries_kind_project(
+    state: AppState, tmp_path: Path
+) -> None:
+    """Even error paths shouldn't leak un-tagged state frames.
+
+    ``handle_load_manifest`` doesn't broadcast on the manifest-not-found
+    error branch (it emits an ``error`` SSE event instead), but the
+    happy path (after this test seeds a valid manifest) goes through
+    ``broadcast_state`` — our new kind-tagged path. Verifies that.
+    """
+    manifest_path = tmp_path / "stems.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "bpm": 120.0,
+                "session_tracks": {"A": [], "B": [], "C": [], "D": []},
+            }
+        )
+    )
+    events = _drain(
+        state,
+        lambda: handle_load_manifest(
+            state,
+            LoadManifestRequest(
+                manifest_path=manifest_path,
+                bpm=120.0,
+                time_sig=(4, 4),
+                project_name="seed",
+            ),
+        ),
+    )
+    state_events = _state_events(events)
+    assert state_events, "expected a state broadcast on successful load"
+    for evt in state_events:
+        assert evt.data.get("kind") in ALLOWED_STATE_KINDS, evt.data
+
+
+# ── Curation CRUD path stays kind:"curations" ───────────────────────────────
+
+
+def test_create_curation_broadcasts_kind_curations(state: AppState) -> None:
+    events = _drain(
+        state,
+        lambda: handle_create_curation(state, CreateCurationBody(name="kindtest", target=Target())),
+    )
+    state_events = _state_events(events)
+    assert state_events
+    # The curation CRUD path emits kind="curations".
+    assert any(e.data.get("kind") == "curations" for e in state_events), [
+        e.data.get("kind") for e in state_events
+    ]
+
+
+def test_open_curation_broadcasts_kind_curations(state: AppState) -> None:
+    # Seed first.
+    asyncio.run(handle_create_curation(state, CreateCurationBody(name="openme", target=Target())))
+    events = _drain(
+        state,
+        lambda: handle_open_curation(state, "openme", OpenCurationBody()),
+    )
+    state_events = _state_events(events)
+    assert state_events
+    assert any(e.data.get("kind") == "curations" for e in state_events)
+
+
+# ── Cold-start SSE snapshot path (server.py /state/stream) ─────────────────
+
+
+def test_cold_start_snapshot_uses_current_curations_state(state: AppState) -> None:
+    """Lane A's cold-start snapshot must emit kind:"curations" too.
+
+    Reaches into the server module to exercise the same builder the
+    ``/state/stream`` route uses on subscribe.
+    """
+    from stemforge.configurator.state import current_curations_state
+
+    snapshot = current_curations_state(state)
+    assert snapshot["kind"] == "curations", snapshot
+    assert "curations" in snapshot
+    assert "active_curations" in snapshot
+
+
+# ── Audit: every kind we ever emit is in the allowlist ─────────────────────
+
+
+def test_no_legacy_untagged_project_broadcast_remains() -> None:
+    """Static-source check: ``broadcast_state`` must wrap with kind:"project".
+
+    A regression that reverts this contract (dropping the kind tag back
+    to a bare Project dump) is the failure mode we're protecting against.
+    Greps the source for the legacy emitter so the test catches "someone
+    edited it back" faster than a runtime test that needs a broadcast
+    to fire.
+    """
+    src = Path("stemforge/configurator/state.py").read_text()
+    # The legacy emitter looked like:
+    #   data=json.loads(project_to_json(self.project))
+    # …unwrapped. The new one wraps in {"kind": "project", "project": ...}.
+    bad = "data=json.loads(project_to_json(self.project))"
+    assert bad not in src, (
+        "found legacy untagged Project broadcast — Lane G's P1-9 fix regressed. "
+        "Wrap the payload in {'kind': 'project', 'project': ..., 'ts': ...}."
+    )
+    # And the new wrapper IS present.
+    assert '"kind": "project"' in src, (
+        "kind:'project' tag missing from state.py broadcast_state. "
+        "Lane G's P1-9 wrapper may have been removed."
+    )
+
+
+def test_allowed_kinds_is_documented_and_synced() -> None:
+    """The allowlist + module docstring must stay synced.
+
+    If a new kind is added to the allowlist, it must also appear in the
+    module docstring (this file's top-of-file kind catalog). This is a
+    cheap belt-and-suspenders to keep humans honest.
+    """
+    doc = __doc__ or ""
+    for kind in ALLOWED_STATE_KINDS:
+        assert f"``{kind}``" in doc, (
+            f"kind {kind!r} is in ALLOWED_STATE_KINDS but missing from the "
+            "module docstring. Update the catalog at the top of this file."
+        )

--- a/tests/test_configurator_state_file.py
+++ b/tests/test_configurator_state_file.py
@@ -13,12 +13,17 @@ from pathlib import Path
 
 import pytest
 
+from stemforge.configurator.intents import POPUP_ALS_SENTINEL
 from stemforge.configurator.schemas import StemforgeState
 from stemforge.configurator.state import (
+    AppState,
+    clear_active_curation_for_host,
     get_active_curation,
+    get_active_curation_for_host,
     load_state,
     save_state,
     set_active_curation,
+    set_active_curation_for_host,
 )
 
 
@@ -100,3 +105,110 @@ def test_set_active_curation_updates_last_seen_at(tmp_path: Path) -> None:
     p = tmp_path / "ts.json"
     state = set_active_curation("/x.als", "n", p)
     assert state.last_seen_at is not None
+
+
+# ── Pre-UAT P1-3 helpers: sentinel-aware writers on AppState ────────────────
+#
+# Tests cover the four call patterns the design call (option (b) — encapsulate
+# the sentinel handling) needs to handle: explicit path, sentinel path,
+# None path, and missing-key reads.
+
+
+def _make_app_state(tmp_path: Path) -> AppState:
+    state = AppState()
+    state.state_path = tmp_path / "host.json"
+    return state
+
+
+def test_set_active_curation_for_host_explicit_path(tmp_path: Path) -> None:
+    """Explicit als_path lands in the dict under that key."""
+    state = _make_app_state(tmp_path)
+    sf_state = set_active_curation_for_host(state, "/abs/project.als", "verse1")
+    assert sf_state.active_curations == {"/abs/project.als": "verse1"}
+    # Cache mirrors disk.
+    assert state.cached_stemforge_state.active_curations == {"/abs/project.als": "verse1"}
+
+
+def test_set_active_curation_for_host_sentinel_path(tmp_path: Path) -> None:
+    """Explicit sentinel als_path lands under the sentinel key."""
+    state = _make_app_state(tmp_path)
+    sf_state = set_active_curation_for_host(state, POPUP_ALS_SENTINEL, "verse2")
+    assert sf_state.active_curations == {"__popup__": "verse2"}
+
+
+def test_set_active_curation_for_host_none_normalizes_to_sentinel(
+    tmp_path: Path,
+) -> None:
+    """None als_path normalizes to the popup sentinel."""
+    state = _make_app_state(tmp_path)
+    sf_state = set_active_curation_for_host(state, None, "verse3")
+    assert sf_state.active_curations == {"__popup__": "verse3"}
+
+
+def test_set_active_curation_for_host_empty_string_normalizes_to_sentinel(
+    tmp_path: Path,
+) -> None:
+    """Empty-string als_path is treated as missing (defensive)."""
+    state = _make_app_state(tmp_path)
+    sf_state = set_active_curation_for_host(state, "", "verse4")
+    assert sf_state.active_curations == {"__popup__": "verse4"}
+
+
+def test_clear_active_curation_for_host_explicit_path(tmp_path: Path) -> None:
+    state = _make_app_state(tmp_path)
+    set_active_curation_for_host(state, "/abs/p.als", "v")
+    sf_state = clear_active_curation_for_host(state, "/abs/p.als")
+    assert sf_state.active_curations == {}
+
+
+def test_clear_active_curation_for_host_sentinel_path(tmp_path: Path) -> None:
+    state = _make_app_state(tmp_path)
+    set_active_curation_for_host(state, POPUP_ALS_SENTINEL, "v")
+    sf_state = clear_active_curation_for_host(state, None)  # None → sentinel
+    assert sf_state.active_curations == {}
+
+
+def test_clear_active_curation_for_host_idempotent_when_missing(
+    tmp_path: Path,
+) -> None:
+    """Clearing an unset host is a no-op + returns empty state."""
+    state = _make_app_state(tmp_path)
+    sf_state = clear_active_curation_for_host(state, "/never-set.als")
+    assert sf_state.active_curations == {}
+
+
+def test_get_active_curation_for_host_returns_value(tmp_path: Path) -> None:
+    state = _make_app_state(tmp_path)
+    set_active_curation_for_host(state, "/abs/p.als", "verse")
+    assert get_active_curation_for_host(state, "/abs/p.als") == "verse"
+
+
+def test_get_active_curation_for_host_sentinel_lookup(tmp_path: Path) -> None:
+    state = _make_app_state(tmp_path)
+    set_active_curation_for_host(state, POPUP_ALS_SENTINEL, "verse")
+    # All three lookups (sentinel, None, "") return the same value.
+    assert get_active_curation_for_host(state, POPUP_ALS_SENTINEL) == "verse"
+    assert get_active_curation_for_host(state, None) == "verse"
+    assert get_active_curation_for_host(state, "") == "verse"
+
+
+def test_get_active_curation_for_host_missing_key_returns_none(tmp_path: Path) -> None:
+    state = _make_app_state(tmp_path)
+    assert get_active_curation_for_host(state, "/nope.als") is None
+    # Sentinel namespace also empty when nothing was ever written.
+    assert get_active_curation_for_host(state, None) is None
+
+
+def test_helpers_keep_in_memory_cache_in_sync(tmp_path: Path) -> None:
+    """Writes through the helper refresh the cache without disk read.
+
+    Belt-and-suspenders: the helpers don't just persist — they also
+    mirror into ``cached_stemforge_state`` so the ``POST /als-opened``
+    fast-path sees the latest map immediately.
+    """
+    state = _make_app_state(tmp_path)
+    assert state.cached_stemforge_state.active_curations == {}
+    set_active_curation_for_host(state, "/cache.als", "fresh")
+    assert state.cached_stemforge_state.active_curations == {"/cache.als": "fresh"}
+    clear_active_curation_for_host(state, "/cache.als")
+    assert state.cached_stemforge_state.active_curations == {}

--- a/tests/test_popup_contract.py
+++ b/tests/test_popup_contract.py
@@ -1,0 +1,377 @@
+"""Popup↔server contract tests (Pre-UAT P1-1, flagship deliverable).
+
+The biggest miss in the pre-UAT review was that 8 of the P0 bugs were
+popup↔server wire mismatches that msw mocks silently approved. msw is
+happy to stub any path the popup asks for — the server doesn't see those
+stubs, so a typo in the popup's URL silently becomes a green popup test
++ a 404 in production.
+
+This module is the regression gate. We parse every
+``jsonRequest<T>(path, init)`` call out of
+``web/configurator/src/lib/api.ts``, walk each ``path + method`` against
+a real FastAPI ``TestClient``, and assert the route resolves (i.e. is
+neither 404 nor 405). Body-shape assertions cover the three high-risk
+endpoints whose request shape just changed in Lane A/B
+(``openCuration``, ``closeActiveCuration``, ``createCuration``).
+
+Maintenance pattern
+-------------------
+
+When you add a new ``jsonRequest`` call in ``api.ts``:
+
+* Use a relative path literal so the regex picks it up. Template-literal
+  segments like ``${encodeURIComponent(slug)}`` get substituted with the
+  fixture stub ``"fixture-slug"`` before hitting the server — any route
+  that can't accept a slug-as-string in its parameters will fail here.
+* Pick a real HTTP verb — the regex defaults to ``GET`` when no
+  ``method`` is provided, matching ``fetch``'s default.
+
+If the regex parser starts feeling fragile, replace it with the
+``register-call`` enumeration in ``EXPECTED_ROUTES`` below — keyed off
+the same ``api.ts`` source file, refreshed when wire shapes change.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stemforge.configurator.server import create_app
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_TS_PATH = REPO_ROOT / "web" / "configurator" / "src" / "lib" / "api.ts"
+
+
+# ── api.ts parser ───────────────────────────────────────────────────────────
+
+
+# Capture every `jsonRequest<T>(path, { method?: "X", body?: ... })` call.
+# Path may be a template literal (backticks) or a regular string. Method
+# defaults to GET when no init/method is specified.
+_JSON_REQUEST_RE = re.compile(
+    r"jsonRequest<[^>]+>\(\s*"
+    r"([`'\"])([^`'\"]+)\1"  # quoted/back-ticked path
+    r"(?:\s*,\s*\{([^}]*)\})?",  # optional init block
+    re.MULTILINE | re.DOTALL,
+)
+_METHOD_RE = re.compile(r"method\s*:\s*[\"']([A-Z]+)[\"']")
+
+
+def _parse_api_ts_calls() -> list[tuple[str, str]]:
+    """Return ``[(method, route_template), ...]`` for every jsonRequest call.
+
+    Template-literal placeholders (``${encodeURIComponent(x)}``,
+    ``${x}``) are flattened to the literal stub ``fixture-slug`` so the
+    resulting paths plug straight into ``TestClient.request``.
+    """
+    raw = API_TS_PATH.read_text()
+    calls: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for match in _JSON_REQUEST_RE.finditer(raw):
+        path_template = match.group(2)
+        init_block = match.group(3) or ""
+        method_match = _METHOD_RE.search(init_block)
+        method = method_match.group(1) if method_match else "GET"
+        # Substitute template placeholders with a stub. Two passes: the
+        # encodeURIComponent wrapper first, then any plain ${ ... } left over.
+        concrete = re.sub(r"\$\{encodeURIComponent\([^)]+\)\}", "fixture-slug", path_template)
+        concrete = re.sub(r"\$\{[^}]+\}", "fixture-slug", concrete)
+        key = (method, concrete)
+        if key in seen:
+            continue
+        seen.add(key)
+        calls.append(key)
+    return calls
+
+
+def _expected_min_calls() -> int:
+    """Fail-loud floor: api.ts has at least this many distinct routes today.
+
+    Bumps when api.ts grows. The point isn't the exact count — it's that
+    a regex bug that silently matches zero calls won't pass the parametrize.
+    """
+    return 16
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def configurator_paths(tmp_path: Path) -> dict[str, Path]:
+    curations_dir = tmp_path / "curations"
+    curations_dir.mkdir()
+    state_path = tmp_path / ".stemforge_state.json"
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    static_dir = tmp_path / "static"
+    return {
+        "curations_dir": curations_dir,
+        "state_path": state_path,
+        "processed_dir": processed_dir,
+        "templates_dir": templates_dir,
+        "static_dir": static_dir,
+    }
+
+
+@pytest.fixture
+def client(configurator_paths: dict[str, Path]) -> TestClient:
+    # Stub subprocess so any route that shells out to osascript / uv / the
+    # stemforge CLI returns immediately. The contract test only cares about
+    # route presence + method + (for the body-shape tests) body shape; it
+    # MUST NOT pop up a real macOS dialog on dev machines.
+    class _FastCompleted:
+        returncode = 1  # non-zero so osascript pickers behave as "no path"
+        stdout = ""
+        stderr = "(stubbed-by-contract-test)"
+
+    def _stub_run(*_args, **_kwargs):  # noqa: ARG001
+        return _FastCompleted()
+
+    app = create_app(
+        static_dir=configurator_paths["static_dir"],
+        curations_dir=configurator_paths["curations_dir"],
+        state_path=configurator_paths["state_path"],
+        processed_dir=configurator_paths["processed_dir"],
+        templates_dir=configurator_paths["templates_dir"],
+        subprocess_runner=_stub_run,
+    )
+    return TestClient(app)
+
+
+# ── Sanity: the parser actually finds something ─────────────────────────────
+
+
+def test_parser_finds_known_floor_of_routes() -> None:
+    """Guard against a parser regression that silently matches zero routes."""
+    calls = _parse_api_ts_calls()
+    assert len(calls) >= _expected_min_calls(), (
+        f"expected at least {_expected_min_calls()} jsonRequest calls in api.ts, "
+        f"found {len(calls)}; possible regex regression. Calls found: {calls!r}"
+    )
+
+
+def test_parser_captures_known_landmarks() -> None:
+    """Spot-check that we find the high-traffic routes by name."""
+    calls = {(m, p) for m, p in _parse_api_ts_calls()}
+    landmarks = {
+        ("GET", "/healthz"),
+        ("GET", "/curations"),
+        ("POST", "/curations"),
+        ("POST", "/intent/pick-manifest"),
+        ("POST", "/curations/active/close"),
+    }
+    missing = landmarks - calls
+    assert not missing, f"parser missed landmark routes: {missing!r}"
+
+
+# ── Route existence + method match ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    _parse_api_ts_calls(),
+    ids=lambda v: v.replace("/", "_") if isinstance(v, str) else v,
+)
+def test_popup_route_exists(client: TestClient, method: str, path: str) -> None:
+    """Every ``api.ts`` call resolves to a real route on the server.
+
+    We accept any status that isn't 404 / 405. 422 (body validation) and
+    400/409 (semantic rejection of the stub slug) are fine here — the
+    point is to catch typos and verb mismatches, not full body shapes.
+    Body shapes get their own assertions below.
+    """
+    body: dict | None = {} if method != "GET" else None
+    resp = client.request(method, path, json=body)
+    # 404 is ambiguous in FastAPI — it's used both for "route not registered"
+    # AND for domain "resource not found" (e.g. ``forge not found``). We
+    # distinguish them by the canonical detail string: starlette's default
+    # missing-route response is exactly ``{"detail":"Not Found"}``; any
+    # custom HTTPException sets a different detail.
+    if resp.status_code == 404:
+        try:
+            detail = resp.json().get("detail")
+        except ValueError:
+            detail = None
+        assert detail and detail != "Not Found", (
+            f"{method} {path} returned 404 — route missing from server. "
+            f"api.ts↔server.py drift detected. Body: {resp.text!r}"
+        )
+    assert resp.status_code != 405, (
+        f"{method} {path} returned 405 — verb mismatch. "
+        f"server.py registers a different HTTP method. "
+        f"Allowed: {resp.headers.get('allow', '<none>')!r}"
+    )
+
+
+# ── Body-shape assertions for high-risk endpoints (Lane A/B/G handoff) ──────
+
+
+def test_open_curation_accepts_empty_body_post_lane_a(
+    client: TestClient, configurator_paths: dict[str, Path]
+) -> None:
+    """``POST /curations/{name}/open`` accepts ``{}`` (sentinel default).
+
+    Lane A made ``als_path`` optional on ``OpenCurationBody`` so the
+    standalone popup can call this without a Live-attached path. A
+    regression that re-required the field would 422 here.
+    """
+    # Seed a curation so we get past the 404 branch — the body shape is
+    # what we care about.
+    from datetime import UTC, datetime
+
+    from stemforge.configurator.curation_io import curation_path, write_curation_atomic
+    from stemforge.configurator.schemas import Curation, Group, Pad, Target
+
+    target = Target()
+    groups = {
+        letter: Group(
+            label="",
+            template=None,
+            pads=[Pad(pad_id=f"{letter}{i + 1:02d}") for i in range(12)],
+        )
+        for letter in ["A", "B", "C", "D"]
+    }
+    curation = Curation(
+        name="contract_open",
+        type="deck",
+        created_at=datetime.now(UTC),
+        modified_at=datetime.now(UTC),
+        target=target,
+        referenced_forges=[],
+        groups=groups,
+    )
+    write_curation_atomic(
+        curation_path(configurator_paths["curations_dir"], "contract_open"),
+        curation,
+    )
+
+    resp = client.post("/curations/contract_open/open", json={})
+    assert resp.status_code == 200, (
+        f"open with empty body returned {resp.status_code}: {resp.text!r}. "
+        "Lane A's POPUP_ALS_SENTINEL default may have regressed."
+    )
+    body = resp.json()
+    # The sentinel namespace got the active.
+    assert body["active_curations"].get("__popup__") == "contract_open"
+
+
+def test_close_active_curation_accepts_empty_body_post_lane_a(
+    client: TestClient,
+) -> None:
+    """``POST /curations/active/close`` accepts ``{}`` (sentinel default)."""
+    resp = client.post("/curations/active/close", json={})
+    assert resp.status_code == 200, (
+        f"close with empty body returned {resp.status_code}: {resp.text!r}. "
+        "Lane A's POPUP_ALS_SENTINEL default may have regressed."
+    )
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["als_path"] == "__popup__"
+
+
+def test_create_curation_accepts_name_plus_target(client: TestClient) -> None:
+    """``POST /curations`` accepts ``{name, target}`` per Lane B's wire shape."""
+    body = {
+        "name": "contract_create",
+        "target": {
+            "device": "ep133",
+            "groups": 4,
+            "pads_per_group": 12,
+        },
+    }
+    resp = client.post("/curations", json=body)
+    assert resp.status_code == 201, (
+        f"create returned {resp.status_code}: {resp.text!r}. "
+        "Lane B's CreateCurationRequest may have drifted from CreateCurationBody."
+    )
+    out = resp.json()
+    assert out["name"] == "contract_create"
+
+
+def test_create_curation_accepts_name_alone(client: TestClient) -> None:
+    """Target is optional — default lands automatically."""
+    resp = client.post("/curations", json={"name": "contract_just_name"})
+    assert resp.status_code == 201, resp.text
+    out = resp.json()
+    assert out["name"] == "contract_just_name"
+
+
+def test_pick_manifest_accepts_empty_body(client: TestClient) -> None:
+    """``POST /intent/pick-manifest`` accepts ``{}`` (P0-1 handoff)."""
+    resp = client.post("/intent/pick-manifest", json={})
+    # On non-macOS CI runners osascript is absent → returns {path: null,
+    # kind: "unknown"}; on dev macs the dialog auto-cancels. Either way
+    # we want 200 + the documented shape.
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "kind" in body, body
+    assert "path" in body, body
+
+
+# ── Negative sanity: a synthetic mismatch fires the contract ────────────────
+
+
+def test_synthetic_404_path_would_be_caught() -> None:
+    """Documents the failure mode the contract test protects against.
+
+    This test deliberately does NOT call the server with a bogus path —
+    that would muddy the parametrize. Instead it asserts that if the
+    parser ever picked up a route that doesn't exist on the server, the
+    parametrized test above would catch it (by returning 404).
+
+    To verify manually: add ``jsonRequest<unknown>("/totally-bogus")``
+    temporarily to api.ts, re-run this module, watch
+    ``test_popup_route_exists[GET-_totally-bogus]`` fail with 404.
+    """
+    # Self-check: parser still returns a non-empty list.
+    calls = _parse_api_ts_calls()
+    assert calls, "parser found zero calls — guard against silent regression"
+    # Self-check: the synthetic floor is real.
+    assert len(calls) >= _expected_min_calls()
+
+
+# ── Reverse coverage: every server route in api.ts is intentional ──────────
+
+
+def _server_routes(client: TestClient) -> Iterable[tuple[str, str]]:
+    """Yield ``(method, path)`` for every registered FastAPI route."""
+    for route in client.app.routes:  # type: ignore[attr-defined]
+        methods = getattr(route, "methods", None) or set()
+        path = getattr(route, "path", None)
+        if not path:
+            continue
+        for method in methods:
+            if method == "HEAD":
+                continue
+            yield (method, path)
+
+
+def test_api_ts_does_not_reference_unknown_prefixes(client: TestClient) -> None:
+    """Every api.ts route's *prefix* exists on the server.
+
+    Path-parameter style differences (``/curations/{name}`` vs the popup's
+    ``/curations/fixture-slug``) make exact-match comparison flaky, so we
+    assert prefix overlap: the popup's path must share its first two
+    segments with at least one server route.
+    """
+    server_prefixes = set()
+    for _method, path in _server_routes(client):
+        parts = path.split("/")
+        if len(parts) >= 3:
+            server_prefixes.add(f"/{parts[1]}/{parts[2]}")
+        elif len(parts) >= 2:
+            server_prefixes.add(f"/{parts[1]}")
+    for method, path in _parse_api_ts_calls():
+        parts = path.split("/")
+        candidate = f"/{parts[1]}/{parts[2]}" if len(parts) >= 3 else f"/{parts[1]}"
+        candidate_root = f"/{parts[1]}" if len(parts) >= 2 else "/"
+        assert candidate in server_prefixes or candidate_root in server_prefixes, (
+            f"api.ts route {method} {path} has no server-side prefix match. "
+            f"Known prefixes: {sorted(server_prefixes)!r}"
+        )


### PR DESCRIPTION
## Summary

Lane G — the last remediation lane before UAT. Closes out the P1 backend hardening backlog.

- **P1-1 (flagship)** — Popup↔server contract tests. Parses `web/configurator/src/lib/api.ts` for every `jsonRequest<T>(path, init)` call, walks each `(method, path)` against a real FastAPI `TestClient`, and asserts every route resolves. Body-shape assertions for the three high-risk endpoints (`openCuration`, `closeActiveCuration`, `createCuration`). 32 tests. Synthetic-mismatch demo verified manually.
- **P1-3** — `__popup__` sentinel encapsulation. Picked **option (b)** (encapsulate via helpers) over option (a) (parallel `headless_active_curation` schema slot). Reasoning: less disruptive (no TS regen ripple), cleaner code (one source of truth), the sentinel is just a glorified namespace prefix anyway, and tests reading `active_curations[some_als_path]` keep working. Three new helpers — `set_active_curation_for_host` / `clear_active_curation_for_host` / `get_active_curation_for_host` — handle None/empty/sentinel normalization and keep the in-memory cache in sync with disk.
- **P1-4** — mypy delta cleanup. Brought `stemforge/configurator/` non-test mypy errors from 10 → 0 via `Field(default=...)` keyword form + lambda factories + a couple of local narrowings. Project-wide errors 32 → 15; the remaining 15 are all in `schemas/test_*.py` (intentionally-bogus negative-shape constructors), out of scope.
- **P1-9** — SSE shape lock. `broadcast_state()` now wraps the legacy `Project` payload in `{"kind": "project", "project": ..., "ts": ...}` so every `state` SSE frame the server emits carries a discriminator. Recognized kinds: `curations`, `forges`, `bootstrap`, `bounce-start`, `project`. Regression test in `tests/test_configurator_sse_shape.py` drives the legacy `/intent/*` broadcasters through the subscriber queue and asserts every frame is tagged.

## Audit notes (P1-9)

Grepped `state.project.model_dump | project_to_json | Project(` in `server.py`, `intents.py`, `state.py`. The only emitter still in play is `AppState.broadcast_state` (used by `handle_load_manifest`, `handle_commit`, `handle_assign_pad`, `handle_clear_pad`, `handle_set_group_format`, `handle_recompute`, `handle_export`). All seven now ride the new kind-tagged wrapper. No legacy untagged broadcasts remain.

## Test count

- 32 popup↔server contract tests (`tests/test_popup_contract.py`).
- 10 SSE-shape regression tests (`tests/test_configurator_sse_shape.py`).
- 11 sentinel-aware helper tests (`tests/test_configurator_state_file.py`).

**Total: 53 new tests, all green.** Full configurator suite: 282 tests green. Whole-repo suite (minus the demucs-extras test and the JS bridge): 1212 passed, 10 skipped.

## Test plan

- [x] `uv run pytest tests/test_popup_contract.py tests/test_configurator_sse_shape.py tests/test_configurator_state_file.py -v` — 62 passed.
- [x] `uv run pytest tests/test_configurator_*.py tests/test_popup_contract.py stemforge/configurator/` — 282 passed.
- [x] `uv run ruff format --check stemforge tests scripts tools` — clean.
- [x] `uv run ruff check stemforge tests` — clean.
- [x] `uv run mypy stemforge/configurator/` — 15 errors (down from 32, all in intentionally-bogus schemas/test_*.py).
- [x] `uv run python scripts/gen_typescript_types.py` — no diff (schema unchanged from popup's perspective).
- [x] `cd web/configurator && npm test -- --run` — 69 popup tests passed.
- [x] `cd web/configurator && npm run lint && npm run build` — green.
- [x] Synthetic-mismatch contract-test sanity check verified manually (added `jsonRequest<unknown>("/totally-bogus")` to api.ts, contract test failed with 404 + correct error message, then reverted).

Lane G complete — P1 backlog cleared for UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
