### PR TITLE
fix(device): open popup as a Chrome app window, not a browser tab (#129)

### DIFF
--- a/tests/js_mocks/test_open_editor.test.js
+++ b/tests/js_mocks/test_open_editor.test.js
@@ -1,12 +1,13 @@
 // test_open_editor.test.js
 // ─────────────────────────────────────────────────────────────────────────────
-// Phase 4B — openEditor() on stemforge_loader.v0.js.
+// openEditor() on stemforge_loader.v0.js.
 //
-// The footer's [ Open Editor ] button fires `messnamed("max",
-// "launchbrowser", <url>)` after resolving the server's port from
-// ~/stemforge/.configurator_port. This test captures the messnamed
-// emissions so we can assert against the URL the loader would have
-// opened in production.
+// The footer's [ Open Editor ] button resolves the configurator server's
+// port from ~/stemforge/.configurator_port and opens the popup as a Chrome
+// *app window* — `outlet(3, "/usr/bin/open", "-n", "-a", "Google Chrome",
+// "--args", "--app=<url>")` → [shell]. (It used to fire `messnamed("max",
+// "launchbrowser", url)`, which piled up a tab in the main browser — #129.)
+// This test captures the outlet emissions to assert the opened URL.
 // ─────────────────────────────────────────────────────────────────────────────
 
 'use strict';
@@ -22,11 +23,13 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const LOADER = path.join(REPO_ROOT, 'v0', 'src', 'm4l-js', 'stemforge_loader.v0.js');
 
 function makeSandbox() {
-    const captured = { messnamed: [] };
+    const captured = { outlet: [], messnamed: [] };
     const ctx = createSandbox({
         extras: {
+            outlet: function () {
+                captured.outlet.push(Array.prototype.slice.call(arguments));
+            },
             messnamed: function () {
-                // Capture every (recv, ...args) tuple.
                 captured.messnamed.push(Array.prototype.slice.call(arguments));
             },
             max: { getsystemvariable: () => '/Users/test' },
@@ -36,6 +39,22 @@ function makeSandbox() {
     return { ctx, captured };
 }
 
+// Assert openEditor opened `url` as a Chrome app window via outlet 3.
+function assertAppWindow(captured, url) {
+    assert.ok(captured.outlet.length >= 1, 'openEditor should emit on an outlet');
+    const args = captured.outlet[0].map(String);
+    assert.equal(args[0], '3', 'must use outlet 3 → [shell]');
+    assert.match(args[1], /\/open$/, 'shells `open`');
+    assert.ok(args.includes('-n'), '`-n` forces a new instance so --args applies');
+    assert.ok(args.includes('--args'));
+    assert.ok(args.includes('--app=' + url), 'opens the popup URL as an app window');
+    // Must NOT regress to the old launchbrowser-tab behavior.
+    const usedLaunchBrowser = captured.messnamed.some(
+        (m) => m.indexOf('launchbrowser') !== -1,
+    );
+    assert.ok(!usedLaunchBrowser, 'openEditor must not use launchbrowser');
+}
+
 test('openEditor falls back to default port 7430 when no port file is present', () => {
     maxApi.resetState();
     const { ctx, captured } = makeSandbox();
@@ -43,20 +62,13 @@ test('openEditor falls back to default port 7430 when no port file is present', 
     const url = invoke(ctx, 'openEditor');
 
     assert.equal(url, 'http://127.0.0.1:7430/');
-    assert.ok(captured.messnamed.length >= 1, 'messnamed should fire once');
-    const [recv, verb, payload] = captured.messnamed[0];
-    assert.equal(recv, 'max');
-    assert.equal(verb, 'launchbrowser');
-    assert.equal(payload, 'http://127.0.0.1:7430/');
+    assertAppWindow(captured, 'http://127.0.0.1:7430/');
 });
 
 test('openEditor reads the resolved port from ~/stemforge/.configurator_port', () => {
     maxApi.resetState();
-    // Seed the mock filesystem with the port file at HFS path the loader looks
-    // for: "Macintosh HD:/Users/test/stemforge/.configurator_port".
-    // The mock File constructor converts "Macintosh HD:" → POSIX, then
-    // looks up state.fs[posixPath]. Seed at the POSIX key so the open
-    // succeeds.
+    // Seed the mock filesystem with the port file. The mock File constructor
+    // converts "Macintosh HD:" → POSIX, then looks up state.fs[posixPath].
     const hfsPath = '/Users/test/stemforge/.configurator_port';
     maxApi.seedFile(hfsPath, '7438');
 
@@ -64,14 +76,11 @@ test('openEditor reads the resolved port from ~/stemforge/.configurator_port', (
     const url = invoke(ctx, 'openEditor');
 
     assert.equal(url, 'http://127.0.0.1:7438/');
-    assert.equal(captured.messnamed[0][2], 'http://127.0.0.1:7438/');
+    assertAppWindow(captured, 'http://127.0.0.1:7438/');
 });
 
 test('openEditor falls back when port file contains garbage', () => {
     maxApi.resetState();
-    // The mock File constructor converts "Macintosh HD:" → POSIX, then
-    // looks up state.fs[posixPath]. Seed at the POSIX key so the open
-    // succeeds.
     const hfsPath = '/Users/test/stemforge/.configurator_port';
     maxApi.seedFile(hfsPath, 'not-a-number\n');
 
@@ -80,13 +89,13 @@ test('openEditor falls back when port file contains garbage', () => {
 
     // parseInt would yield NaN; we fall back to the default.
     assert.equal(url, 'http://127.0.0.1:7430/');
-    assert.equal(captured.messnamed[0][2], 'http://127.0.0.1:7430/');
+    assertAppWindow(captured, 'http://127.0.0.1:7430/');
 });
 
 test('_readConfiguratorPort returns null when HOME is unresolvable', () => {
     maxApi.resetState();
     // No `max` global → File.getenv also returns no HOME → null.
-    const ctx = createSandbox({ extras: { messnamed: () => {} } });
+    const ctx = createSandbox({ extras: { messnamed: () => {}, outlet: () => {} } });
     loadModule(ctx, LOADER);
 
     const port = invoke(ctx, '_readConfiguratorPort');

--- a/v0/src/m4l-js/stemforge_loader.v0.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.js
@@ -43,7 +43,7 @@ outlets = 4;   // 0: status text  1: bang  2: preset umenu  3: [shell] (mkdir-p)
 // File.readstring loops (caught during second-UAT run).
 
 // Build fingerprint, injected by tools/inject_build_manifest.py.
-var SF_BUILD_MANIFEST = "build=2026-05-16T14:31 amxd=967a3f8d js={sf_arrangement_loader=4bcd599d,sf_arrangement_reader=b67c502e,sf_clip_export=4b1a9d8c,sf_forge=3d7fcc90,sf_locator_anchor=a3bc63f2,sf_logger=4553d0b2,sf_manifest_loader=10eafd2c,sf_preset_loader=e89b01ab,sf_settings=d7628255,sf_state=e5b4e215,sf_ui=0479c90c,stemforge_bridge=723460c9,stemforge_loader=a0b9d7e7,stemforge_loader.test=7086de36,stemforge_ndjson_parser=2447843f,stemforge_param_scraper=849b1239,stemforge_quadrant_router=a919d46e}";
+var SF_BUILD_MANIFEST = "build=2026-05-16T19:43 amxd=967a3f8d js={sf_arrangement_loader=4bcd599d,sf_arrangement_reader=b67c502e,sf_clip_export=4b1a9d8c,sf_forge=3d7fcc90,sf_locator_anchor=a3bc63f2,sf_logger=4553d0b2,sf_manifest_loader=10eafd2c,sf_preset_loader=e89b01ab,sf_settings=d7628255,sf_state=e5b4e215,sf_ui=0479c90c,stemforge_bridge=723460c9,stemforge_loader=77345a73,stemforge_loader.test=d15bbb07,stemforge_ndjson_parser=2447843f,stemforge_param_scraper=849b1239,stemforge_quadrant_router=a919d46e}";
 
 try {
     post("[sf_loader] " + SF_BUILD_MANIFEST + "\n");
@@ -4520,17 +4520,27 @@ function curationOpened(name) {
  * patcher's `[r sf-open-editor]` receiver.
  *
  * Resolves the configurator server's port from disk (or falls back to
- * 7430 — the start of the server's PORT_RANGE) and asks Max to open the
- * popup URL via the documented `messnamed("max", "launchbrowser", url)`
- * verb. Returns the URL so tests can assert against it without driving
- * `messnamed` through a real Max.
+ * 7430 — the start of the server's PORT_RANGE) and opens the popup as a
+ * Chrome **app window** — a dedicated standalone window, NOT a tab in the
+ * user's main browser. The old `messnamed("max", "launchbrowser", url)`
+ * piled up a fresh tab in the working browser on every click (#129).
+ *
+ * Shelled via outlet 3 → `[shell]` (the same wire bounce uses):
+ *   open -n -a "Google Chrome" --args --app=<url>
+ * `-n` forces a new instance so `--args` actually reaches Chrome — macOS
+ * `open` silently drops `--args` when the target app is already running.
+ *
+ * Returns the URL so tests can assert against it.
  */
 function openEditor() {
     var port = _readConfiguratorPort();
     if (port == null) port = CONFIGURATOR_DEFAULT_PORT;
     var url = "http://" + CONFIGURATOR_HOST + ":" + port + "/";
-    try { messnamed("max", "launchbrowser", url); } catch (e) {
-        try { post("[sf_loader] openEditor messnamed failed: " + e + "\n"); } catch (_) {}
+    try {
+        outlet(3, "/usr/bin/open", "-n", "-a", "Google Chrome",
+            "--args", "--app=" + url);
+    } catch (e) {
+        try { post("[sf_loader] openEditor outlet failed: " + e + "\n"); } catch (_) {}
     }
     status("editor → " + url);
     return url;

--- a/v0/src/m4l-js/stemforge_loader.v0.test.js
+++ b/v0/src/m4l-js/stemforge_loader.v0.test.js
@@ -1722,3 +1722,32 @@ describe("reAnchor() — ANCH button entry", () => {
   });
 });
 
+// ─── openEditor — Chrome app window, not a browser tab (#129) ─────────────────
+//
+// The old openEditor did `messnamed("max", "launchbrowser", url)`, which
+// opened a fresh tab in the user's main browser on every click. It now
+// shells `open -n -a "Google Chrome" --args --app=<url>` via outlet 3 → a
+// dedicated app window, never a tab.
+
+describe("openEditor — opens the popup as a Chrome app window", () => {
+  test("shells an app-mode Chrome open, not a launchbrowser tab", () => {
+    const url = T.openEditor();
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+
+    const shellEmits = outletEmissions.filter((e) => e.idx === 3);
+    expect(shellEmits.length).toBe(1);
+    const args = shellEmits[0].args.map(String);
+    expect(args[0]).toMatch(/\/open$/);
+    expect(args).toContain("-n");
+    expect(args).toContain("--args");
+    expect(args.some((a) => a === "--app=" + url)).toBe(true);
+
+    // Must NOT fall back to launchbrowser (the old new-tab behavior).
+    expect(
+      messnamedCalls.some(
+        (c) => (c.args || []).indexOf("launchbrowser") !== -1
+      )
+    ).toBe(false);
+  });
+});
+

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.js
@@ -43,7 +43,7 @@ outlets = 4;   // 0: status text  1: bang  2: preset umenu  3: [shell] (mkdir-p)
 // File.readstring loops (caught during second-UAT run).
 
 // Build fingerprint, injected by tools/inject_build_manifest.py.
-var SF_BUILD_MANIFEST = "build=2026-05-16T14:31 amxd=967a3f8d js={sf_arrangement_loader=4bcd599d,sf_arrangement_reader=b67c502e,sf_clip_export=4b1a9d8c,sf_forge=3d7fcc90,sf_locator_anchor=a3bc63f2,sf_logger=4553d0b2,sf_manifest_loader=10eafd2c,sf_preset_loader=e89b01ab,sf_settings=d7628255,sf_state=e5b4e215,sf_ui=0479c90c,stemforge_bridge=723460c9,stemforge_loader=a0b9d7e7,stemforge_loader.test=7086de36,stemforge_ndjson_parser=2447843f,stemforge_param_scraper=849b1239,stemforge_quadrant_router=a919d46e}";
+var SF_BUILD_MANIFEST = "build=2026-05-16T19:43 amxd=967a3f8d js={sf_arrangement_loader=4bcd599d,sf_arrangement_reader=b67c502e,sf_clip_export=4b1a9d8c,sf_forge=3d7fcc90,sf_locator_anchor=a3bc63f2,sf_logger=4553d0b2,sf_manifest_loader=10eafd2c,sf_preset_loader=e89b01ab,sf_settings=d7628255,sf_state=e5b4e215,sf_ui=0479c90c,stemforge_bridge=723460c9,stemforge_loader=77345a73,stemforge_loader.test=d15bbb07,stemforge_ndjson_parser=2447843f,stemforge_param_scraper=849b1239,stemforge_quadrant_router=a919d46e}";
 
 try {
     post("[sf_loader] " + SF_BUILD_MANIFEST + "\n");
@@ -4520,17 +4520,27 @@ function curationOpened(name) {
  * patcher's `[r sf-open-editor]` receiver.
  *
  * Resolves the configurator server's port from disk (or falls back to
- * 7430 — the start of the server's PORT_RANGE) and asks Max to open the
- * popup URL via the documented `messnamed("max", "launchbrowser", url)`
- * verb. Returns the URL so tests can assert against it without driving
- * `messnamed` through a real Max.
+ * 7430 — the start of the server's PORT_RANGE) and opens the popup as a
+ * Chrome **app window** — a dedicated standalone window, NOT a tab in the
+ * user's main browser. The old `messnamed("max", "launchbrowser", url)`
+ * piled up a fresh tab in the working browser on every click (#129).
+ *
+ * Shelled via outlet 3 → `[shell]` (the same wire bounce uses):
+ *   open -n -a "Google Chrome" --args --app=<url>
+ * `-n` forces a new instance so `--args` actually reaches Chrome — macOS
+ * `open` silently drops `--args` when the target app is already running.
+ *
+ * Returns the URL so tests can assert against it.
  */
 function openEditor() {
     var port = _readConfiguratorPort();
     if (port == null) port = CONFIGURATOR_DEFAULT_PORT;
     var url = "http://" + CONFIGURATOR_HOST + ":" + port + "/";
-    try { messnamed("max", "launchbrowser", url); } catch (e) {
-        try { post("[sf_loader] openEditor messnamed failed: " + e + "\n"); } catch (_) {}
+    try {
+        outlet(3, "/usr/bin/open", "-n", "-a", "Google Chrome",
+            "--args", "--app=" + url);
+    } catch (e) {
+        try { post("[sf_loader] openEditor outlet failed: " + e + "\n"); } catch (_) {}
     }
     status("editor → " + url);
     return url;

--- a/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.test.js
+++ b/v0/src/m4l-package/StemForge/javascript/stemforge_loader.v0.test.js
@@ -1722,3 +1722,32 @@ describe("reAnchor() — ANCH button entry", () => {
   });
 });
 
+// ─── openEditor — Chrome app window, not a browser tab (#129) ─────────────────
+//
+// The old openEditor did `messnamed("max", "launchbrowser", url)`, which
+// opened a fresh tab in the user's main browser on every click. It now
+// shells `open -n -a "Google Chrome" --args --app=<url>` via outlet 3 → a
+// dedicated app window, never a tab.
+
+describe("openEditor — opens the popup as a Chrome app window", () => {
+  test("shells an app-mode Chrome open, not a launchbrowser tab", () => {
+    const url = T.openEditor();
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+
+    const shellEmits = outletEmissions.filter((e) => e.idx === 3);
+    expect(shellEmits.length).toBe(1);
+    const args = shellEmits[0].args.map(String);
+    expect(args[0]).toMatch(/\/open$/);
+    expect(args).toContain("-n");
+    expect(args).toContain("--args");
+    expect(args.some((a) => a === "--app=" + url)).toBe(true);
+
+    // Must NOT fall back to launchbrowser (the old new-tab behavior).
+    expect(
+      messnamedCalls.some(
+        (c) => (c.args || []).indexOf("launchbrowser") !== -1
+      )
+    ).toBe(false);
+  });
+});
+


### PR DESCRIPTION
Closes #129.

The device's **Open Editor** button ran `messnamed("max", "launchbrowser", url)` — which opens the popup as a new **tab in the main browser** every click. Tabs piled up across a session.

## Fix

`openEditor()` now shells `open -n -a "Google Chrome" --args --app=<url>` via outlet 3 → `[shell]` (the wire bounce already uses). That opens the popup as a dedicated Chrome **app window** — standalone, no tab, not in the working browser.

`-n` is load-bearing: macOS `open` silently drops `--args` when the target app is already running, so without it `--app` never reaches Chrome.

## Tests

- New device-JS test: openEditor emits the app-mode `open` on outlet 3 and does **not** use `launchbrowser`. 106 harness tests pass.
- `.amxd` rebuilt; loader JS synced to the Max Package copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)