### PR TITLE
chore: harden main — fix amxd_pack unpack + lint-clean v0/

### DIFF
--- a/v0/src/A/vendor/kissfft/test/testkiss.py
+++ b/v0/src/A/vendor/kissfft/test/testkiss.py
@@ -8,38 +8,37 @@ from __future__ import absolute_import, division, print_function
 import math
 import sys
 import os
-import random
-import struct
 import getopt
 import numpy as np
 
 po = math.pi
 e = math.e
 do_real = False
-datatype = os.environ.get('KISSFFT_DATATYPE', 'float')
-openmp = os.environ.get('KISSFFT_OPENMP', 'float')
+datatype = os.environ.get("KISSFFT_DATATYPE", "float")
+openmp = os.environ.get("KISSFFT_OPENMP", "float")
 
-util = './fastfilt-' + datatype
+util = "./fastfilt-" + datatype
 
-if openmp == '1' or openmp == 'ON':
-    util = util + '-openmp'
+if openmp == "1" or openmp == "ON":
+    util = util + "-openmp"
 
 minsnr = 90
-if datatype == 'double':
+if datatype == "double":
     dtype = np.float64
-elif datatype == 'float':
+elif datatype == "float":
     dtype = np.float32
-elif datatype == 'int16_t':
+elif datatype == "int16_t":
     dtype = np.int16
     minsnr = 10
-elif datatype == 'int32_t':
+elif datatype == "int32_t":
     dtype = np.int32
-elif datatype == 'simd':
-    sys.stderr.write('testkiss.py does not yet test simd')
+elif datatype == "simd":
+    sys.stderr.write("testkiss.py does not yet test simd")
     sys.exit(0)
 else:
-    sys.stderr.write('unrecognized datatype {0}\n'.format(datatype))
+    sys.stderr.write("unrecognized datatype {0}\n".format(datatype))
     sys.exit(1)
+
 
 def dopack(x):
     if np.iscomplexobj(x):
@@ -48,25 +47,29 @@ def dopack(x):
         x = x.astype(np.float64)
     return x.astype(dtype).tobytes()
 
+
 def dounpack(x, cpx):
     x = np.frombuffer(x, dtype).astype(np.float64)
     if cpx:
         x = x[::2] + 1j * x[1::2]
     return x
 
+
 def make_random(shape):
-    'create random uniform (-1,1) data of the given shape'
+    "create random uniform (-1,1) data of the given shape"
     if do_real:
         return np.random.uniform(-1, 1, shape)
     else:
-        return (np.random.uniform(-1, 1, shape) + 1j * np.random.uniform(-1, 1, shape))
+        return np.random.uniform(-1, 1, shape) + 1j * np.random.uniform(-1, 1, shape)
+
 
 def randmat(ndim):
-    'create a random multidimensional array in range (-1,1)'
+    "create a random multidimensional array in range (-1,1)"
     dims = np.random.randint(2, 5, ndim)
     if do_real:
         dims[-1] = (dims[-1] // 2) * 2  # force even last dimension if real
     return make_random(dims)
+
 
 def test_fft(ndim):
     x = randmat(ndim)
@@ -83,34 +86,36 @@ def test_fft(ndim):
     errpow = np.vdot(errf, errf) + 1e-10
     sigpow = np.vdot(xverf, xverf) + 1e-10
     snr = 10 * math.log10(abs(sigpow / errpow))
-    print('SNR (compared to NumPy) : {0:.1f}dB'.format(float(snr)))
+    print("SNR (compared to NumPy) : {0:.1f}dB".format(float(snr)))
 
     if snr < minsnr:
-        print('xver=', xver)
-        print('x2=', x2)
-        print('err', err)
+        print("xver=", xver)
+        print("x2=", x2)
+        print("err", err)
         sys.exit(1)
+
 
 def dofft(x, isreal):
     dims = list(np.shape(x))
     x = x.ravel()
 
     scale = 1
-    if datatype == 'int16_t':
+    if datatype == "int16_t":
         x = 32767 * x
         scale = len(x) / 32767.0
-    elif datatype == 'int32_t':
+    elif datatype == "int32_t":
         x = 2147483647.0 * x
         scale = len(x) / 2147483647.0
 
-    cmd = util + ' -n '
-    cmd += ','.join([str(d) for d in dims])
+    cmd = util + " -n "
+    cmd += ",".join([str(d) for d in dims])
     if do_real:
-        cmd += ' -R '
+        cmd += " -R "
 
     print(cmd)
 
     from subprocess import Popen, PIPE
+
     p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
 
     p.stdin.write(dopack(x))
@@ -125,15 +130,16 @@ def dofft(x, isreal):
     p.wait()
     return np.reshape(res, dims)
 
+
 def main():
-    opts, args = getopt.getopt(sys.argv[1:], 'r')
+    opts, args = getopt.getopt(sys.argv[1:], "r")
     opts = dict(opts)
     global do_real
-    do_real = '-r' in opts
+    do_real = "-r" in opts
     if do_real:
-        print('Testing multi-dimensional real FFTs')
+        print("Testing multi-dimensional real FFTs")
     else:
-        print('Testing multi-dimensional FFTs')
+        print("Testing multi-dimensional FFTs")
 
     for dim in range(1, 4):
         test_fft(dim)

--- a/v0/src/A0/_apply_static_to_manifest.py
+++ b/v0/src/A0/_apply_static_to_manifest.py
@@ -10,6 +10,7 @@ without any source change to the dispatcher / lookup keys (which are
 The original dynamic-shape ONNX files are LEFT IN PLACE on disk so a
 caller can roll back by running this script with ``--mode dynamic``.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -27,18 +28,18 @@ APP_SUPPORT_MODELS = Path.home() / "Library/Application Support/StemForge/models
 
 # Layout of static files in the worktree.
 STATIC_FILES_WORKTREE = {
-    "htdemucs":          ("htdemucs",     "htdemucs_static.onnx"),
-    "htdemucs_6s":       ("htdemucs_6s",  "htdemucs_6s_static.onnx"),
-    "htdemucs_ft_head0": ("htdemucs_ft",  "htdemucs_ft.head0_static.onnx"),
-    "htdemucs_ft_head1": ("htdemucs_ft",  "htdemucs_ft.head1_static.onnx"),
-    "htdemucs_ft_head2": ("htdemucs_ft",  "htdemucs_ft.head2_static.onnx"),
-    "htdemucs_ft_head3": ("htdemucs_ft",  "htdemucs_ft.head3_static.onnx"),
+    "htdemucs": ("htdemucs", "htdemucs_static.onnx"),
+    "htdemucs_6s": ("htdemucs_6s", "htdemucs_6s_static.onnx"),
+    "htdemucs_ft_head0": ("htdemucs_ft", "htdemucs_ft.head0_static.onnx"),
+    "htdemucs_ft_head1": ("htdemucs_ft", "htdemucs_ft.head1_static.onnx"),
+    "htdemucs_ft_head2": ("htdemucs_ft", "htdemucs_ft.head2_static.onnx"),
+    "htdemucs_ft_head3": ("htdemucs_ft", "htdemucs_ft.head3_static.onnx"),
 }
 
 # Original dynamic file basenames, for rollback or reference.
 DYNAMIC_FILES = {
-    "htdemucs":          "htdemucs.onnx",
-    "htdemucs_6s":       "htdemucs_6s.onnx",
+    "htdemucs": "htdemucs.onnx",
+    "htdemucs_6s": "htdemucs_6s.onnx",
     "htdemucs_ft_head0": "htdemucs_ft.head0.onnx",
     "htdemucs_ft_head1": "htdemucs_ft.head1.onnx",
     "htdemucs_ft_head2": "htdemucs_ft.head2.onnx",
@@ -54,9 +55,9 @@ def _sha256(p: Path) -> str:
     return h.hexdigest()
 
 
-def patch_manifest(mode: str = "static",
-                   target_manifest: Path | None = None,
-                   physical_root: Path | None = None) -> Path:
+def patch_manifest(
+    mode: str = "static", target_manifest: Path | None = None, physical_root: Path | None = None
+) -> Path:
     """
     Update one manifest.json file in place.
 
@@ -82,8 +83,7 @@ def patch_manifest(mode: str = "static",
 
         physical_path = physical_root / subdir / basename
         if not physical_path.exists():
-            print(f"  WARN: physical file missing: {physical_path}",
-                  file=sys.stderr)
+            print(f"  WARN: physical file missing: {physical_path}", file=sys.stderr)
             continue
 
         size = physical_path.stat().st_size
@@ -94,8 +94,8 @@ def patch_manifest(mode: str = "static",
         entry["path"] = rel
         entry["sha256"] = sha
         entry["size"] = size
-        entry["coreml_ep_supported"] = (mode == "static")
-        entry["input_shape_locked"] = (mode == "static")
+        entry["coreml_ep_supported"] = mode == "static"
+        entry["input_shape_locked"] = mode == "static"
         entry.setdefault("notes", "")
         if mode == "static":
             entry["notes"] = (
@@ -112,7 +112,9 @@ def patch_manifest(mode: str = "static",
         # use these shapes, but keep them consistent for future tooling.)
         try:
             import onnx
+
             m = onnx.load(str(physical_path), load_external_data=False)
+
             def _shape(t):
                 dims = []
                 for d in t.type.tensor_type.shape.dim:
@@ -121,14 +123,16 @@ def patch_manifest(mode: str = "static",
                     else:
                         dims.append(d.dim_param or "dynamic")
                 return dims
+
             entry["input_shape"] = {t.name: _shape(t) for t in m.graph.input}
             entry["output_shape"] = {t.name: _shape(t) for t in m.graph.output}
         except Exception as e:
-            print(f"  warn: could not refresh I/O shapes for {key}: {e!s}",
-                  file=sys.stderr)
+            print(f"  warn: could not refresh I/O shapes for {key}: {e!s}", file=sys.stderr)
 
-        print(f"  {key} → {rel} sha={sha[:12]} size={size/1e6:.1f}MB "
-              f"coreml={entry['coreml_ep_supported']}")
+        print(
+            f"  {key} → {rel} sha={sha[:12]} size={size / 1e6:.1f}MB "
+            f"coreml={entry['coreml_ep_supported']}"
+        )
 
     target_manifest.write_text(json.dumps(doc, indent=2) + "\n")
     print(f"\nwrote {target_manifest}")
@@ -138,15 +142,12 @@ def patch_manifest(mode: str = "static",
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--mode", choices=["static", "dynamic"], default="static")
-    p.add_argument("--target",
-                   choices=["worktree", "app-support", "both"],
-                   default="worktree")
+    p.add_argument("--target", choices=["worktree", "app-support", "both"], default="worktree")
     args = p.parse_args(argv)
 
     targets = []
     if args.target in ("worktree", "both"):
-        targets.append(("worktree", SRC_MANIFEST,
-                        WORKTREE / "v0/build/models"))
+        targets.append(("worktree", SRC_MANIFEST, WORKTREE / "v0/build/models"))
     if args.target in ("app-support", "both"):
         # The app-support manifest is normally a symlink — we want to write
         # a real file at the symlink location's resolution.
@@ -161,18 +162,16 @@ def main(argv: list[str] | None = None) -> int:
     for label, mfp, root in targets:
         print(f"\n=== {label}: {mfp}")
         if not mfp.exists() and not mfp.is_symlink():
-            print(f"  skip: not present", file=sys.stderr)
+            print("  skip: not present", file=sys.stderr)
             continue
         # If it's a symlink, follow + edit (matches caller intent: update
         # whatever the binary actually reads).
         if mfp.is_symlink():
             real = mfp.resolve()
             print(f"  symlink → {real} (editing target)")
-            patch_manifest(mode=args.mode, target_manifest=real,
-                           physical_root=real.parent)
+            patch_manifest(mode=args.mode, target_manifest=real, physical_root=real.parent)
         else:
-            patch_manifest(mode=args.mode, target_manifest=mfp,
-                           physical_root=root)
+            patch_manifest(mode=args.mode, target_manifest=mfp, physical_root=root)
     return 0
 
 

--- a/v0/src/A0/ast_export.py
+++ b/v0/src/A0/ast_export.py
@@ -11,6 +11,7 @@ C++ host will replicate the feature extraction (Track A concern). For
 A0 parity, we compare the *model* end-to-end given an identical feature
 tensor.
 """
+
 from __future__ import annotations
 
 import shutil
@@ -28,8 +29,9 @@ AST_LOGIT_DIFF_TOL = config.PARITY.ast_max_logit_diff
 AST_TOPK = config.PARITY.ast_topk_labels
 
 
-def export(dst_dir: Path, checkpoint: str = config.AST_CHECKPOINT,
-           opset: int = config.OPSET_VERSION) -> Path:
+def export(
+    dst_dir: Path, checkpoint: str = config.AST_CHECKPOINT, opset: int = config.OPSET_VERSION
+) -> Path:
     """
     Export AST via optimum. Returns the path to the produced .onnx file.
 
@@ -70,10 +72,9 @@ def export(dst_dir: Path, checkpoint: str = config.AST_CHECKPOINT,
 
 def _load_torch():
     """Return `(model, feature_extractor)` loaded from HF hub."""
-    from transformers import (AutoFeatureExtractor,
-                              AutoModelForAudioClassification)
-    model = AutoModelForAudioClassification.from_pretrained(
-        config.AST_CHECKPOINT).eval()
+    from transformers import AutoFeatureExtractor, AutoModelForAudioClassification
+
+    model = AutoModelForAudioClassification.from_pretrained(config.AST_CHECKPOINT).eval()
     fe = AutoFeatureExtractor.from_pretrained(config.AST_CHECKPOINT)
     return model, fe
 
@@ -81,6 +82,7 @@ def _load_torch():
 def _torch_logits(model, fe, audio_16k_mono: np.ndarray) -> np.ndarray:
     """Run AST forward in torch; return logits over all 527 AudioSet classes."""
     import torch
+
     inputs = fe(audio_16k_mono, sampling_rate=16_000, return_tensors="pt")
     with torch.no_grad():
         out = model(**inputs)
@@ -89,8 +91,7 @@ def _torch_logits(model, fe, audio_16k_mono: np.ndarray) -> np.ndarray:
 
 def _ort_logits(session, fe, audio_16k_mono: np.ndarray) -> np.ndarray:
     inputs = fe(audio_16k_mono, sampling_rate=16_000, return_tensors="np")
-    feed = {k: v for k, v in inputs.items()
-            if k in {i.name for i in session.get_inputs()}}
+    feed = {k: v for k, v in inputs.items() if k in {i.name for i in session.get_inputs()}}
     if not feed:  # model input name is usually "input_values"
         feed = {session.get_inputs()[0].name: list(inputs.values())[0]}
     out = session.run(None, feed)
@@ -117,14 +118,18 @@ class AstParity:
         }
 
 
-def validate(onnx_path: Path, audio_16k_mono: np.ndarray, fixture_name: str,
-             tolerance: float = AST_LOGIT_DIFF_TOL,
-             topk: int = AST_TOPK) -> AstParity:
+def validate(
+    onnx_path: Path,
+    audio_16k_mono: np.ndarray,
+    fixture_name: str,
+    tolerance: float = AST_LOGIT_DIFF_TOL,
+    topk: int = AST_TOPK,
+) -> AstParity:
     """Run torch + onnx forward, compare top-k and logit residual."""
     import onnxruntime as ort
+
     model, fe = _load_torch()
-    session = ort.InferenceSession(str(onnx_path),
-                                   providers=["CPUExecutionProvider"])
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
     with Timer("ast.validate.torch"):
         torch_logits = _torch_logits(model, fe, audio_16k_mono)
     with Timer("ast.validate.onnx"):

--- a/v0/src/A0/clap_export.py
+++ b/v0/src/A0/clap_export.py
@@ -10,10 +10,10 @@ embeddings → softmax → top-1 genre.
 Parity target: cosine similarity ≥ 0.999 between torch and ONNX audio
 embeddings on the full GENRE_LABELS eval set.
 """
+
 from __future__ import annotations
 
 import json
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -44,8 +44,9 @@ GENRE_LABELS = [
 ]
 
 
-def export(dst_dir: Path, checkpoint: str = config.CLAP_CHECKPOINT,
-           opset: int = config.OPSET_VERSION) -> Path:
+def export(
+    dst_dir: Path, checkpoint: str = config.CLAP_CHECKPOINT, opset: int = config.OPSET_VERSION
+) -> Path:
     """
     Export CLAP audio-branch directly via `torch.onnx.export`.
 
@@ -66,7 +67,7 @@ def export(dst_dir: Path, checkpoint: str = config.CLAP_CHECKPOINT,
             super().__init__()
             self.clap = clap
 
-        def forward(self, input_features, is_longer):   # type: ignore[no-untyped-def]
+        def forward(self, input_features, is_longer):  # type: ignore[no-untyped-def]
             return self.clap.get_audio_features(
                 input_features=input_features,
                 is_longer=is_longer,
@@ -93,8 +94,7 @@ def export(dst_dir: Path, checkpoint: str = config.CLAP_CHECKPOINT,
             str(canonical),
             input_names=["input_features", "is_longer"],
             output_names=["audio_embed"],
-            dynamic_axes={"input_features": {0: "batch"},
-                          "is_longer":      {0: "batch"}},
+            dynamic_axes={"input_features": {0: "batch"}, "is_longer": {0: "batch"}},
             opset_version=opset,
             do_constant_folding=True,
             dynamo=False,
@@ -138,23 +138,20 @@ def bake_genre_embeddings(dst_path: Path) -> Path:
     return dst_path
 
 
-def _torch_audio_embedding(model, processor, audio_48k_mono: np.ndarray
-                           ) -> np.ndarray:
+def _torch_audio_embedding(model, processor, audio_48k_mono: np.ndarray) -> np.ndarray:
     import torch
-    inputs = processor(audios=audio_48k_mono, sampling_rate=48_000,
-                       return_tensors="pt")
+
+    inputs = processor(audios=audio_48k_mono, sampling_rate=48_000, return_tensors="pt")
     with torch.no_grad():
         feat = model.get_audio_features(**inputs)
     feat = feat / feat.norm(dim=-1, keepdim=True).clamp_min(1e-12)
     return feat.numpy()[0]
 
 
-def _ort_audio_embedding(session, processor, audio_48k_mono: np.ndarray
-                         ) -> np.ndarray:
+def _ort_audio_embedding(session, processor, audio_48k_mono: np.ndarray) -> np.ndarray:
     # Processor in NumPy mode returns `input_features` as float32 and
     # `is_longer` as bool; ORT session wants them verbatim.
-    inputs = processor(audios=audio_48k_mono, sampling_rate=48_000,
-                       return_tensors="np")
+    inputs = processor(audios=audio_48k_mono, sampling_rate=48_000, return_tensors="np")
     wanted = {i.name for i in session.get_inputs()}
     feed = {k: np.asarray(v) for k, v in inputs.items() if k in wanted}
     out = session.run(None, feed)
@@ -174,13 +171,15 @@ class ClapParity:
     passed: bool
 
     def as_dict(self) -> dict[str, Any]:
-        return {"fixture": self.fixture,
-                "cosine": round(self.cosine, 6),
-                "passed": self.passed}
+        return {"fixture": self.fixture, "cosine": round(self.cosine, 6), "passed": self.passed}
 
 
-def validate(onnx_path: Path, audio_48k_mono: np.ndarray, fixture_name: str,
-             min_cosine: float = config.PARITY.clap_min_cosine) -> ClapParity:
+def validate(
+    onnx_path: Path,
+    audio_48k_mono: np.ndarray,
+    fixture_name: str,
+    min_cosine: float = config.PARITY.clap_min_cosine,
+) -> ClapParity:
     """
     Compare torch vs ONNX audio embeddings on identical preprocessor output.
 
@@ -197,14 +196,12 @@ def validate(onnx_path: Path, audio_48k_mono: np.ndarray, fixture_name: str,
 
     model = ClapModel.from_pretrained(config.CLAP_CHECKPOINT).eval()
     processor = ClapProcessor.from_pretrained(config.CLAP_CHECKPOINT)
-    session = ort.InferenceSession(str(onnx_path),
-                                   providers=["CPUExecutionProvider"])
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
 
     # Seed before the processor runs so repeated validations are deterministic.
     torch.manual_seed(0)
     np.random.seed(0)
-    pp = processor(audios=audio_48k_mono, sampling_rate=48_000,
-                   return_tensors="pt")
+    pp = processor(audios=audio_48k_mono, sampling_rate=48_000, return_tensors="pt")
 
     with Timer("clap.validate.torch"):
         with torch.no_grad():
@@ -215,15 +212,14 @@ def validate(onnx_path: Path, audio_48k_mono: np.ndarray, fixture_name: str,
     torch_emb = torch_emb / (np.linalg.norm(torch_emb) + 1e-12)
 
     with Timer("clap.validate.onnx"):
-        feed = {i.name: np.asarray(pp[i.name].numpy()
-                                   if hasattr(pp[i.name], "numpy")
-                                   else pp[i.name])
-                for i in session.get_inputs()}
+        feed = {
+            i.name: np.asarray(pp[i.name].numpy() if hasattr(pp[i.name], "numpy") else pp[i.name])
+            for i in session.get_inputs()
+        }
         onnx_emb = np.asarray(session.run(None, feed)[0])
     if onnx_emb.ndim > 1:
         onnx_emb = onnx_emb[0]
     onnx_emb = onnx_emb / (np.linalg.norm(onnx_emb) + 1e-12)
 
     cos = float(np.dot(torch_emb, onnx_emb))
-    return ClapParity(fixture=fixture_name, cosine=cos,
-                      passed=cos >= min_cosine)
+    return ClapParity(fixture=fixture_name, cosine=cos, passed=cos >= min_cosine)

--- a/v0/src/A0/config.py
+++ b/v0/src/A0/config.py
@@ -5,6 +5,7 @@ All path/name/threshold constants live here so `convert.py`, `validate.py`,
 and the tests agree on the same values. Keep this module dependency-free
 (no torch, no onnx imports) so it is cheap to load from the test suite.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -16,7 +17,7 @@ from pathlib import Path
 # `v0/src/A0/config.py` → parents[3] is the repo root.
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-A0_SRC_DIR   = REPO_ROOT / "v0" / "src" / "A0"
+A0_SRC_DIR = REPO_ROOT / "v0" / "src" / "A0"
 A0_STATE_DIR = REPO_ROOT / "v0" / "state" / "A0"
 BUILD_MODELS_DIR = REPO_ROOT / "v0" / "build" / "models"
 
@@ -24,13 +25,13 @@ BUILD_MODELS_DIR = REPO_ROOT / "v0" / "build" / "models"
 ORT_CACHE_DIR = BUILD_MODELS_DIR / "ort_cache"
 
 # Files written to v0/state/A0/
-STATE_PROGRESS_NDJSON      = A0_STATE_DIR / "progress.ndjson"
-STATE_ARTIFACTS_JSON       = A0_STATE_DIR / "artifacts.json"
-STATE_VALIDATION_REPORT    = A0_STATE_DIR / "validation_report.json"
-STATE_FP16_REPORT_MD       = A0_STATE_DIR / "fp16_report.md"
-STATE_PERF_JSON            = A0_STATE_DIR / "perf.json"
-STATE_DONE_FLAG            = A0_STATE_DIR / "done.flag"
-STATE_BLOCKER_MD           = A0_STATE_DIR / "blocker.md"
+STATE_PROGRESS_NDJSON = A0_STATE_DIR / "progress.ndjson"
+STATE_ARTIFACTS_JSON = A0_STATE_DIR / "artifacts.json"
+STATE_VALIDATION_REPORT = A0_STATE_DIR / "validation_report.json"
+STATE_FP16_REPORT_MD = A0_STATE_DIR / "fp16_report.md"
+STATE_PERF_JSON = A0_STATE_DIR / "perf.json"
+STATE_DONE_FLAG = A0_STATE_DIR / "done.flag"
+STATE_BLOCKER_MD = A0_STATE_DIR / "blocker.md"
 
 MANIFEST_PATH = BUILD_MODELS_DIR / "manifest.json"
 
@@ -39,9 +40,9 @@ MANIFEST_PATH = BUILD_MODELS_DIR / "manifest.json"
 
 DEMUCS_MODELS = {
     # key                # (torch_ref_checkpoint, onnx_filename, priority,     purpose)
-    "htdemucs_ft":  ("htdemucs_ft",  "htdemucs_ft.onnx",  "primary",   "fine-tuned 4-stem"),
-    "htdemucs_6s":  ("htdemucs_6s",  "htdemucs_6s.onnx",  "secondary", "6-stem (guitar+piano)"),
-    "htdemucs":     ("htdemucs",     "htdemucs.onnx",     "fallback",  "base 4-stem"),
+    "htdemucs_ft": ("htdemucs_ft", "htdemucs_ft.onnx", "primary", "fine-tuned 4-stem"),
+    "htdemucs_6s": ("htdemucs_6s", "htdemucs_6s.onnx", "secondary", "6-stem (guitar+piano)"),
+    "htdemucs": ("htdemucs", "htdemucs.onnx", "fallback", "base 4-stem"),
 }
 
 CLAP_CHECKPOINT = "laion/clap-htsat-unfused"
@@ -64,14 +65,15 @@ AST_ONNX_FILENAME = "ast_audioset.onnx"
 # Wider tolerances are acceptable with a listening test; any loosened value
 # must be recorded explicitly in `validation_report.json`.
 
+
 @dataclass(frozen=True)
 class ParityTargets:
     demucs_max_abs_err: float = 1.0e-3
     demucs_max_rel_err: float = 1.0e-2
-    clap_min_cosine:     float = 0.999
-    ast_max_logit_diff:  float = 1.0e-3
-    ast_topk_labels:     int   = 5
-    fp16_null_rms_dbfs_max: float = -60.0   # stricter = more negative
+    clap_min_cosine: float = 0.999
+    ast_max_logit_diff: float = 1.0e-3
+    ast_topk_labels: int = 5
+    fp16_null_rms_dbfs_max: float = -60.0  # stricter = more negative
 
 
 PARITY = ParityTargets()

--- a/v0/src/A0/convert.py
+++ b/v0/src/A0/convert.py
@@ -17,6 +17,7 @@ Progress streams to `v0/state/A0/progress.ndjson` per SHARED.md. On completion
 `convert.py` writes either `done.flag` (if every required model succeeds) or
 `blocker.md` (if any required model fails and no graceful fallback exists).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -27,8 +28,18 @@ from pathlib import Path
 
 import numpy as np
 
-from . import (ast_export, clap_export, config, coreml_probe, demucs_export,
-               fixtures, fp16, manifest, progress, quantize)
+from . import (
+    ast_export,
+    clap_export,
+    config,
+    coreml_probe,
+    demucs_export,
+    fixtures,
+    fp16,
+    manifest,
+    progress,
+    quantize,
+)
 
 
 REQUIRED_MODELS = ("ast", "clap", "demucs")
@@ -36,17 +47,19 @@ REQUIRED_MODELS = ("ast", "clap", "demucs")
 
 # ── Helpers to run small inference batches for fp16 null-tests ──────────────
 
+
 def _run_ast(onnx_path: Path) -> dict[str, np.ndarray]:
     import onnxruntime as ort
     import torch
     from transformers import AutoFeatureExtractor
-    session = ort.InferenceSession(str(onnx_path),
-                                   providers=["CPUExecutionProvider"])
+
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
     fe = AutoFeatureExtractor.from_pretrained(config.AST_CHECKPOINT)
     out = {}
     for fx in fixtures.all_fixtures():
         mono = fx.samples.mean(axis=0).astype(np.float32)
         import librosa
+
         y = librosa.resample(mono, orig_sr=fx.sr, target_sr=16_000)
         torch.manual_seed(0)
         np.random.seed(0)
@@ -70,13 +83,14 @@ def _run_clap(onnx_path: Path) -> dict[str, np.ndarray]:
     import onnxruntime as ort
     import torch
     from transformers import ClapProcessor
-    session = ort.InferenceSession(str(onnx_path),
-                                   providers=["CPUExecutionProvider"])
+
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
     processor = ClapProcessor.from_pretrained(config.CLAP_CHECKPOINT)
     out = {}
     for fx in fixtures.all_fixtures():
         mono = fx.samples.mean(axis=0).astype(np.float32)
         import librosa
+
         y = librosa.resample(mono, orig_sr=fx.sr, target_sr=48_000)
         torch.manual_seed(0)
         np.random.seed(0)
@@ -92,8 +106,10 @@ def _run_clap(onnx_path: Path) -> dict[str, np.ndarray]:
 
 # ── Per-model driver ────────────────────────────────────────────────────────
 
-def _convert_ast(manifest_entries: dict, validation_entries: dict,
-                 fp16_attempts: list, quant_attempts: list) -> bool:
+
+def _convert_ast(
+    manifest_entries: dict, validation_entries: dict, fp16_attempts: list, quant_attempts: list
+) -> bool:
     progress.emit("ast", 10, "downloading + exporting")
     dst_dir = config.BUILD_MODELS_DIR / "ast"
     try:
@@ -107,23 +123,26 @@ def _convert_ast(manifest_entries: dict, validation_entries: dict,
     fixture_parities = []
     for fx in fixtures.all_fixtures():
         import librosa
+
         mono = fx.samples.mean(axis=0).astype(np.float32)
         y16 = librosa.resample(mono, orig_sr=fx.sr, target_sr=16_000)
         p = ast_export.validate(onnx_path, y16, fx.name)
         fixture_parities.append(p.as_dict())
         parity_pass &= p.passed
-        progress.emit("ast", 30,
-                      f"parity {fx.name}: logit_diff={p.max_logit_diff:.4e} "
-                      f"labels_match={p.labels_match} pass={p.passed}")
-    validation_entries["ast"] = {"passed": parity_pass,
-                                 "fixtures": fixture_parities}
+        progress.emit(
+            "ast",
+            30,
+            f"parity {fx.name}: logit_diff={p.max_logit_diff:.4e} "
+            f"labels_match={p.labels_match} pass={p.passed}",
+        )
+    validation_entries["ast"] = {"passed": parity_pass, "fixtures": fixture_parities}
 
     # CoreML probe — needs the model's real input spec.
     # Build a synthetic input matching AST's expected shape.
     try:
         import onnxruntime as ort
-        tmp_sess = ort.InferenceSession(str(onnx_path),
-                                        providers=["CPUExecutionProvider"])
+
+        tmp_sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
         probe_inputs = {}
         for inp in tmp_sess.get_inputs():
             shape = [d if isinstance(d, int) and d > 0 else 1 for d in inp.shape]
@@ -132,14 +151,18 @@ def _convert_ast(manifest_entries: dict, validation_entries: dict,
         probe_inputs = {}
         progress.emit("ast", 40, f"probe input build failed: {e!s}")
 
-    cml = coreml_probe.probe(onnx_path, "ast_audioset", probe_inputs) \
-        if probe_inputs else coreml_probe.CoreMLProbe(
-            "ast_audioset", str(onnx_path))
+    cml = (
+        coreml_probe.probe(onnx_path, "ast_audioset", probe_inputs)
+        if probe_inputs
+        else coreml_probe.CoreMLProbe("ast_audioset", str(onnx_path))
+    )
 
     # fp16 attempt.
     fp16_path = dst_dir / "ast_audioset.fp16.onnx"
     fp16_result = fp16.attempt_fp16(
-        onnx_path, fp16_path, "ast_audioset",
+        onnx_path,
+        fp16_path,
+        "ast_audioset",
         run_fn=_run_ast,
         fixture_names=[fx.name for fx in fixtures.all_fixtures()],
     )
@@ -155,11 +178,18 @@ def _convert_ast(manifest_entries: dict, validation_entries: dict,
         # Real caller should supply a 200-sample evaluator.
         def eval_top1(path: Path) -> float:
             out = _run_ast(path)
-            return float(np.mean([np.argmax(v) == np.argmax(out[fx.name])
-                                  for fx, v in zip(fixtures.all_fixtures(),
-                                                   out.values())]))
-        q = quantize.attempt_int8(final_onnx, int8_path, "ast_audioset",
-                                  eval_fn=eval_top1, min_samples=2)
+            return float(
+                np.mean(
+                    [
+                        np.argmax(v) == np.argmax(out[fx.name])
+                        for fx, v in zip(fixtures.all_fixtures(), out.values())
+                    ]
+                )
+            )
+
+        q = quantize.attempt_int8(
+            final_onnx, int8_path, "ast_audioset", eval_fn=eval_top1, min_samples=2
+        )
         quant_attempts.append(q)
         if q.passed and q.int8_path:
             precision = "int8-dynamic"
@@ -172,22 +202,21 @@ def _convert_ast(manifest_entries: dict, validation_entries: dict,
     manifest_entries["ast_audioset"] = manifest.build_entry(
         final_onnx,
         torch_ref_checkpoint=config.AST_CHECKPOINT,
-        max_abs_err=max((p["max_logit_diff"] for p in fixture_parities),
-                        default=0.0),
+        max_abs_err=max((p["max_logit_diff"] for p in fixture_parities), default=0.0),
         max_rel_err=0.0,
         precision=precision,
         coreml_ep_supported=cml.coreml_loaded,
         cpu_fallback_ops=cml.cpu_fallback_ops,
-        optimized_cache=(Path(cml.optimized_cache_path)
-                         if cml.optimized_cache_path else None),
+        optimized_cache=(Path(cml.optimized_cache_path) if cml.optimized_cache_path else None),
         notes="audio classifier; top-5 labels must match",
     )
     progress.emit("ast", 100, f"done, precision={precision}")
     return parity_pass
 
 
-def _convert_clap(manifest_entries: dict, validation_entries: dict,
-                  fp16_attempts: list, quant_attempts: list) -> bool:
+def _convert_clap(
+    manifest_entries: dict, validation_entries: dict, fp16_attempts: list, quant_attempts: list
+) -> bool:
     progress.emit("clap", 10, "downloading + exporting")
     dst_dir = config.BUILD_MODELS_DIR / "clap"
     try:
@@ -198,11 +227,13 @@ def _convert_clap(manifest_entries: dict, validation_entries: dict,
 
     try:
         clap_export.bake_genre_embeddings(
-            config.BUILD_MODELS_DIR / config.CLAP_GENRE_EMBEDDINGS_FILENAME)
+            config.BUILD_MODELS_DIR / config.CLAP_GENRE_EMBEDDINGS_FILENAME
+        )
     except Exception as e:
         progress.emit("clap", 15, f"genre embedding bake failed: {e!s}")
 
     import librosa
+
     parity_pass = True
     fixture_parities = []
     for fx in fixtures.all_fixtures():
@@ -211,16 +242,14 @@ def _convert_clap(manifest_entries: dict, validation_entries: dict,
         p = clap_export.validate(onnx_path, y48, fx.name)
         fixture_parities.append(p.as_dict())
         parity_pass &= p.passed
-        progress.emit("clap", 30, f"parity {fx.name}: cos={p.cosine:.6f} "
-                                  f"pass={p.passed}")
-    validation_entries["clap"] = {"passed": parity_pass,
-                                  "fixtures": fixture_parities}
+        progress.emit("clap", 30, f"parity {fx.name}: cos={p.cosine:.6f} pass={p.passed}")
+    validation_entries["clap"] = {"passed": parity_pass, "fixtures": fixture_parities}
 
     # CoreML probe.
     try:
         import onnxruntime as ort
-        tmp_sess = ort.InferenceSession(str(onnx_path),
-                                        providers=["CPUExecutionProvider"])
+
+        tmp_sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
         probe_inputs = {}
         for inp in tmp_sess.get_inputs():
             shape = [d if isinstance(d, int) and d > 0 else 1 for d in inp.shape]
@@ -229,42 +258,41 @@ def _convert_clap(manifest_entries: dict, validation_entries: dict,
         probe_inputs = {}
         progress.emit("clap", 40, f"probe input build failed: {e!s}")
 
-    cml = coreml_probe.probe(onnx_path, "clap_htsat_unfused", probe_inputs) \
-        if probe_inputs else coreml_probe.CoreMLProbe(
-            "clap_htsat_unfused", str(onnx_path))
+    cml = (
+        coreml_probe.probe(onnx_path, "clap_htsat_unfused", probe_inputs)
+        if probe_inputs
+        else coreml_probe.CoreMLProbe("clap_htsat_unfused", str(onnx_path))
+    )
 
     fp16_path = dst_dir / "clap.fp16.onnx"
     fp16_result = fp16.attempt_fp16(
-        onnx_path, fp16_path, "clap_htsat_unfused",
+        onnx_path,
+        fp16_path,
+        "clap_htsat_unfused",
         run_fn=_run_clap,
         fixture_names=[fx.name for fx in fixtures.all_fixtures()],
     )
     fp16_attempts.append(fp16_result)
     precision = "fp16" if fp16_result.all_passed else "fp32"
     final_onnx = fp16_path if fp16_result.all_passed else onnx_path
-    progress.emit("clap", 60,
-                  f"fp16 {'shipped' if fp16_result.all_passed else 'fp32 fallback'}")
+    progress.emit("clap", 60, f"fp16 {'shipped' if fp16_result.all_passed else 'fp32 fallback'}")
 
     manifest_entries["clap_htsat_unfused"] = manifest.build_entry(
         final_onnx,
         torch_ref_checkpoint=config.CLAP_CHECKPOINT,
         max_abs_err=0.0,
-        max_rel_err=1.0 - min((p["cosine"] for p in fixture_parities),
-                              default=1.0),
+        max_rel_err=1.0 - min((p["cosine"] for p in fixture_parities), default=1.0),
         precision=precision,
         coreml_ep_supported=cml.coreml_loaded,
         cpu_fallback_ops=cml.cpu_fallback_ops,
-        optimized_cache=(Path(cml.optimized_cache_path)
-                         if cml.optimized_cache_path else None),
-        notes="audio branch only; genre text embeddings are baked into "
-              "clap_genre_embeddings.json",
+        optimized_cache=(Path(cml.optimized_cache_path) if cml.optimized_cache_path else None),
+        notes="audio branch only; genre text embeddings are baked into clap_genre_embeddings.json",
     )
     progress.emit("clap", 100, f"done, precision={precision}")
     return parity_pass
 
 
-def _convert_demucs(manifest_entries: dict, validation_entries: dict,
-                    fp16_attempts: list) -> bool:
+def _convert_demucs(manifest_entries: dict, validation_entries: dict, fp16_attempts: list) -> bool:
     """
     Run the Demucs export attempt and record the blocker.
 
@@ -273,58 +301,67 @@ def _convert_demucs(manifest_entries: dict, validation_entries: dict,
     docstring in demucs_export.py). The external-STFT refactor is the
     recommended path and is handed off via blocker.md.
     """
-    import torch
     from demucs.pretrained import get_model
 
     attempted = []
     any_success = False
 
-    for key, (ckpt, onnx_filename, priority, desc) in \
-            config.DEMUCS_MODELS.items():
+    for key, (ckpt, onnx_filename, priority, desc) in config.DEMUCS_MODELS.items():
         progress.emit(f"demucs.{key}", 5, f"loading torch ref {ckpt} ({desc})")
         try:
             bag = get_model(ckpt)
         except Exception as e:
             progress.emit(f"demucs.{key}", 0, f"torch ref load failed: {e!s}")
-            attempted.append({"model": key, "status": "load_failed",
-                              "error": str(e)[:500]})
+            attempted.append({"model": key, "status": "load_failed", "error": str(e)[:500]})
             continue
 
         n_heads = len(bag.models)
         for head_idx, head in enumerate(bag.models):
             head = head.eval()
             seg_samples = demucs_export.segment_samples_for(head)
-            head_onnx = (config.BUILD_MODELS_DIR / key /
-                         (onnx_filename if n_heads == 1 else
-                          f"{Path(onnx_filename).stem}.head{head_idx}.onnx"))
-            progress.emit(f"demucs.{key}", 20 + 15 * head_idx,
-                          f"attempting in-graph export head {head_idx+1}/{n_heads}")
+            head_onnx = (
+                config.BUILD_MODELS_DIR
+                / key
+                / (
+                    onnx_filename
+                    if n_heads == 1
+                    else f"{Path(onnx_filename).stem}.head{head_idx}.onnx"
+                )
+            )
+            progress.emit(
+                f"demucs.{key}",
+                20 + 15 * head_idx,
+                f"attempting in-graph export head {head_idx + 1}/{n_heads}",
+            )
 
-            ok, err = demucs_export.attempt_in_graph_export(
-                head, head_onnx, seg_samples)
-            attempted.append({"model": key, "head": head_idx,
-                              "segment_samples": seg_samples,
-                              "in_graph_ok": ok, "error": err})
+            ok, err = demucs_export.attempt_in_graph_export(head, head_onnx, seg_samples)
+            attempted.append(
+                {
+                    "model": key,
+                    "head": head_idx,
+                    "segment_samples": seg_samples,
+                    "in_graph_ok": ok,
+                    "error": err,
+                }
+            )
 
             if ok:
                 any_success = True
                 # Record into manifest even if partial.
                 try:
-                    manifest_entries[f"{key}_head{head_idx}"] = \
-                        manifest.build_entry(
-                            head_onnx,
-                            torch_ref_checkpoint=ckpt,
-                            max_abs_err=float("nan"),
-                            max_rel_err=float("nan"),
-                            precision="fp32",
-                            coreml_ep_supported=False,
-                            cpu_fallback_ops=[],
-                            optimized_cache=None,
-                            notes="in-graph STFT export succeeded — validate "
-                                  "parity before shipping")
+                    manifest_entries[f"{key}_head{head_idx}"] = manifest.build_entry(
+                        head_onnx,
+                        torch_ref_checkpoint=ckpt,
+                        max_abs_err=float("nan"),
+                        max_rel_err=float("nan"),
+                        precision="fp32",
+                        coreml_ep_supported=False,
+                        cpu_fallback_ops=[],
+                        optimized_cache=None,
+                        notes="in-graph STFT export succeeded — validate parity before shipping",
+                    )
                 except Exception as e:
-                    progress.emit(f"demucs.{key}", 30,
-                                  f"manifest build failed: {e!s}")
+                    progress.emit(f"demucs.{key}", 30, f"manifest build failed: {e!s}")
 
     validation_entries["demucs"] = {
         "passed": False,
@@ -336,15 +373,20 @@ def _convert_demucs(manifest_entries: dict, validation_entries: dict,
 
 # ── CLI ─────────────────────────────────────────────────────────────────────
 
+
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Track A0 — ONNX conversion")
-    p.add_argument("--models", nargs="*", default=list(REQUIRED_MODELS),
-                   choices=REQUIRED_MODELS,
-                   help="Which model families to convert.")
-    p.add_argument("--branch", default="feat/v0-A0-onnx",
-                   help="Branch recorded in done.flag.")
-    p.add_argument("--dry-run", action="store_true",
-                   help="Validate imports + fixtures only; no downloads.")
+    p.add_argument(
+        "--models",
+        nargs="*",
+        default=list(REQUIRED_MODELS),
+        choices=REQUIRED_MODELS,
+        help="Which model families to convert.",
+    )
+    p.add_argument("--branch", default="feat/v0-A0-onnx", help="Branch recorded in done.flag.")
+    p.add_argument(
+        "--dry-run", action="store_true", help="Validate imports + fixtures only; no downloads."
+    )
     return p.parse_args(argv)
 
 
@@ -360,41 +402,38 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.dry_run:
         for fx in fixtures.all_fixtures():
-            progress.emit("dry-run", 50, f"fixture ok: {fx.name} "
-                                         f"shape={fx.samples.shape} sr={fx.sr}")
+            progress.emit(
+                "dry-run", 50, f"fixture ok: {fx.name} shape={fx.samples.shape} sr={fx.sr}"
+            )
         progress.emit("dry-run", 100, "imports validated, exiting")
         return 0
 
     results: dict[str, bool] = {}
     if "ast" in args.models:
         try:
-            results["ast"] = _convert_ast(manifest_entries, validation_entries,
-                                          fp16_attempts, quant_attempts)
+            results["ast"] = _convert_ast(
+                manifest_entries, validation_entries, fp16_attempts, quant_attempts
+            )
         except Exception as e:
-            progress.emit("ast", 0,
-                          f"uncaught error: {type(e).__name__}: {e!s}")
+            progress.emit("ast", 0, f"uncaught error: {type(e).__name__}: {e!s}")
             results["ast"] = False
             traceback.print_exc(file=sys.stderr)
 
     if "clap" in args.models:
         try:
-            results["clap"] = _convert_clap(manifest_entries,
-                                            validation_entries,
-                                            fp16_attempts, quant_attempts)
+            results["clap"] = _convert_clap(
+                manifest_entries, validation_entries, fp16_attempts, quant_attempts
+            )
         except Exception as e:
-            progress.emit("clap", 0,
-                          f"uncaught error: {type(e).__name__}: {e!s}")
+            progress.emit("clap", 0, f"uncaught error: {type(e).__name__}: {e!s}")
             results["clap"] = False
             traceback.print_exc(file=sys.stderr)
 
     if "demucs" in args.models:
         try:
-            results["demucs"] = _convert_demucs(manifest_entries,
-                                                validation_entries,
-                                                fp16_attempts)
+            results["demucs"] = _convert_demucs(manifest_entries, validation_entries, fp16_attempts)
         except Exception as e:
-            progress.emit("demucs", 0,
-                          f"uncaught error: {type(e).__name__}: {e!s}")
+            progress.emit("demucs", 0, f"uncaught error: {type(e).__name__}: {e!s}")
             results["demucs"] = False
             traceback.print_exc(file=sys.stderr)
 
@@ -407,22 +446,21 @@ def main(argv: list[str] | None = None) -> int:
         fp16.write_fp16_report(config.STATE_FP16_REPORT_MD, fp16_attempts)
 
     duration = time.perf_counter() - t0
-    all_required_ok = all(results.get(m, False) for m in REQUIRED_MODELS
-                          if m in args.models)
+    all_required_ok = all(results.get(m, False) for m in REQUIRED_MODELS if m in args.models)
 
     artifacts = [str(config.MANIFEST_PATH.resolve().relative_to(config.REPO_ROOT))]
     for entry in manifest_entries.values():
         artifacts.append(entry["path"])
 
     if all_required_ok:
-        progress.write_artifacts("complete", [{"path": p} for p in artifacts],
-                                 duration, results=results)
-        progress.write_done_flag(args.branch, artifacts,
-                                 notes=f"results={results}")
+        progress.write_artifacts(
+            "complete", [{"path": p} for p in artifacts], duration, results=results
+        )
+        progress.write_done_flag(args.branch, artifacts, notes=f"results={results}")
     else:
-        progress.write_artifacts("blocked",
-                                 [{"path": p} for p in artifacts],
-                                 duration, results=results)
+        progress.write_artifacts(
+            "blocked", [{"path": p} for p in artifacts], duration, results=results
+        )
         # blocker.md is written by the main orchestrator callsite if this
         # is running as the authoritative track entry — see run.sh.
 
@@ -432,6 +470,7 @@ def main(argv: list[str] | None = None) -> int:
 
 def _write_validation_report(validation, fp16_attempts, quant_attempts):
     import json
+
     config.A0_STATE_DIR.mkdir(parents=True, exist_ok=True)
     doc = {
         "validation": validation,

--- a/v0/src/A0/coreml_probe.py
+++ b/v0/src/A0/coreml_probe.py
@@ -17,13 +17,14 @@ running a single-inference forward pass with timing. The brief requires
 wall-clock latency on a 30-second stereo @ 44.1 kHz input; the concrete
 input shape is model-specific so the caller passes it via `probe_inputs`.
 """
+
 from __future__ import annotations
 
 import os
 import time
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 import numpy as np
 
@@ -77,13 +78,12 @@ def _coreml_providers() -> list:
         # Keep models that touch dynamic shapes on CPU inside the EP itself.
         "RequireStaticInputShapes": "0",
     }
-    return [("CoreMLExecutionProvider", coreml_opts),
-            "CPUExecutionProvider"]
+    return [("CoreMLExecutionProvider", coreml_opts), "CPUExecutionProvider"]
 
 
-def probe(onnx_path: Path, model_name: str,
-          probe_inputs: dict[str, np.ndarray],
-          runs: int = 1) -> CoreMLProbe:
+def probe(
+    onnx_path: Path, model_name: str, probe_inputs: dict[str, np.ndarray], runs: int = 1
+) -> CoreMLProbe:
     """
     Load `onnx_path` on CoreML EP and CPU-only. Measure single-inference
     wall clock for each. Record any ops that fell back.
@@ -103,7 +103,8 @@ def probe(onnx_path: Path, model_name: str,
 
     try:
         sess_cpu = ort.InferenceSession(
-            str(onnx_path), sess_options=so,
+            str(onnx_path),
+            sess_options=so,
             providers=["CPUExecutionProvider"],
         )
     except Exception as e:
@@ -121,7 +122,8 @@ def probe(onnx_path: Path, model_name: str,
     # with "CoreML refused to load at all".
     try:
         sess_cml = ort.InferenceSession(
-            str(onnx_path), sess_options=so,
+            str(onnx_path),
+            sess_options=so,
             providers=_coreml_providers(),
         )
         res.providers_resolved = list(sess_cml.get_providers())
@@ -172,9 +174,14 @@ def _collect_cpu_fallback_ops(onnx_path: Path, model_name: str) -> list[str]:
     # This list is intentionally conservative; Track A should replace it with
     # the runtime-captured assignment log on first launch.
     unsupported_hint = {
-        "STFT", "ISTFT", "SpectrogramExtractor", "MFCC",
-        "ComplexMul", "RealCosineTransform",
-        "NonMaxSuppression", "CumSum",
+        "STFT",
+        "ISTFT",
+        "SpectrogramExtractor",
+        "MFCC",
+        "ComplexMul",
+        "RealCosineTransform",
+        "NonMaxSuppression",
+        "CumSum",
         "LSTM",  # partial support — varies by version/activation
     }
     return sorted(ops & unsupported_hint)

--- a/v0/src/A0/coreml_probe_static.py
+++ b/v0/src/A0/coreml_probe_static.py
@@ -25,11 +25,11 @@ Outputs a JSON report at ``v0/state/A0/coreml_probe_static_report.json``
 and a human-readable Markdown summary at
 ``v0/state/A0/coreml_probe_static_report.md``.
 """
+
 from __future__ import annotations
 
 import argparse
 import contextlib
-import io
 import json
 import os
 import re
@@ -75,6 +75,7 @@ class ProbeResult:
 
 def _stft_shape(segment_samples: int) -> tuple[int, int]:
     import math
+
     n_fft = 4096
     hop = 1024
     return n_fft // 2, int(math.ceil(segment_samples / hop))
@@ -103,6 +104,7 @@ def _count_nodes(onnx_path: Path) -> int | None:
 
 # ── ORT VERBOSE log scraping ────────────────────────────────────────────────
 
+
 # CoreML EP emits lines like:
 #   [V:onnxruntime:, coreml_execution_provider.cc:GetCapability]
 #   <op_name> assigned to CoreML.
@@ -113,8 +115,7 @@ def _count_nodes(onnx_path: Path) -> int | None:
 def _capture_stderr_to_file():
     """Redirect fd 2 (stderr) to a temp file, yield path, restore on exit."""
     saved_fd = os.dup(2)
-    tmp = tempfile.NamedTemporaryFile(prefix="ort_stderr_", suffix=".log",
-                                      delete=False)
+    tmp = tempfile.NamedTemporaryFile(prefix="ort_stderr_", suffix=".log", delete=False)
     try:
         os.dup2(tmp.fileno(), 2)
         tmp.close()
@@ -124,8 +125,7 @@ def _capture_stderr_to_file():
         os.close(saved_fd)
 
 
-_RE_COREML_NODE = re.compile(r"node:\s*'([^']+)'.*?(?:CoreML|coreml)",
-                             re.IGNORECASE)
+_RE_COREML_NODE = re.compile(r"node:\s*'([^']+)'.*?(?:CoreML|coreml)", re.IGNORECASE)
 _RE_ASSIGN_LINE = re.compile(
     r"\b(?P<provider>CoreMLExecutionProvider|CPUExecutionProvider)\b",
     re.IGNORECASE,
@@ -166,14 +166,18 @@ def _scrape_assignments(log_path: Path) -> tuple[int, int]:
 
 # ── Probe a single (onnx, options) combination ──────────────────────────────
 
-def probe_one(label: str, onnx_path: Path,
-              probe_inputs: dict[str, np.ndarray],
-              coreml_options: dict[str, str] | None,
-              n_warmup: int = 3, n_timed: int = 5) -> ProbeResult:
+
+def probe_one(
+    label: str,
+    onnx_path: Path,
+    probe_inputs: dict[str, np.ndarray],
+    coreml_options: dict[str, str] | None,
+    n_warmup: int = 3,
+    n_timed: int = 5,
+) -> ProbeResult:
     import onnxruntime as ort
 
-    res = ProbeResult(label=label, onnx_path=str(onnx_path),
-                      options=dict(coreml_options or {}))
+    res = ProbeResult(label=label, onnx_path=str(onnx_path), options=dict(coreml_options or {}))
 
     so = ort.SessionOptions()
     so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -182,8 +186,7 @@ def probe_one(label: str, onnx_path: Path,
     so.intra_op_num_threads = max(1, (os.cpu_count() or 4) - 1)
 
     providers = (
-        [("CoreMLExecutionProvider", coreml_options or {}),
-         "CPUExecutionProvider"]
+        [("CoreMLExecutionProvider", coreml_options or {}), "CPUExecutionProvider"]
         if coreml_options is not None
         else ["CPUExecutionProvider"]
     )
@@ -192,7 +195,9 @@ def probe_one(label: str, onnx_path: Path,
     with _capture_stderr_to_file() as log_path:
         try:
             sess = ort.InferenceSession(
-                str(onnx_path), sess_options=so, providers=providers,
+                str(onnx_path),
+                sess_options=so,
+                providers=providers,
             )
             res.providers_resolved = list(sess.get_providers())
             res.coreml_loaded = "CoreMLExecutionProvider" in res.providers_resolved
@@ -230,9 +235,9 @@ def probe_one(label: str, onnx_path: Path,
         res.runs = n_timed
         res.mean_latency_sec = round(sum(latencies) / len(latencies), 4)
         res.p50_latency_sec = round(latencies[len(latencies) // 2], 4)
-        res.p95_latency_sec = round(latencies[min(len(latencies) - 1,
-                                                  int(0.95 * len(latencies)))],
-                                    4)
+        res.p95_latency_sec = round(
+            latencies[min(len(latencies) - 1, int(0.95 * len(latencies)))], 4
+        )
     except Exception as e:
         res.forward_error = f"timed: {type(e).__name__}: {e!s}"[:600]
 
@@ -249,62 +254,83 @@ def probe_one(label: str, onnx_path: Path,
 
 OPTION_MATRIX: list[tuple[str, dict[str, str] | None]] = [
     ("cpu_only", None),
-    ("coreml_mlprogram_all_dynamic", {
-        "MLComputeUnits": "ALL",
-        "ModelFormat": "MLProgram",
-        "RequireStaticInputShapes": "0",
-        "EnableOnSubgraphs": "1",
-    }),
-    ("coreml_mlprogram_all_static", {
-        "MLComputeUnits": "ALL",
-        "ModelFormat": "MLProgram",
-        "RequireStaticInputShapes": "1",
-        "EnableOnSubgraphs": "1",
-    }),
-    ("coreml_mlprogram_ane_only", {
-        "MLComputeUnits": "CPUAndNeuralEngine",
-        "ModelFormat": "MLProgram",
-        "RequireStaticInputShapes": "1",
-        "EnableOnSubgraphs": "1",
-    }),
-    ("coreml_neuralnetwork_all", {
-        "MLComputeUnits": "ALL",
-        "ModelFormat": "NeuralNetwork",
-        "RequireStaticInputShapes": "1",
-        "EnableOnSubgraphs": "1",
-    }),
+    (
+        "coreml_mlprogram_all_dynamic",
+        {
+            "MLComputeUnits": "ALL",
+            "ModelFormat": "MLProgram",
+            "RequireStaticInputShapes": "0",
+            "EnableOnSubgraphs": "1",
+        },
+    ),
+    (
+        "coreml_mlprogram_all_static",
+        {
+            "MLComputeUnits": "ALL",
+            "ModelFormat": "MLProgram",
+            "RequireStaticInputShapes": "1",
+            "EnableOnSubgraphs": "1",
+        },
+    ),
+    (
+        "coreml_mlprogram_ane_only",
+        {
+            "MLComputeUnits": "CPUAndNeuralEngine",
+            "ModelFormat": "MLProgram",
+            "RequireStaticInputShapes": "1",
+            "EnableOnSubgraphs": "1",
+        },
+    ),
+    (
+        "coreml_neuralnetwork_all",
+        {
+            "MLComputeUnits": "ALL",
+            "ModelFormat": "NeuralNetwork",
+            "RequireStaticInputShapes": "1",
+            "EnableOnSubgraphs": "1",
+        },
+    ),
 ]
 
 
-def probe_file(label_prefix: str, onnx_path: Path,
-               segment_samples: int = 343980,
-               option_matrix: list = OPTION_MATRIX,
-               n_warmup: int = 3, n_timed: int = 5) -> list[ProbeResult]:
+def probe_file(
+    label_prefix: str,
+    onnx_path: Path,
+    segment_samples: int = 343980,
+    option_matrix: list = OPTION_MATRIX,
+    n_warmup: int = 3,
+    n_timed: int = 5,
+) -> list[ProbeResult]:
     inputs = _build_inputs(segment_samples)
     results: list[ProbeResult] = []
     for combo_label, opts in option_matrix:
         full_label = f"{label_prefix}::{combo_label}"
         print(f"[probe] {full_label}", flush=True)
         try:
-            r = probe_one(full_label, onnx_path, inputs, opts,
-                          n_warmup=n_warmup, n_timed=n_timed)
+            r = probe_one(full_label, onnx_path, inputs, opts, n_warmup=n_warmup, n_timed=n_timed)
         except Exception as e:
-            r = ProbeResult(label=full_label, onnx_path=str(onnx_path),
-                            options=dict(opts or {}),
-                            load_error=f"outer: {type(e).__name__}: {e!s}")
+            r = ProbeResult(
+                label=full_label,
+                onnx_path=str(onnx_path),
+                options=dict(opts or {}),
+                load_error=f"outer: {type(e).__name__}: {e!s}",
+            )
         results.append(r)
         if r.load_error:
             print(f"  LOAD FAIL: {r.load_error}", flush=True)
         elif r.forward_error:
             print(f"  FWD  FAIL: {r.forward_error}", flush=True)
         else:
-            print(f"  load=ok coreml_loaded={r.coreml_loaded} "
-                  f"part={r.coreml_partition_pct}% mean={r.mean_latency_sec}s",
-                  flush=True)
+            print(
+                f"  load=ok coreml_loaded={r.coreml_loaded} "
+                f"part={r.coreml_partition_pct}% mean={r.mean_latency_sec}s",
+                flush=True,
+            )
     return results
 
 
 # ── Reporting ───────────────────────────────────────────────────────────────
+
 
 def write_markdown_report(results: list[ProbeResult], path: Path) -> None:
     lines = ["# CoreML EP probe — static vs dynamic shapes", ""]
@@ -316,8 +342,7 @@ def write_markdown_report(results: list[ProbeResult], path: Path) -> None:
         "|---|---:|---|---:|---:|---:|---:|---|",
     ]
     for r in results:
-        nodes = (f"{r.n_nodes_coreml}/{r.n_nodes_cpu}/{r.n_nodes_total}"
-                 if r.n_nodes_total else "—")
+        nodes = f"{r.n_nodes_coreml}/{r.n_nodes_cpu}/{r.n_nodes_total}" if r.n_nodes_total else "—"
         err = (r.load_error or r.forward_error or "").replace("|", "/")
         lines.append(
             f"| {r.label} | {r.coreml_loaded} | {nodes} | "
@@ -333,13 +358,17 @@ def write_markdown_report(results: list[ProbeResult], path: Path) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
-    p.add_argument("--onnx", action="append", required=True,
-                   help="(label, path) pair, e.g. htdemucs:/abs/path.onnx")
+    p.add_argument(
+        "--onnx",
+        action="append",
+        required=True,
+        help="(label, path) pair, e.g. htdemucs:/abs/path.onnx",
+    )
     p.add_argument("--segment-samples", type=int, default=343980)
-    p.add_argument("--report-json", type=Path,
-                   default=STATE_DIR / "coreml_probe_static_report.json")
-    p.add_argument("--report-md", type=Path,
-                   default=STATE_DIR / "coreml_probe_static_report.md")
+    p.add_argument(
+        "--report-json", type=Path, default=STATE_DIR / "coreml_probe_static_report.json"
+    )
+    p.add_argument("--report-md", type=Path, default=STATE_DIR / "coreml_probe_static_report.md")
     args = p.parse_args(argv)
 
     all_results: list[ProbeResult] = []
@@ -352,8 +381,7 @@ def main(argv: list[str] | None = None) -> int:
         if not path.exists():
             print(f"missing onnx: {path}", file=sys.stderr)
             return 2
-        all_results += probe_file(label, path,
-                                  segment_samples=args.segment_samples)
+        all_results += probe_file(label, path, segment_samples=args.segment_samples)
 
     args.report_json.parent.mkdir(parents=True, exist_ok=True)
     with open(args.report_json, "w") as fh:

--- a/v0/src/A0/demucs_driver.py
+++ b/v0/src/A0/demucs_driver.py
@@ -25,6 +25,7 @@ replacing it.  ``convert.py`` is retained for backwards compatibility
 with the original blocker-writing behaviour but is no longer the primary
 entrypoint for Demucs.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -33,7 +34,6 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 
@@ -41,6 +41,7 @@ from . import config, demucs_export, fixtures, fp16, manifest, progress
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
+
 
 def _head_onnx_paths(variant: str, bag) -> list[Path]:
     """
@@ -59,6 +60,7 @@ def _stft_shape_for(segment_samples: int) -> tuple[int, int]:
     # HTDemucs._spec strips the Nyquist bin; see demucs_export.export_head.
     freq_bins = demucs_export.STFT.n_fft // 2
     import math
+
     frames = int(math.ceil(segment_samples / demucs_export.STFT.hop_length))
     return freq_bins, frames
 
@@ -73,6 +75,7 @@ def _build_coreml_probe_inputs(segment_samples: int) -> dict[str, np.ndarray]:
 
 def _fp16_run_fn_for(onnx_paths: list[Path], segment_samples: int):
     """Return a run_fn for fp16.attempt_fp16 — averaged per-fixture stems."""
+
     def _run(path: Path) -> dict[str, np.ndarray]:
         # fp16.attempt_fp16 converts one path at a time — but Demucs bag is
         # multiple heads.  We convert the caller's single path and substitute
@@ -80,38 +83,43 @@ def _fp16_run_fn_for(onnx_paths: list[Path], segment_samples: int):
         # sufficient for the null-test.
         out = {}
         for fx in fixtures.all_fixtures():
-            mix, _ = demucs_export._pad_fixture_to_segment(
-                fx.samples, segment_samples)
+            mix, _ = demucs_export._pad_fixture_to_segment(fx.samples, segment_samples)
             mix_bcs = mix[None, ...]
             arr = demucs_export.run_head_onnx(path, mix_bcs)
             out[fx.name] = arr.astype(np.float32)
         return out
+
     return _run
 
 
 # ── Per-variant driver ──────────────────────────────────────────────────────
 
-def _run_variant(variant: str,
-                 manifest_entries: dict,
-                 validation_entries: dict,
-                 fp16_attempts: list,
-                 precisions: dict) -> bool:
+
+def _run_variant(
+    variant: str,
+    manifest_entries: dict,
+    validation_entries: dict,
+    fp16_attempts: list,
+    precisions: dict,
+) -> bool:
     from demucs.pretrained import get_model
 
-    progress.emit(f"demucs.{variant}", 5, f"loading torch reference")
+    progress.emit(f"demucs.{variant}", 5, "loading torch reference")
     bag = get_model(variant)
     onnx_paths = _head_onnx_paths(variant, bag)
     segment_samples = demucs_export.segment_samples_for(bag.models[0])
 
     # 1. Export each head.
     for i, (head, dst) in enumerate(zip(bag.models, onnx_paths)):
-        progress.emit(f"demucs.{variant}", 10 + i * 5,
-                      f"exporting head {i+1}/{len(bag.models)} → {dst.name}")
+        progress.emit(
+            f"demucs.{variant}",
+            10 + i * 5,
+            f"exporting head {i + 1}/{len(bag.models)} → {dst.name}",
+        )
         head = head.eval()
         demucs_export.export_head(head, dst, segment_samples)
         size_mb = dst.stat().st_size / 1024 / 1024
-        progress.emit(f"demucs.{variant}", 15 + i * 5,
-                      f"exported {dst.name} ({size_mb:.1f} MB)")
+        progress.emit(f"demucs.{variant}", 15 + i * 5, f"exported {dst.name} ({size_mb:.1f} MB)")
 
     # 2. Parity on fixtures.
     #
@@ -133,13 +141,16 @@ def _run_variant(variant: str,
     primary_pass = True
     for fx in fixtures.all_fixtures():
         p = demucs_export.validate_head(
-            bag, onnx_paths, fx.samples, fx.name, variant, segment_samples)
+            bag, onnx_paths, fx.samples, fx.name, variant, segment_samples
+        )
         fixture_parities.append(p.as_dict())
         progress.emit(
-            f"demucs.{variant}", 50,
+            f"demucs.{variant}",
+            50,
             f"parity {fx.name}: max_abs={p.max_abs_err:.3e} "
             f"rms={p.residual_rms_dbfs:+.1f}dBFS rel_peak={p.rel_peak:.3e} "
-            f"pass={p.passed}")
+            f"pass={p.passed}",
+        )
         # Gate on the full-mix fixture (representative of real music).
         if fx.name == "full_mix_30s":
             primary_pass &= p.passed
@@ -148,8 +159,10 @@ def _run_variant(variant: str,
         "passed": primary_pass,
         "fixtures": fixture_parities,
         "heads": [str(p.relative_to(config.REPO_ROOT)) for p in onnx_paths],
-        "gating_policy": ("full_mix_30s strict; drum_loop_10s advisory "
-                          "(synthetic-transient residual is informational)"),
+        "gating_policy": (
+            "full_mix_30s strict; drum_loop_10s advisory "
+            "(synthetic-transient residual is informational)"
+        ),
     }
     # Keep ``parity_pass`` name for downstream code that still reads it.
     parity_pass = primary_pass
@@ -161,7 +174,9 @@ def _run_variant(variant: str,
     fp16_dir = config.BUILD_MODELS_DIR / variant
     fp16_head0 = fp16_dir / f"{onnx_paths[0].stem}.fp16.onnx"
     fp16_result = fp16.attempt_fp16(
-        onnx_paths[0], fp16_head0, variant,
+        onnx_paths[0],
+        fp16_head0,
+        variant,
         run_fn=_fp16_run_fn_for(onnx_paths, segment_samples),
         fixture_names=[fx.name for fx in fixtures.all_fixtures()],
     )
@@ -173,24 +188,29 @@ def _run_variant(variant: str,
             try:
                 fp16.convert_to_fp16(p, dst)
             except Exception as e:  # pragma: no cover
-                progress.emit(f"demucs.{variant}", 60,
-                              f"fp16 head conversion failed ({p.name}): {e!s}")
+                progress.emit(
+                    f"demucs.{variant}", 60, f"fp16 head conversion failed ({p.name}): {e!s}"
+                )
                 fp16_result.all_passed = False
                 break
     precision = "fp16" if fp16_result.all_passed else "fp32"
     precisions[variant] = precision
-    progress.emit(f"demucs.{variant}", 65,
-                  f"fp16 {'shipped' if fp16_result.all_passed else 'fallback fp32'}")
+    progress.emit(
+        f"demucs.{variant}", 65, f"fp16 {'shipped' if fp16_result.all_passed else 'fallback fp32'}"
+    )
 
     # 4. CoreML EP probe — on the head 0 ONNX at the final precision.
-    probe_path = (fp16_head0 if fp16_result.all_passed else onnx_paths[0])
+    probe_path = fp16_head0 if fp16_result.all_passed else onnx_paths[0]
     probe_inputs = _build_coreml_probe_inputs(segment_samples)
     cml = cml_mod.probe(probe_path, variant, probe_inputs)
-    progress.emit(f"demucs.{variant}", 80,
-                  f"coreml_loaded={cml.coreml_loaded} "
-                  f"cpu_lat={cml.cpu_only_latency_sec} "
-                  f"cml_lat={cml.coreml_latency_sec} "
-                  f"fallback={cml.cpu_fallback_ops}")
+    progress.emit(
+        f"demucs.{variant}",
+        80,
+        f"coreml_loaded={cml.coreml_loaded} "
+        f"cpu_lat={cml.cpu_only_latency_sec} "
+        f"cml_lat={cml.coreml_latency_sec} "
+        f"fallback={cml.cpu_fallback_ops}",
+    )
 
     # 5. Manifest entry (one per head).
     for i, p in enumerate(onnx_paths):
@@ -201,18 +221,17 @@ def _run_variant(variant: str,
         manifest_entries[manifest_key] = manifest.build_entry(
             shipped,
             torch_ref_checkpoint=variant,
-            max_abs_err=max((fp["max_abs_err"] for fp in fixture_parities),
-                            default=0.0),
-            max_rel_err=max((fp["max_rel_err"] for fp in fixture_parities),
-                            default=0.0),
+            max_abs_err=max((fp["max_abs_err"] for fp in fixture_parities), default=0.0),
+            max_rel_err=max((fp["max_rel_err"] for fp in fixture_parities), default=0.0),
             precision=precision,
             coreml_ep_supported=cml.coreml_loaded,
             cpu_fallback_ops=cml.cpu_fallback_ops,
-            optimized_cache=(Path(cml.optimized_cache_path)
-                             if cml.optimized_cache_path else None),
-            notes=("external STFT/iSTFT — caller must drive n_fft=4096 "
-                   "hop=1024 hann center=True reflect onesided. See "
-                   "stemforge._vendor.demucs_patched.HTDemucs.forward_from_spec"),
+            optimized_cache=(Path(cml.optimized_cache_path) if cml.optimized_cache_path else None),
+            notes=(
+                "external STFT/iSTFT — caller must drive n_fft=4096 "
+                "hop=1024 hann center=True reflect onesided. See "
+                "stemforge._vendor.demucs_patched.HTDemucs.forward_from_spec"
+            ),
         )
         # Embed stft params and latency inside each entry so the C++ host
         # has everything it needs in one JSON.
@@ -222,18 +241,23 @@ def _run_variant(variant: str,
         if len(onnx_paths) > 1:
             manifest_entries[manifest_key]["bag_head_index"] = i
             manifest_entries[manifest_key]["bag_size"] = len(onnx_paths)
-    progress.emit(f"demucs.{variant}", 100,
-                  f"done, precision={precision}, parity_pass={parity_pass}")
+    progress.emit(
+        f"demucs.{variant}", 100, f"done, precision={precision}, parity_pass={parity_pass}"
+    )
     return parity_pass
 
 
 # ── CLI ─────────────────────────────────────────────────────────────────────
 
+
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Track A0.1 — Demucs export driver")
-    p.add_argument("--models", nargs="*",
-                   default=list(config.DEMUCS_MODELS.keys()),
-                   choices=list(config.DEMUCS_MODELS.keys()))
+    p.add_argument(
+        "--models",
+        nargs="*",
+        default=list(config.DEMUCS_MODELS.keys()),
+        choices=list(config.DEMUCS_MODELS.keys()),
+    )
     return p.parse_args(argv)
 
 
@@ -253,11 +277,10 @@ def main(argv: list[str] | None = None) -> int:
     for variant in args.models:
         try:
             results[variant] = _run_variant(
-                variant, manifest_entries, validation_entries,
-                fp16_attempts, precisions)
+                variant, manifest_entries, validation_entries, fp16_attempts, precisions
+            )
         except Exception as e:
-            progress.emit(f"demucs.{variant}", 0,
-                          f"uncaught error: {type(e).__name__}: {e!s}")
+            progress.emit(f"demucs.{variant}", 0, f"uncaught error: {type(e).__name__}: {e!s}")
             traceback.print_exc(file=sys.stderr)
             results[variant] = False
 
@@ -272,8 +295,7 @@ def main(argv: list[str] | None = None) -> int:
     duration = time.perf_counter() - t0
     all_ok = all(results.values())
 
-    progress.emit("demucs.done", 100,
-                  f"results={results} duration={duration:.1f}s")
+    progress.emit("demucs.done", 100, f"results={results} duration={duration:.1f}s")
     return 0 if all_ok else 1
 
 

--- a/v0/src/A0/demucs_export.py
+++ b/v0/src/A0/demucs_export.py
@@ -40,6 +40,7 @@ that this factoring is numerically equivalent to upstream ``forward``.
   6. ``run_bag_onnx`` — average per-head ONNX outputs the way
      ``demucs.apply.apply_model`` averages bag-of-heads internally.
 """
+
 from __future__ import annotations
 
 import math
@@ -56,11 +57,12 @@ from .progress import Timer, emit
 
 # ── STFT parameters HTDemucs uses internally (demucs/spec.py) ────────────────
 
+
 @dataclass(frozen=True)
 class StftConfig:
     n_fft: int = 4096
     hop_length: int = 1024
-    window: str = "hann"    # hann_window(n_fft)
+    window: str = "hann"  # hann_window(n_fft)
     center: bool = True
     pad_mode: str = "reflect"
     normalized: bool = False
@@ -94,12 +96,14 @@ def stft_params() -> dict[str, Any]:
 try:
     import torch
     import torch.nn as nn
+
     _TORCH_OK = True
 except ImportError:  # pragma: no cover
     _TORCH_OK = False
 
 
 if _TORCH_OK:
+
     class ExternalSpecHTDemucs(nn.Module):
         """
         Wraps one HTDemucs head so that STFT/iSTFT happen outside the graph.
@@ -129,6 +133,7 @@ if _TORCH_OK:
         def forward(self, mix: "torch.Tensor", z_cac: "torch.Tensor"):
             return self.head.forward_from_spec_cac(mix, z_cac)
 else:  # pragma: no cover
+
     class ExternalSpecHTDemucs:  # type: ignore[no-redef]
         def __init__(self, *a, **kw):
             raise RuntimeError("torch is not installed")
@@ -139,8 +144,10 @@ else:  # pragma: no cover
 # These are thin wrappers around the logic in the vendored module so the
 # validate harness and the C++ host share one reference.
 
-def apply_stft(mix_padded: "torch.Tensor", n_fft: int = STFT.n_fft,
-               hop: int = STFT.hop_length) -> "torch.Tensor":
+
+def apply_stft(
+    mix_padded: "torch.Tensor", n_fft: int = STFT.n_fft, hop: int = STFT.hop_length
+) -> "torch.Tensor":
     """
     Compute the complex spectrogram exactly as demucs.htdemucs._spec does.
 
@@ -148,32 +155,34 @@ def apply_stft(mix_padded: "torch.Tensor", n_fft: int = STFT.n_fft,
     """
     from demucs.spec import spectro
     from demucs.hdemucs import pad1d
+
     assert hop == n_fft // 4
     le = int(math.ceil(mix_padded.shape[-1] / hop))
     pad = hop // 2 * 3
-    x = pad1d(mix_padded, (pad, pad + le * hop - mix_padded.shape[-1]),
-              mode="reflect")
+    x = pad1d(mix_padded, (pad, pad + le * hop - mix_padded.shape[-1]), mode="reflect")
     z = spectro(x, n_fft, hop)[..., :-1, :]
-    z = z[..., 2: 2 + le]
+    z = z[..., 2 : 2 + le]
     return z
 
 
-def apply_istft(zout: "torch.Tensor", length: int,
-                n_fft: int = STFT.n_fft,
-                hop: int = STFT.hop_length) -> "torch.Tensor":
+def apply_istft(
+    zout: "torch.Tensor", length: int, n_fft: int = STFT.n_fft, hop: int = STFT.hop_length
+) -> "torch.Tensor":
     """Inverse STFT matching demucs.htdemucs._ispec at scale=0."""
     import torch.nn.functional as F
     from demucs.spec import ispectro
+
     z = F.pad(zout, (0, 0, 0, 1))
     z = F.pad(z, (2, 2))
     pad = hop // 2 * 3
     le = hop * int(math.ceil(length / hop)) + 2 * pad
     x = ispectro(z, hop, length=le)
-    x = x[..., pad: pad + length]
+    x = x[..., pad : pad + length]
     return x
 
 
 # ── Export entrypoint ───────────────────────────────────────────────────────
+
 
 def _wrap_head_with_vendored_class(head: "nn.Module") -> "nn.Module":
     """
@@ -191,10 +200,9 @@ def _wrap_head_with_vendored_class(head: "nn.Module") -> "nn.Module":
     """
     from stemforge._vendor.demucs_patched import HTDemucs as VendoredHTDemucs
     import types
-    for name in ("forward_from_spec", "forward_from_spec_cac",
-                 "_learned_forward"):
-        setattr(head, name, types.MethodType(getattr(VendoredHTDemucs, name),
-                                             head))
+
+    for name in ("forward_from_spec", "forward_from_spec_cac", "_learned_forward"):
+        setattr(head, name, types.MethodType(getattr(VendoredHTDemucs, name), head))
     return head
 
 
@@ -216,14 +224,12 @@ def pack_cac(z_complex: "torch.Tensor") -> "torch.Tensor":
     return m.reshape(B, C * 2, Fq, T).contiguous()
 
 
-def unpack_cac(zout_cac: "torch.Tensor", audio_channels: int = 2
-               ) -> "torch.Tensor":
+def unpack_cac(zout_cac: "torch.Tensor", audio_channels: int = 2) -> "torch.Tensor":
     """
     Invert :func:`pack_cac` on the network output ``(B, S, 2*C, Fq, T)``
     → complex ``(B, S, C, Fq, T)``.
     """
     B, S, twoC, Fq, T = zout_cac.shape
-    C = twoC // audio_channels  # For audio_channels=2 and twoC=4 → C=2
     # Reshape to (B, S, C, 2, Fq, T), permute so the trailing dim is the
     # real/imag pair, then view_as_complex.
     z = zout_cac.view(B, S, audio_channels, 2, Fq, T)
@@ -231,8 +237,7 @@ def unpack_cac(zout_cac: "torch.Tensor", audio_channels: int = 2
     return torch.view_as_complex(z)
 
 
-def export_head(head_module: "nn.Module", dst_onnx: Path,
-                segment_samples: int) -> Path:
+def export_head(head_module: "nn.Module", dst_onnx: Path, segment_samples: int) -> Path:
     """
     Export one HTDemucs head as ONNX using the external-spec refactor.
 
@@ -256,8 +261,7 @@ def export_head(head_module: "nn.Module", dst_onnx: Path,
     z_cac = torch.zeros(1, 4, freq_bins, frames)  # 2 audio chans × 2 (re, im)
 
     dst_onnx.parent.mkdir(parents=True, exist_ok=True)
-    with Timer(f"demucs.export_head.{dst_onnx.stem}",
-               segment_samples=segment_samples):
+    with Timer(f"demucs.export_head.{dst_onnx.stem}", segment_samples=segment_samples):
         torch.onnx.export(
             wrapper,
             (mix, z_cac),
@@ -279,8 +283,10 @@ def export_head(head_module: "nn.Module", dst_onnx: Path,
 
 # ── Legacy in-graph export (retained for diagnostic / smoke-test) ───────────
 
-def attempt_in_graph_export(head_module: "nn.Module", dst_onnx: Path,
-                            segment_samples: int) -> tuple[bool, str]:
+
+def attempt_in_graph_export(
+    head_module: "nn.Module", dst_onnx: Path, segment_samples: int
+) -> tuple[bool, str]:
     """
     Attempt the direct ``torch.onnx.export(head)`` with STFT inside the graph.
 
@@ -299,10 +305,15 @@ def attempt_in_graph_export(head_module: "nn.Module", dst_onnx: Path,
         try:
             with Timer(f"demucs.export.in_graph.dynamo={dynamo_flag}"):
                 torch.onnx.export(
-                    head_module.eval(), (mix,), str(dst_onnx),
-                    input_names=["mix"], output_names=["stems"],
-                    dynamic_axes={"mix": {0: "batch", 2: "samples"},
-                                  "stems": {0: "batch", 3: "samples"}},
+                    head_module.eval(),
+                    (mix,),
+                    str(dst_onnx),
+                    input_names=["mix"],
+                    output_names=["stems"],
+                    dynamic_axes={
+                        "mix": {0: "batch", 2: "samples"},
+                        "stems": {0: "batch", 3: "samples"},
+                    },
                     opset_version=config.OPSET_VERSION,
                     do_constant_folding=True,
                     dynamo=dynamo_flag,
@@ -316,8 +327,8 @@ def attempt_in_graph_export(head_module: "nn.Module", dst_onnx: Path,
 
 # ── Inference helpers ───────────────────────────────────────────────────────
 
-def run_head_onnx(onnx_path: Path, mix_np: np.ndarray,
-                  providers: list | None = None) -> np.ndarray:
+
+def run_head_onnx(onnx_path: Path, mix_np: np.ndarray, providers: list | None = None) -> np.ndarray:
     """
     Run one ONNX head on a ``(batch, 2, samples)`` mix.
 
@@ -348,7 +359,8 @@ def run_head_onnx(onnx_path: Path, mix_np: np.ndarray,
     mix_in = mix_t.numpy().astype(dtype)
 
     time_out, zout_cac = sess.run(
-        None, {"mix": mix_in, "z_cac": z_cac},
+        None,
+        {"mix": mix_in, "z_cac": z_cac},
     )
     time_out = np.asarray(time_out, dtype=np.float32)
     zout_cac_t = torch.from_numpy(np.asarray(zout_cac, dtype=np.float32))
@@ -357,9 +369,12 @@ def run_head_onnx(onnx_path: Path, mix_np: np.ndarray,
     return (time_out + x_freq).astype(np.float32)
 
 
-def run_bag_onnx(onnx_paths: list[Path], mix_np: np.ndarray,
-                 providers: list | None = None,
-                 weights: list[list[float]] | None = None) -> np.ndarray:
+def run_bag_onnx(
+    onnx_paths: list[Path],
+    mix_np: np.ndarray,
+    providers: list | None = None,
+    weights: list[list[float]] | None = None,
+) -> np.ndarray:
     """
     Combine per-head ONNX outputs using the bag's per-source weights.
 
@@ -368,8 +383,7 @@ def run_bag_onnx(onnx_paths: list[Path], mix_np: np.ndarray,
     sum(w_i[k])`` across heads.  When ``weights`` is None, uniform
     averaging is used (single-model bags collapse to this automatically).
     """
-    outs = [run_head_onnx(p, mix_np, providers=providers)
-            for p in onnx_paths]
+    outs = [run_head_onnx(p, mix_np, providers=providers) for p in onnx_paths]
     n_heads = len(outs)
     if n_heads == 1:
         return outs[0]
@@ -390,6 +404,7 @@ def run_bag_onnx(onnx_paths: list[Path], mix_np: np.ndarray,
 
 # ── Parity harness ──────────────────────────────────────────────────────────
 
+
 @dataclass
 class DemucsParity:
     fixture: str
@@ -408,18 +423,21 @@ class DemucsParity:
     passed: bool
 
     def as_dict(self) -> dict[str, Any]:
-        return {"fixture": self.fixture,
-                "model_key": self.model_key,
-                "segment_samples": self.segment_samples,
-                "max_abs_err": float(self.max_abs_err),
-                "max_rel_err": float(self.max_rel_err),
-                "residual_rms_dbfs": float(self.residual_rms_dbfs),
-                "rel_peak": float(self.rel_peak),
-                "passed": self.passed}
+        return {
+            "fixture": self.fixture,
+            "model_key": self.model_key,
+            "segment_samples": self.segment_samples,
+            "max_abs_err": float(self.max_abs_err),
+            "max_rel_err": float(self.max_rel_err),
+            "residual_rms_dbfs": float(self.residual_rms_dbfs),
+            "rel_peak": float(self.rel_peak),
+            "passed": self.passed,
+        }
 
 
-def _pad_fixture_to_segment(fixture_audio: np.ndarray, segment_samples: int
-                            ) -> tuple[np.ndarray, int]:
+def _pad_fixture_to_segment(
+    fixture_audio: np.ndarray, segment_samples: int
+) -> tuple[np.ndarray, int]:
     """Pad mono/stereo fixture to ``segment_samples`` along the last dim."""
     if fixture_audio.ndim == 1:
         fixture_audio = np.stack([fixture_audio, fixture_audio], axis=0)
@@ -429,7 +447,7 @@ def _pad_fixture_to_segment(fixture_audio: np.ndarray, segment_samples: int
     if length > segment_samples:
         # Take centre slice to keep transients.
         start = (length - segment_samples) // 2
-        mix = fixture_audio[..., start:start + segment_samples]
+        mix = fixture_audio[..., start : start + segment_samples]
         used_len = segment_samples
     else:
         pad = segment_samples - length
@@ -441,23 +459,28 @@ def _pad_fixture_to_segment(fixture_audio: np.ndarray, segment_samples: int
 def torch_reference(head_or_bag, mix_np: np.ndarray) -> np.ndarray:
     """Run the torch reference model on a mix array."""
     from demucs.apply import apply_model
+
     mix_t = torch.from_numpy(mix_np).to(torch.float32)
     if mix_t.dim() == 2:
         mix_t = mix_t.unsqueeze(0)
     # apply_model handles bag (list of heads) and single models.
     with torch.no_grad():
-        out = apply_model(head_or_bag, mix_t, shifts=0, split=False,
-                          overlap=0.0, progress=False, num_workers=0)
+        out = apply_model(
+            head_or_bag, mix_t, shifts=0, split=False, overlap=0.0, progress=False, num_workers=0
+        )
     return out.cpu().numpy()
 
 
-def validate_head(bag_or_head, onnx_paths: list[Path],
-                  fixture_audio: np.ndarray, fixture_name: str,
-                  model_key: str,
-                  segment_samples: int,
-                  abs_tol: float = config.PARITY.demucs_max_abs_err,
-                  rel_tol: float = config.PARITY.demucs_max_rel_err
-                  ) -> DemucsParity:
+def validate_head(
+    bag_or_head,
+    onnx_paths: list[Path],
+    fixture_audio: np.ndarray,
+    fixture_name: str,
+    model_key: str,
+    segment_samples: int,
+    abs_tol: float = config.PARITY.demucs_max_abs_err,
+    rel_tol: float = config.PARITY.demucs_max_rel_err,
+) -> DemucsParity:
     """Compare torch-reference stems to ONNX stems on `fixture_audio`."""
     mix, _used = _pad_fixture_to_segment(fixture_audio, segment_samples)
     # apply_model takes shape (B, C, S).
@@ -470,11 +493,9 @@ def validate_head(bag_or_head, onnx_paths: list[Path],
     weights = getattr(bag_or_head, "weights", None)
 
     with Timer(f"demucs.validate.torch.{model_key}.{fixture_name}"):
-        ref = np.asarray(torch_reference(bag_or_head, mix_bcs),
-                         dtype=np.float64)
+        ref = np.asarray(torch_reference(bag_or_head, mix_bcs), dtype=np.float64)
     with Timer(f"demucs.validate.onnx.{model_key}.{fixture_name}"):
-        got = np.asarray(run_bag_onnx(onnx_paths, mix_bcs, weights=weights),
-                         dtype=np.float64)
+        got = np.asarray(run_bag_onnx(onnx_paths, mix_bcs, weights=weights), dtype=np.float64)
 
     # Align shapes — apply_model returns (B, S, C, T) while our onnx runner
     # returns (B, S, C, T) too via head.forward_from_spec.  Sanity check.
@@ -488,7 +509,7 @@ def validate_head(bag_or_head, onnx_paths: list[Path],
 
     # Residual RMS in dBFS — stable across fixture levels.
     residual = ref - got
-    rms = float(np.sqrt(np.mean(residual ** 2)))
+    rms = float(np.sqrt(np.mean(residual**2)))
     rms_dbfs = -240.0 if rms <= 0 else 20.0 * math.log10(rms)
 
     # Peak-normalised relative error.

--- a/v0/src/A0/fixtures.py
+++ b/v0/src/A0/fixtures.py
@@ -10,6 +10,7 @@ deterministic test audio (silence + click track, tonal sweep) so the pipeline
 is runnable on a fresh checkout. The synthetic fixtures are reproducible
 given a fixed random seed so parity numbers are comparable across runs.
 """
+
 from __future__ import annotations
 
 import math
@@ -28,15 +29,14 @@ FULL_MIX_SECS = 30.0
 class Fixture:
     name: str
     sr: int
-    samples: np.ndarray   # shape (channels, samples)
+    samples: np.ndarray  # shape (channels, samples)
 
     @property
     def seconds(self) -> float:
         return self.samples.shape[-1] / self.sr
 
 
-def _click_track(seconds: float, sr: int, bpm: float = 120.0,
-                 seed: int = 1234) -> np.ndarray:
+def _click_track(seconds: float, sr: int, bpm: float = 120.0, seed: int = 1234) -> np.ndarray:
     """Deterministic percussive click at `bpm` with soft noise floor."""
     rng = np.random.default_rng(seed)
     n = int(seconds * sr)
@@ -58,8 +58,7 @@ def _click_track(seconds: float, sr: int, bpm: float = 120.0,
     return np.stack([y, y], axis=0)
 
 
-def _full_mix(seconds: float, sr: int, bpm: float = 128.0,
-              seed: int = 4321) -> np.ndarray:
+def _full_mix(seconds: float, sr: int, bpm: float = 128.0, seed: int = 4321) -> np.ndarray:
     """Synthetic multi-band mix: click + bass sine + mid pad + stereo decor."""
     rng = np.random.default_rng(seed)
     n = int(seconds * sr)
@@ -73,8 +72,9 @@ def _full_mix(seconds: float, sr: int, bpm: float = 128.0,
 
     # Pad (filtered noise band around 800 Hz).
     freqs = np.linspace(400, 1200, 5)
-    pad = sum(0.05 * np.sin(2 * math.pi * f * t + rng.uniform(0, 2 * math.pi))
-              for f in freqs).astype(np.float32)
+    pad = sum(
+        0.05 * np.sin(2 * math.pi * f * t + rng.uniform(0, 2 * math.pi)) for f in freqs
+    ).astype(np.float32)
 
     # Click on top.
     click = _click_track(seconds, sr, bpm=bpm, seed=seed + 1)[0]
@@ -91,13 +91,15 @@ def _full_mix(seconds: float, sr: int, bpm: float = 128.0,
 
 
 def drum_loop(sr: int = DEFAULT_SR) -> Fixture:
-    return Fixture(name="drum_loop_10s", sr=sr,
-                   samples=_click_track(DRUM_LOOP_SECS, sr).astype(np.float32))
+    return Fixture(
+        name="drum_loop_10s", sr=sr, samples=_click_track(DRUM_LOOP_SECS, sr).astype(np.float32)
+    )
 
 
 def full_mix(sr: int = DEFAULT_SR) -> Fixture:
-    return Fixture(name="full_mix_30s", sr=sr,
-                   samples=_full_mix(FULL_MIX_SECS, sr).astype(np.float32))
+    return Fixture(
+        name="full_mix_30s", sr=sr, samples=_full_mix(FULL_MIX_SECS, sr).astype(np.float32)
+    )
 
 
 def all_fixtures(sr: int = DEFAULT_SR) -> list[Fixture]:
@@ -106,6 +108,7 @@ def all_fixtures(sr: int = DEFAULT_SR) -> list[Fixture]:
 
 def save_wav(fixture: Fixture, path: Path) -> None:
     import soundfile as sf
+
     path.parent.mkdir(parents=True, exist_ok=True)
     sf.write(str(path), fixture.samples.T, fixture.sr, subtype="PCM_24")
 
@@ -115,6 +118,7 @@ def load_external_fixture(path: Path) -> Fixture | None:
     if not path.exists():
         return None
     import soundfile as sf
+
     data, sr = sf.read(str(path), always_2d=True)
     # soundfile returns (samples, channels) — transpose to (channels, samples).
     arr = np.asarray(data, dtype=np.float32).T

--- a/v0/src/A0/fp16.py
+++ b/v0/src/A0/fp16.py
@@ -12,6 +12,7 @@ PIVOT §E requirements for A0.7:
 For classifiers (CLAP, AST) the null-test morphs into "top-1 accuracy within
 1% on ≥200-sample eval set". Callers pass the appropriate metric.
 """
+
 from __future__ import annotations
 
 import math
@@ -50,15 +51,20 @@ def rms_dbfs(signal: np.ndarray) -> float:
     signal = np.asarray(signal, dtype=np.float64)
     if signal.size == 0:
         return -math.inf
-    rms = float(np.sqrt(np.mean(signal ** 2)))
+    rms = float(np.sqrt(np.mean(signal**2)))
     if rms <= 0.0:
         return -math.inf
     return 20.0 * math.log10(rms)
 
 
-def null_test(fp32_output: np.ndarray, fp16_output: np.ndarray,
-              *, model_name: str, fixture: str,
-              threshold_dbfs: float = NULL_TEST_FLOOR_DBFS) -> NullTestResult:
+def null_test(
+    fp32_output: np.ndarray,
+    fp16_output: np.ndarray,
+    *,
+    model_name: str,
+    fixture: str,
+    threshold_dbfs: float = NULL_TEST_FLOOR_DBFS,
+) -> NullTestResult:
     """Compute residual and compare to threshold."""
     a = np.asarray(fp32_output, dtype=np.float64)
     b = np.asarray(fp16_output, dtype=np.float64)
@@ -76,15 +82,15 @@ def null_test(fp32_output: np.ndarray, fp16_output: np.ndarray,
     )
 
 
-def convert_to_fp16(src_onnx: Path, dst_onnx: Path, *,
-                    keep_io_types: bool = True) -> None:
+def convert_to_fp16(src_onnx: Path, dst_onnx: Path, *, keep_io_types: bool = True) -> None:
     """Wrap `onnxconverter_common.float16.convert_float_to_float16`."""
     import onnx
     from onnxconverter_common import float16
 
     model = onnx.load(str(src_onnx))
     model_fp16 = float16.convert_float_to_float16(
-        model, keep_io_types=keep_io_types,
+        model,
+        keep_io_types=keep_io_types,
     )
     dst_onnx.parent.mkdir(parents=True, exist_ok=True)
     onnx.save(model_fp16, str(dst_onnx))
@@ -110,10 +116,14 @@ class Fp16Attempt:
         }
 
 
-def attempt_fp16(fp32_path: Path, fp16_path: Path, model_name: str,
-                 run_fn: Callable[[Path], dict[str, np.ndarray]],
-                 fixture_names: Iterable[str],
-                 threshold_dbfs: float = NULL_TEST_FLOOR_DBFS) -> Fp16Attempt:
+def attempt_fp16(
+    fp32_path: Path,
+    fp16_path: Path,
+    model_name: str,
+    run_fn: Callable[[Path], dict[str, np.ndarray]],
+    fixture_names: Iterable[str],
+    threshold_dbfs: float = NULL_TEST_FLOOR_DBFS,
+) -> Fp16Attempt:
     """
     High-level helper: convert fp32→fp16, run `run_fn` on both, null-test.
 
@@ -124,25 +134,36 @@ def attempt_fp16(fp32_path: Path, fp16_path: Path, model_name: str,
     try:
         convert_to_fp16(fp32_path, fp16_path)
     except Exception as e:
-        return Fp16Attempt(model_name=model_name, fp32_path=str(fp32_path),
-                           fp16_path=None, notes=f"conversion failed: {e!s}")
+        return Fp16Attempt(
+            model_name=model_name,
+            fp32_path=str(fp32_path),
+            fp16_path=None,
+            notes=f"conversion failed: {e!s}",
+        )
 
     try:
         fp32_out = run_fn(fp32_path)
         fp16_out = run_fn(fp16_path)
     except Exception as e:
-        return Fp16Attempt(model_name=model_name, fp32_path=str(fp32_path),
-                           fp16_path=str(fp16_path),
-                           notes=f"inference failed: {e!s}")
+        return Fp16Attempt(
+            model_name=model_name,
+            fp32_path=str(fp32_path),
+            fp16_path=str(fp16_path),
+            notes=f"inference failed: {e!s}",
+        )
 
     residuals = []
     all_ok = True
     for name in fixture_names:
         if name not in fp32_out or name not in fp16_out:
             continue
-        r = null_test(fp32_out[name], fp16_out[name],
-                      model_name=model_name, fixture=name,
-                      threshold_dbfs=threshold_dbfs)
+        r = null_test(
+            fp32_out[name],
+            fp16_out[name],
+            model_name=model_name,
+            fixture=name,
+            threshold_dbfs=threshold_dbfs,
+        )
         residuals.append(r)
         all_ok &= r.passed
 
@@ -157,17 +178,20 @@ def attempt_fp16(fp32_path: Path, fp16_path: Path, model_name: str,
 
 def write_fp16_report(path: Path, attempts: list[Fp16Attempt]) -> None:
     """Write `v0/state/A0/fp16_report.md` when any attempt fails."""
-    lines = ["# fp16 Export Investigation — Track A0.7",
-             "",
-             "Null-test threshold: RMS residual of (fp32 − fp16) ≤ "
-             f"{NULL_TEST_FLOOR_DBFS} dBFS.",
-             "",
-             "| Model | Fixture | Residual RMS (dBFS) | Peak |abs| | Pass |",
-             "|---|---|---:|---:|:---:|"]
+    lines = [
+        "# fp16 Export Investigation — Track A0.7",
+        "",
+        f"Null-test threshold: RMS residual of (fp32 − fp16) ≤ {NULL_TEST_FLOOR_DBFS} dBFS.",
+        "",
+        "| Model | Fixture | Residual RMS (dBFS) | Peak |abs| | Pass |",
+        "|---|---|---:|---:|:---:|",
+    ]
     for a in attempts:
         if not a.residuals:
-            lines.append(f"| {a.model_name} | (no residuals) | — | — | "
-                         f"{'skip' if 'skip' in a.notes else 'fail'} |")
+            lines.append(
+                f"| {a.model_name} | (no residuals) | — | — | "
+                f"{'skip' if 'skip' in a.notes else 'fail'} |"
+            )
             continue
         for r in a.residuals:
             lines.append(

--- a/v0/src/A0/fuse_ft.py
+++ b/v0/src/A0/fuse_ft.py
@@ -41,6 +41,7 @@ Usage::
 
     uv run --active python -m v0.src.A0.fuse_ft
 """
+
 from __future__ import annotations
 
 import argparse
@@ -50,7 +51,6 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any
 
 import onnx
 from onnx import helper, TensorProto
@@ -66,8 +66,10 @@ SPECIALIST_SOURCES = ["drums", "bass", "other", "vocals"]
 
 
 def _dims_of(vi: onnx.ValueInfoProto) -> list[int | str]:
-    return [d.dim_value if d.HasField("dim_value") else d.dim_param
-            for d in vi.type.tensor_type.shape.dim]
+    return [
+        d.dim_value if d.HasField("dim_value") else d.dim_param
+        for d in vi.type.tensor_type.shape.dim
+    ]
 
 
 def _dedupe_opsets(model: onnx.ModelProto) -> None:
@@ -101,16 +103,18 @@ def fuse_ft(head_paths: list[Path], dst_onnx: Path) -> onnx.ModelProto:
     zcac_vi = next(vi for vi in fused.graph.input if vi.name == "h0__z_cac")
 
     shared_mix = helper.make_tensor_value_info(
-        "mix", mix_vi.type.tensor_type.elem_type, _dims_of(mix_vi))
+        "mix", mix_vi.type.tensor_type.elem_type, _dims_of(mix_vi)
+    )
     shared_zcac = helper.make_tensor_value_info(
-        "z_cac", zcac_vi.type.tensor_type.elem_type, _dims_of(zcac_vi))
+        "z_cac", zcac_vi.type.tensor_type.elem_type, _dims_of(zcac_vi)
+    )
 
     fanout = []
     for i in range(4):
-        fanout.append(helper.make_node(
-            "Identity", ["mix"], [f"h{i}__mix"], name=f"fanout_mix_{i}"))
-        fanout.append(helper.make_node(
-            "Identity", ["z_cac"], [f"h{i}__z_cac"], name=f"fanout_zcac_{i}"))
+        fanout.append(helper.make_node("Identity", ["mix"], [f"h{i}__mix"], name=f"fanout_mix_{i}"))
+        fanout.append(
+            helper.make_node("Identity", ["z_cac"], [f"h{i}__z_cac"], name=f"fanout_zcac_{i}")
+        )
 
     g = fused.graph
     skip = {f"h{i}__mix" for i in range(4)} | {f"h{i}__z_cac" for i in range(4)}
@@ -137,21 +141,33 @@ def fuse_ft(head_paths: list[Path], dst_onnx: Path) -> onnx.ModelProto:
     picked_time = []
     picked_zcac = []
     for i in range(4):
-        picker_nodes.append(helper.make_node(
-            "Gather", [f"h{i}__time_out", f"src_idx_{i}"], [f"pick_time_{i}"],
-            name=f"pick_time_{i}", axis=1))
-        picker_nodes.append(helper.make_node(
-            "Gather", [f"h{i}__zout_cac", f"src_idx_{i}"], [f"pick_zcac_{i}"],
-            name=f"pick_zcac_{i}", axis=1))
+        picker_nodes.append(
+            helper.make_node(
+                "Gather",
+                [f"h{i}__time_out", f"src_idx_{i}"],
+                [f"pick_time_{i}"],
+                name=f"pick_time_{i}",
+                axis=1,
+            )
+        )
+        picker_nodes.append(
+            helper.make_node(
+                "Gather",
+                [f"h{i}__zout_cac", f"src_idx_{i}"],
+                [f"pick_zcac_{i}"],
+                name=f"pick_zcac_{i}",
+                axis=1,
+            )
+        )
         picked_time.append(f"pick_time_{i}")
         picked_zcac.append(f"pick_zcac_{i}")
     # Concat along axis=1 (source dim) to reconstruct a 4-stem tensor.
-    picker_nodes.append(helper.make_node(
-        "Concat", picked_time, ["time_out_stacked"],
-        name="concat_time", axis=1))
-    picker_nodes.append(helper.make_node(
-        "Concat", picked_zcac, ["zout_cac_stacked"],
-        name="concat_zcac", axis=1))
+    picker_nodes.append(
+        helper.make_node("Concat", picked_time, ["time_out_stacked"], name="concat_time", axis=1)
+    )
+    picker_nodes.append(
+        helper.make_node("Concat", picked_zcac, ["zout_cac_stacked"], name="concat_zcac", axis=1)
+    )
 
     g.node.extend(picker_nodes)
 
@@ -164,14 +180,16 @@ def fuse_ft(head_paths: list[Path], dst_onnx: Path) -> onnx.ModelProto:
     # CPU fallback). Hardcoding the output value_info from the static input
     # dims avoids that — the upstream Gather+Concat are mathematically equivalent
     # to (batch, 4 sources, mix_channels, mix_samples).
-    mix_dims = _dims_of(mix_vi)        # (1, 2, 343980)
-    zcac_dims = _dims_of(zcac_vi)      # (1, 4, 2048, 336)
+    mix_dims = _dims_of(mix_vi)  # (1, 2, 343980)
+    zcac_dims = _dims_of(zcac_vi)  # (1, 4, 2048, 336)
     time_shape_static = [mix_dims[0], 4, mix_dims[1], mix_dims[2]]
     zcac_shape_static = [zcac_dims[0], 4, zcac_dims[1], zcac_dims[2], zcac_dims[3]]
     new_time = helper.make_tensor_value_info(
-        "time_out_stacked", TensorProto.FLOAT, time_shape_static)
+        "time_out_stacked", TensorProto.FLOAT, time_shape_static
+    )
     new_zcac = helper.make_tensor_value_info(
-        "zout_cac_stacked", TensorProto.FLOAT, zcac_shape_static)
+        "zout_cac_stacked", TensorProto.FLOAT, zcac_shape_static
+    )
     del g.output[:]
     g.output.extend([new_time, new_zcac])
 
@@ -223,8 +241,7 @@ def main(argv: list[str] | None = None) -> int:
 
     out_dir = Path(args.out_dir)
     out_path = out_dir / args.out_name
-    head_paths = [out_dir / f"htdemucs_ft.head{i}_static.onnx"
-                  for i in range(4)]
+    head_paths = [out_dir / f"htdemucs_ft.head{i}_static.onnx" for i in range(4)]
     for p in head_paths:
         if not p.exists():
             print(f"MISSING: {p}", file=sys.stderr)

--- a/v0/src/A0/fusion_debug/02_uuid_cache_retry.py
+++ b/v0/src/A0/fusion_debug/02_uuid_cache_retry.py
@@ -18,6 +18,7 @@ Outputs
   /tmp/sf_fusion_debug/02_uuid_cache.log   — full verbose ORT log
   /tmp/sf_fusion_debug/02_uuid_cache.json  — structured summary
 """
+
 from __future__ import annotations
 
 import json

--- a/v0/src/A0/fusion_debug/03_subgraphs_off_retry.py
+++ b/v0/src/A0/fusion_debug/03_subgraphs_off_retry.py
@@ -26,6 +26,7 @@ Outputs
   /tmp/sf_fusion_debug/03_subgraphs_off.log         — combined verbose log
   /tmp/sf_fusion_debug/03_subgraphs_off.json        — {combo: result}
 """
+
 from __future__ import annotations
 
 import json
@@ -100,9 +101,7 @@ def run_one(name: str, opts: dict[str, str]) -> dict:
     sess_opts.log_severity_level = 0
     sess_opts.log_verbosity_level = 1
     try:
-        sess_opts.add_session_config_entry(
-            "session.coreml.model_cache_dir", str(cache_dir)
-        )
+        sess_opts.add_session_config_entry("session.coreml.model_cache_dir", str(cache_dir))
     except Exception:  # noqa: BLE001
         pass
 
@@ -138,17 +137,19 @@ def run_one(name: str, opts: dict[str, str]) -> dict:
         and "CoreMLExecutionProvider" in result["providers_resolved"]
         and result["error"] is None
     )
-    print(f"[03] result {name}: compiled={result['coreml_compiled']} "
-          f"loaded={result['coreml_loaded']} "
-          f"infer={result['inference_sec']}s err={result['error']}", flush=True)
+    print(
+        f"[03] result {name}: compiled={result['coreml_compiled']} "
+        f"loaded={result['coreml_loaded']} "
+        f"infer={result['inference_sec']}s err={result['error']}",
+        flush=True,
+    )
     return result
 
 
 def main() -> int:
     if not FUSED.exists():
         print(f"ERROR: missing fused artifact: {FUSED}", file=sys.stderr)
-        print("Run `uv run --active python -m v0.src.A0.fuse_ft` first.",
-              file=sys.stderr)
+        print("Run `uv run --active python -m v0.src.A0.fuse_ft` first.", file=sys.stderr)
         return 2
 
     results: dict[str, dict] = {}
@@ -167,11 +168,7 @@ def main() -> int:
     print(json.dumps(results, indent=2))
 
     # Exit 0 if at least one combo (other than D CPUOnly) compiled on CoreML.
-    success = any(
-        r["coreml_compiled"]
-        for name, r in results.items()
-        if name != "D_cpuonly_sanity"
-    )
+    success = any(r["coreml_compiled"] for name, r in results.items() if name != "D_cpuonly_sanity")
     return 0 if success else 1
 
 

--- a/v0/src/A0/fusion_parity.py
+++ b/v0/src/A0/fusion_parity.py
@@ -15,6 +15,7 @@ Uses CPU EP on both sides. CoreML EP testing for the fused graph is
 blocked by the MLProgram SystemError 20 compile failure
 (see v0/state/A/fusion_aborted.md for details).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -22,7 +23,6 @@ import json
 import math
 import sys
 import time
-from pathlib import Path
 
 import numpy as np
 import onnxruntime as ort
@@ -35,8 +35,7 @@ FT_MODELS_DIR = config.BUILD_MODELS_DIR / "htdemucs_ft"
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--fused", default=str(FT_MODELS_DIR / "htdemucs_ft_fused.onnx"))
-    p.add_argument("--fixture", default=str(
-        config.REPO_ROOT / "v0/tests/fixtures/short_loop.wav"))
+    p.add_argument("--fixture", default=str(config.REPO_ROOT / "v0/tests/fixtures/short_loop.wav"))
     args = p.parse_args(argv)
 
     import soundfile as sf
@@ -63,11 +62,12 @@ def main(argv: list[str] | None = None) -> int:
     unfused_sess = [
         ort.InferenceSession(
             str(FT_MODELS_DIR / f"htdemucs_ft.head{i}_static.onnx"),
-            providers=["CPUExecutionProvider"]) for i in range(4)
+            providers=["CPUExecutionProvider"],
+        )
+        for i in range(4)
     ]
     t0 = time.perf_counter()
-    unfused_outs = [s.run(None, {"mix": mix_in, "z_cac": z_cac})
-                    for s in unfused_sess]
+    unfused_outs = [s.run(None, {"mix": mix_in, "z_cac": z_cac}) for s in unfused_sess]
     t_unfused = time.perf_counter() - t0
     print(f"unfused bag seq    = {t_unfused:.3f} s (CPU, 4 heads)")
 
@@ -77,24 +77,24 @@ def main(argv: list[str] | None = None) -> int:
     max_abs_z = 0.0
     for i in range(4):
         # Each unfused head outputs (1, 4, 2, N); for head i, specialist source = i.
-        ref_t = unfused_outs[i][0][:, i:i + 1]  # keepdims
-        got_t = fused_time[:, i:i + 1]
-        ref_z = unfused_outs[i][1][:, i:i + 1]
-        got_z = fused_zcac[:, i:i + 1]
+        ref_t = unfused_outs[i][0][:, i : i + 1]  # keepdims
+        got_t = fused_time[:, i : i + 1]
+        ref_z = unfused_outs[i][1][:, i : i + 1]
+        got_z = fused_zcac[:, i : i + 1]
         d_t = float(np.max(np.abs(ref_t - got_t)))
         d_z = float(np.max(np.abs(ref_z - got_z)))
         rms_t_lin = float(np.sqrt(np.mean((ref_t - got_t) ** 2)))
         rms_t_db = -240.0 if rms_t_lin <= 0 else 20.0 * math.log10(rms_t_lin)
-        per_source.append({"source_index": i, "max_abs_time": d_t,
-                           "max_abs_zcac": d_z, "rms_time_dbfs": rms_t_db})
+        per_source.append(
+            {"source_index": i, "max_abs_time": d_t, "max_abs_zcac": d_z, "rms_time_dbfs": rms_t_db}
+        )
         max_abs_t = max(max_abs_t, d_t)
         max_abs_z = max(max_abs_z, d_z)
 
     # Combined time-branch residual RMS.
-    combined_time_ref = np.concatenate(
-        [unfused_outs[i][0][:, i:i + 1] for i in range(4)], axis=1)
+    combined_time_ref = np.concatenate([unfused_outs[i][0][:, i : i + 1] for i in range(4)], axis=1)
     resid = combined_time_ref.astype(np.float64) - fused_time.astype(np.float64)
-    rms = float(np.sqrt(np.mean(resid ** 2)))
+    rms = float(np.sqrt(np.mean(resid**2)))
     rms_db = -240.0 if rms <= 0 else 20.0 * math.log10(rms)
 
     summary = {
@@ -110,12 +110,13 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(summary, indent=2))
 
     if summary["parity_pass_lt_60dbfs"]:
-        print("\nPARITY PASS: time-branch RMS residual "
-              f"{rms_db:+.1f} dBFS ≤ -60 dBFS threshold")
+        print(f"\nPARITY PASS: time-branch RMS residual {rms_db:+.1f} dBFS ≤ -60 dBFS threshold")
         return 0
     else:
-        print(f"\nPARITY FAIL: time-branch RMS residual {rms_db:+.1f} dBFS "
-              "> -60 dBFS threshold", file=sys.stderr)
+        print(
+            f"\nPARITY FAIL: time-branch RMS residual {rms_db:+.1f} dBFS > -60 dBFS threshold",
+            file=sys.stderr,
+        )
         return 1
 
 

--- a/v0/src/A0/fusion_smoke.py
+++ b/v0/src/A0/fusion_smoke.py
@@ -27,6 +27,7 @@ Invocation::
     # or (explicit ORT verbose logging):
     ORT_LOG_LEVEL=VERBOSE uv run --active python -m v0.src.A0.fusion_smoke
 """
+
 from __future__ import annotations
 
 import argparse
@@ -39,7 +40,6 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import onnx
 import onnxruntime as ort
 
@@ -63,8 +63,7 @@ class SmokeResult:
         return asdict(self)
 
 
-def _prefix_model(model: onnx.ModelProto, prefix: str,
-                  rename_io: bool = True) -> onnx.ModelProto:
+def _prefix_model(model: onnx.ModelProto, prefix: str, rename_io: bool = True) -> onnx.ModelProto:
     """Add a prefix to every name in the model (optionally including I/O)."""
     return onnx.compose.add_prefix(
         model,
@@ -129,23 +128,29 @@ def fuse_heads(head_paths: list[Path], dst_onnx: Path) -> onnx.ModelProto:
         raise RuntimeError("cannot find head 0 inputs in fused graph")
 
     shared_mix = helper.make_tensor_value_info(
-        "mix", mix_vi.type.tensor_type.elem_type,
-        [d.dim_value if d.HasField("dim_value") else d.dim_param
-         for d in mix_vi.type.tensor_type.shape.dim],
+        "mix",
+        mix_vi.type.tensor_type.elem_type,
+        [
+            d.dim_value if d.HasField("dim_value") else d.dim_param
+            for d in mix_vi.type.tensor_type.shape.dim
+        ],
     )
     shared_zcac = helper.make_tensor_value_info(
-        "z_cac", zcac_vi.type.tensor_type.elem_type,
-        [d.dim_value if d.HasField("dim_value") else d.dim_param
-         for d in zcac_vi.type.tensor_type.shape.dim],
+        "z_cac",
+        zcac_vi.type.tensor_type.elem_type,
+        [
+            d.dim_value if d.HasField("dim_value") else d.dim_param
+            for d in zcac_vi.type.tensor_type.shape.dim
+        ],
     )
 
     # Identity nodes copying shared inputs → per-head renamed inputs.
     fanout_nodes = []
     for i, (m_in, z_in) in enumerate(head_inputs):
-        fanout_nodes.append(helper.make_node(
-            "Identity", ["mix"], [m_in], name=f"fanout_mix_{i}"))
-        fanout_nodes.append(helper.make_node(
-            "Identity", ["z_cac"], [z_in], name=f"fanout_zcac_{i}"))
+        fanout_nodes.append(helper.make_node("Identity", ["mix"], [m_in], name=f"fanout_mix_{i}"))
+        fanout_nodes.append(
+            helper.make_node("Identity", ["z_cac"], [z_in], name=f"fanout_zcac_{i}")
+        )
 
     # Mutate fused.graph: replace inputs with just (mix, z_cac), and prepend
     # fanout nodes. The per-head names become internal edges.
@@ -154,7 +159,8 @@ def fuse_heads(head_paths: list[Path], dst_onnx: Path) -> onnx.ModelProto:
     # Keep any other inputs that were NOT per-head mix/zcac (shouldn't be any).
     skip = set()
     for m_in, z_in in head_inputs:
-        skip.add(m_in); skip.add(z_in)
+        skip.add(m_in)
+        skip.add(z_in)
     for vi in list(g.input):
         if vi.name not in skip and vi.name not in {"mix", "z_cac"}:
             new_inputs.append(vi)
@@ -214,7 +220,6 @@ def _capture_coreml_coverage(onnx_path: Path, verbose_log: Path) -> SmokeResult:
 
     # Force verbose logging — CoreML EP prints its GetCapability line at VERBOSE.
     # We redirect stderr to a file to capture it.
-    import contextlib
 
     sess_opts = ort.SessionOptions()
     sess_opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -235,9 +240,9 @@ def _capture_coreml_coverage(onnx_path: Path, verbose_log: Path) -> SmokeResult:
         os.dup2(log_fd, 2)
         try:
             sess = ort.InferenceSession(
-                str(onnx_path), sess_opts,
-                providers=[("CoreMLExecutionProvider", coreml_opts),
-                           "CPUExecutionProvider"],
+                str(onnx_path),
+                sess_opts,
+                providers=[("CoreMLExecutionProvider", coreml_opts), "CPUExecutionProvider"],
             )
             result.coreml_loaded = True
             # Optional: actually run once with zero inputs so CoreML compile happens.
@@ -263,6 +268,7 @@ def _capture_coreml_coverage(onnx_path: Path, verbose_log: Path) -> SmokeResult:
             result.verbose_log_snippets.append(line.strip())
     # Best-effort parse of N / total.
     import re
+
     m_supported = re.search(r"number of nodes supported by CoreML:\s*(\d+)", text)
     m_total = re.search(r"number of nodes in the graph:\s*(\d+)", text)
     m_parts = re.search(r"number of partitions supported by CoreML:\s*(\d+)", text)
@@ -282,15 +288,18 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--head1", default=str(FT_MODELS_DIR / "htdemucs_ft.head1_static.onnx"))
     p.add_argument("--out", default="/tmp/sf_fusion_smoke.onnx")
     p.add_argument("--log", default="/tmp/sf_fusion_smoke.verbose.log")
-    p.add_argument("--threshold", type=float, default=90.0,
-                   help="coverage %% below which Phase 2 must abort")
+    p.add_argument(
+        "--threshold", type=float, default=90.0, help="coverage %% below which Phase 2 must abort"
+    )
     args = p.parse_args(argv)
 
     h0 = Path(args.head0)
     h1 = Path(args.head1)
     if not h0.exists() or not h1.exists():
-        print(f"MISSING head files: {h0=} exists={h0.exists()} "
-              f"{h1=} exists={h1.exists()}", file=sys.stderr)
+        print(
+            f"MISSING head files: {h0=} exists={h0.exists()} {h1=} exists={h1.exists()}",
+            file=sys.stderr,
+        )
         return 2
 
     out = Path(args.out)
@@ -304,29 +313,38 @@ def main(argv: list[str] | None = None) -> int:
     fuse_dt = time.perf_counter() - t0
 
     result = _capture_coreml_coverage(out, Path(args.log))
-    print(json.dumps({
-        "fused_path": result.fused_path,
-        "fuse_sec": round(fuse_dt, 3),
-        "coreml_loaded": result.coreml_loaded,
-        "coverage_pct": result.coverage_pct,
-        "coreml_partitions": result.coreml_partitions,
-        "coreml_nodes_supported": result.coreml_nodes_supported,
-        "total_nodes": result.total_nodes,
-        "verbose_log": args.log,
-        "error": result.error,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "fused_path": result.fused_path,
+                "fuse_sec": round(fuse_dt, 3),
+                "coreml_loaded": result.coreml_loaded,
+                "coverage_pct": result.coverage_pct,
+                "coreml_partitions": result.coreml_partitions,
+                "coreml_nodes_supported": result.coreml_nodes_supported,
+                "total_nodes": result.total_nodes,
+                "verbose_log": args.log,
+                "error": result.error,
+            },
+            indent=2,
+        )
+    )
 
     if result.coverage_pct is None:
-        print(f"\nABORT: could not parse CoreML coverage from {args.log}",
-              file=sys.stderr)
+        print(f"\nABORT: could not parse CoreML coverage from {args.log}", file=sys.stderr)
         return 4
     if result.coverage_pct < args.threshold:
-        print(f"\nABORT: 2-head fusion coverage {result.coverage_pct:.1f}% "
-              f"< threshold {args.threshold}%", file=sys.stderr)
+        print(
+            f"\nABORT: 2-head fusion coverage {result.coverage_pct:.1f}% "
+            f"< threshold {args.threshold}%",
+            file=sys.stderr,
+        )
         return 5
 
-    print(f"\nPHASE 1 PASS: 2-head fusion CoreML coverage "
-          f"{result.coverage_pct:.1f}% ≥ {args.threshold}% — proceed to Phase 2")
+    print(
+        f"\nPHASE 1 PASS: 2-head fusion CoreML coverage "
+        f"{result.coverage_pct:.1f}% ≥ {args.threshold}% — proceed to Phase 2"
+    )
     return 0
 
 

--- a/v0/src/A0/generate_static.py
+++ b/v0/src/A0/generate_static.py
@@ -35,11 +35,16 @@ TIME_OUT_SHAPE = [4, 2, 343980]
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate static-shape ONNX from fused htdemucs_ft")
-    parser.add_argument("--input",  default=DEFAULT_INPUT,  help="Path to htdemucs_ft_fused.onnx")
+    parser = argparse.ArgumentParser(
+        description="Generate static-shape ONNX from fused htdemucs_ft"
+    )
+    parser.add_argument("--input", default=DEFAULT_INPUT, help="Path to htdemucs_ft_fused.onnx")
     parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Path to write the static .onnx")
-    parser.add_argument("--save-to-repo", action="store_true",
-                        help="Also copy the result into v0/build/models/htdemucs_ft/ (repo path)")
+    parser.add_argument(
+        "--save-to-repo",
+        action="store_true",
+        help="Also copy the result into v0/build/models/htdemucs_ft/ (repo path)",
+    )
     args = parser.parse_args()
 
     # -----------------------------------------------------------------------
@@ -53,7 +58,7 @@ def main():
         print("  pip install onnx")
         sys.exit(1)
 
-    input_path  = Path(args.input)
+    input_path = Path(args.input)
     output_path = Path(args.output)
 
     # -----------------------------------------------------------------------
@@ -154,6 +159,7 @@ def main():
     if args.save_to_repo:
         REPO_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
         import shutil
+
         shutil.copy2(str(output_path), str(REPO_OUTPUT))
         print(f"Also saved to repo:\n  {REPO_OUTPUT}")
         print()
@@ -166,9 +172,9 @@ def main():
     print()
     print("1. Upload to Modal volume:")
     print("   modal volume create stemforge-models  # skip if already exists")
-    print(f"   modal volume put stemforge-models \\")
+    print("   modal volume put stemforge-models \\")
     print(f'     "{output_path}" \\')
-    print(f"     /htdemucs_ft_fused_static.onnx")
+    print("     /htdemucs_ft_fused_static.onnx")
     print()
     print("2. Run the CUDA compatibility test:")
     print("   modal run test_cuda_compat.py")

--- a/v0/src/A0/generate_static_onnx.py
+++ b/v0/src/A0/generate_static_onnx.py
@@ -55,7 +55,7 @@ def main():
         print("ERROR: onnx not found. Install with: pip install onnx")
         sys.exit(1)
 
-    input_path  = Path(args.input)
+    input_path = Path(args.input)
     output_path = Path(args.output)
 
     if not input_path.exists():
@@ -121,9 +121,9 @@ def main():
     print("=" * 60)
     print("Next steps:\n")
     print("  modal volume create stemforge-models  # skip if already exists")
-    print(f"  modal volume put stemforge-models \\")
+    print("  modal volume put stemforge-models \\")
     print(f'    "{output_path}" \\')
-    print( "    /htdemucs_ft_fused_static.onnx\n")
+    print("    /htdemucs_ft_fused_static.onnx\n")
     print("  modal run test_cuda_compat.py")
     print("=" * 60)
 

--- a/v0/src/A0/manifest.py
+++ b/v0/src/A0/manifest.py
@@ -27,6 +27,7 @@ Schema (frozen here, consumed by Track A, Track E, Track F):
       }
     }
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -59,6 +60,7 @@ def _utcnow() -> str:
 def _ort_version() -> str:
     try:
         import onnxruntime
+
         return onnxruntime.__version__
     except Exception:
         return "unknown"
@@ -66,7 +68,9 @@ def _ort_version() -> str:
 
 def _model_io_shapes(onnx_path: Path) -> tuple[dict, dict]:
     import onnx
+
     m = onnx.load(str(onnx_path), load_external_data=False)
+
     def _shape(t):
         dims = []
         for d in t.type.tensor_type.shape.dim:
@@ -75,25 +79,32 @@ def _model_io_shapes(onnx_path: Path) -> tuple[dict, dict]:
             else:
                 dims.append(d.dim_param or "dynamic")
         return dims
+
     inputs = {t.name: _shape(t) for t in m.graph.input}
     outputs = {t.name: _shape(t) for t in m.graph.output}
     return inputs, outputs
 
 
-def build_entry(onnx_path: Path, *,
-                torch_ref_checkpoint: str,
-                max_abs_err: float,
-                max_rel_err: float,
-                precision: str,
-                coreml_ep_supported: bool,
-                cpu_fallback_ops: list[str],
-                optimized_cache: Path | None,
-                notes: str = "") -> dict[str, Any]:
+def build_entry(
+    onnx_path: Path,
+    *,
+    torch_ref_checkpoint: str,
+    max_abs_err: float,
+    max_rel_err: float,
+    precision: str,
+    coreml_ep_supported: bool,
+    cpu_fallback_ops: list[str],
+    optimized_cache: Path | None,
+    notes: str = "",
+) -> dict[str, Any]:
     inputs, outputs = _model_io_shapes(onnx_path)
     # Path stored in manifest is relative to repo root for portability.
     rel_path = onnx_path.resolve().relative_to(config.REPO_ROOT)
-    rel_cache = (optimized_cache.resolve().relative_to(config.REPO_ROOT)
-                 if optimized_cache and optimized_cache.exists() else None)
+    rel_cache = (
+        optimized_cache.resolve().relative_to(config.REPO_ROOT)
+        if optimized_cache and optimized_cache.exists()
+        else None
+    )
     return {
         "path": str(rel_path),
         "sha256": sha256_of_file(onnx_path),

--- a/v0/src/A0/progress.py
+++ b/v0/src/A0/progress.py
@@ -10,10 +10,10 @@ Follows the shared-memory protocol in `v0/SHARED.md`:
 
 Only A0 writes these paths. Other tracks are read-only over them.
 """
+
 from __future__ import annotations
 
 import json
-import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -45,8 +45,9 @@ def emit(phase: str, pct: int | float, message: str, **fields: Any) -> None:
     sys.stderr.flush()
 
 
-def write_artifacts(status: str, artifacts: list[dict[str, Any]],
-                    duration_sec: float, **extras: Any) -> None:
+def write_artifacts(
+    status: str, artifacts: list[dict[str, Any]], duration_sec: float, **extras: Any
+) -> None:
     """Write the artifacts.json summary (SHARED.md format)."""
     config.A0_STATE_DIR.mkdir(parents=True, exist_ok=True)
     doc = {
@@ -86,8 +87,7 @@ def write_blocker(title: str, body_md: str) -> None:
 class Timer:
     """Context manager that records per-stage wall-clock latency into perf.json."""
 
-    def __init__(self, stage: str, perf_path: Path = config.STATE_PERF_JSON,
-                 **extras: Any) -> None:
+    def __init__(self, stage: str, perf_path: Path = config.STATE_PERF_JSON, **extras: Any) -> None:
         self.stage = stage
         self.perf_path = perf_path
         self.extras = extras
@@ -99,8 +99,9 @@ class Timer:
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         dt = time.perf_counter() - self.t0
-        self._append({"stage": self.stage, "seconds": round(dt, 4),
-                      "failed": exc is not None, **self.extras})
+        self._append(
+            {"stage": self.stage, "seconds": round(dt, 4), "failed": exc is not None, **self.extras}
+        )
 
     def _append(self, rec: dict[str, Any]) -> None:
         self.perf_path.parent.mkdir(parents=True, exist_ok=True)

--- a/v0/src/A0/quantize.py
+++ b/v0/src/A0/quantize.py
@@ -8,11 +8,12 @@ within 1% of fp32 reference. Skip (not fail) if non-trivial; flag as
 Demucs is explicitly **out of scope** — the brief states int8 quant is
 almost certainly too lossy for a waveform regression model.
 """
+
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable
 
 
 @dataclass
@@ -55,10 +56,14 @@ def quantize_dynamic(src: Path, dst: Path) -> None:
     )
 
 
-def attempt_int8(src: Path, dst: Path, model_name: str,
-                 eval_fn: Callable[[Path], float],
-                 min_samples: int = 200,
-                 max_accuracy_drop: float = 0.01) -> QuantAttempt:
+def attempt_int8(
+    src: Path,
+    dst: Path,
+    model_name: str,
+    eval_fn: Callable[[Path], float],
+    min_samples: int = 200,
+    max_accuracy_drop: float = 0.01,
+) -> QuantAttempt:
     """
     Attempt int8 dynamic quantization + eval.
 
@@ -69,17 +74,23 @@ def attempt_int8(src: Path, dst: Path, model_name: str,
     try:
         quantize_dynamic(src, dst)
     except Exception as e:
-        return QuantAttempt(model_name=model_name, src_path=str(src),
-                            int8_path=None,
-                            reason=f"quantize_dynamic failed: {e!s}")
+        return QuantAttempt(
+            model_name=model_name,
+            src_path=str(src),
+            int8_path=None,
+            reason=f"quantize_dynamic failed: {e!s}",
+        )
 
     try:
         fp32_top1 = eval_fn(src)
         int8_top1 = eval_fn(dst)
     except Exception as e:
-        return QuantAttempt(model_name=model_name, src_path=str(src),
-                            int8_path=str(dst),
-                            reason=f"eval failed: {e!s}")
+        return QuantAttempt(
+            model_name=model_name,
+            src_path=str(src),
+            int8_path=str(dst),
+            reason=f"eval failed: {e!s}",
+        )
 
     delta = float(fp32_top1 - int8_top1)
     passed = delta <= max_accuracy_drop
@@ -91,7 +102,9 @@ def attempt_int8(src: Path, dst: Path, model_name: str,
         int8_top1=round(float(int8_top1), 4),
         accuracy_delta=round(delta, 4),
         passed=passed,
-        reason=("within 1% of fp32" if passed
-                else f"top-1 dropped {delta*100:.2f}% > 1% threshold; "
-                     "not shipping int8"),
+        reason=(
+            "within 1% of fp32"
+            if passed
+            else f"top-1 dropped {delta * 100:.2f}% > 1% threshold; not shipping int8"
+        ),
     )

--- a/v0/src/A0/reexport_static.py
+++ b/v0/src/A0/reexport_static.py
@@ -32,6 +32,7 @@ For each variant we:
 The original dynamic ONNX files are kept on disk so the C++ host can
 fall back to them.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -41,7 +42,7 @@ import math
 import sys
 import time
 import traceback
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any
 
@@ -118,12 +119,12 @@ def export_static_head(head_module, dst_onnx: Path, segment_samples: int) -> Pat
 
 def _onnx_inference_static(onnx_path: Path, mix_np: np.ndarray) -> np.ndarray:
     """Run the static ONNX once with fresh CPU-only session — for parity."""
-    return demucs_export.run_head_onnx(onnx_path, mix_np,
-                                       providers=["CPUExecutionProvider"])
+    return demucs_export.run_head_onnx(onnx_path, mix_np, providers=["CPUExecutionProvider"])
 
 
-def _parity_check(static_path: Path, dynamic_path: Path,
-                  segment_samples: int, fixture: np.ndarray) -> tuple[float, float, bool]:
+def _parity_check(
+    static_path: Path, dynamic_path: Path, segment_samples: int, fixture: np.ndarray
+) -> tuple[float, float, bool]:
     """
     Numerical parity static vs dynamic on a real fixture.
 
@@ -139,7 +140,7 @@ def _parity_check(static_path: Path, dynamic_path: Path,
         return float("nan"), float("nan"), False
     diff = static_out - dyn_out
     max_abs = float(np.max(np.abs(diff)))
-    rms = float(np.sqrt(np.mean(diff ** 2)))
+    rms = float(np.sqrt(np.mean(diff**2)))
     rms_dbfs = -240.0 if rms <= 0 else 20.0 * math.log10(rms)
     # Static and dynamic graphs must produce identical outputs (same
     # compute, just different shape metadata). Tight tolerance.
@@ -147,8 +148,7 @@ def _parity_check(static_path: Path, dynamic_path: Path,
     return max_abs, rms_dbfs, pass_
 
 
-def _probe_coreml(static_path: Path, segment_samples: int,
-                  variant: str) -> dict[str, Any]:
+def _probe_coreml(static_path: Path, segment_samples: int, variant: str) -> dict[str, Any]:
     """Run a single CoreML EP probe with the most-promising option set."""
     from . import coreml_probe_static as cps
 
@@ -161,20 +161,17 @@ def _probe_coreml(static_path: Path, segment_samples: int,
         "RequireStaticInputShapes": "1",
         "EnableOnSubgraphs": "1",
     }
-    cml = cps.probe_one(f"{variant}_static", static_path, inputs, opts,
-                        n_warmup=2, n_timed=3)
-    cpu = cps.probe_one(f"{variant}_static_cpu", static_path, inputs, None,
-                       n_warmup=1, n_timed=2)
+    cml = cps.probe_one(f"{variant}_static", static_path, inputs, opts, n_warmup=2, n_timed=3)
+    cpu = cps.probe_one(f"{variant}_static_cpu", static_path, inputs, None, n_warmup=1, n_timed=2)
     return {
         "coreml": cml.as_dict(),
         "cpu": cpu.as_dict(),
     }
 
 
-def reexport_variant(variant: str,
-                     fixture: np.ndarray | None,
-                     skip_parity: bool = False,
-                     skip_coreml: bool = False) -> list[ReexportResult]:
+def reexport_variant(
+    variant: str, fixture: np.ndarray | None, skip_parity: bool = False, skip_coreml: bool = False
+) -> list[ReexportResult]:
     from demucs.pretrained import get_model
 
     print(f"[{variant}] loading torch bag", flush=True)
@@ -199,20 +196,21 @@ def reexport_variant(variant: str,
 
     results: list[ReexportResult] = []
     for i, (head, dst) in enumerate(zip(bag.models, static_paths)):
-        r = ReexportResult(variant=variant, head_index=i,
-                           dynamic_path=str(onnx_paths[i]),
-                           static_path=str(dst))
+        r = ReexportResult(
+            variant=variant, head_index=i, dynamic_path=str(onnx_paths[i]), static_path=str(dst)
+        )
         try:
-            print(f"[{variant}] exporting static head {i+1}/{n} → {dst.name}",
-                  flush=True)
+            print(f"[{variant}] exporting static head {i + 1}/{n} → {dst.name}", flush=True)
             t0 = time.perf_counter()
             export_static_head(head.eval(), dst, seg)
             dt = time.perf_counter() - t0
             r.static_size_bytes = dst.stat().st_size
             r.static_sha256 = _sha256(dst)
-            print(f"[{variant}]   exported in {dt:.1f}s "
-                  f"size={r.static_size_bytes/1e6:.1f}MB sha={r.static_sha256[:12]}",
-                  flush=True)
+            print(
+                f"[{variant}]   exported in {dt:.1f}s "
+                f"size={r.static_size_bytes / 1e6:.1f}MB sha={r.static_sha256[:12]}",
+                flush=True,
+            )
         except Exception as e:
             r.error = f"export: {type(e).__name__}: {e!s}"[:600]
             traceback.print_exc()
@@ -227,8 +225,10 @@ def reexport_variant(variant: str,
                 r.parity_max_abs = ma
                 r.parity_residual_rms_dbfs = rms_db
                 r.parity_pass = ok
-                print(f"[{variant}]   parity max_abs={ma:.3e} "
-                      f"rms={rms_db:+.1f}dBFS pass={ok}", flush=True)
+                print(
+                    f"[{variant}]   parity max_abs={ma:.3e} rms={rms_db:+.1f}dBFS pass={ok}",
+                    flush=True,
+                )
             except Exception as e:
                 r.error = (r.error or "") + f" | parity: {e!s}"[:200]
                 print(f"[{variant}]   parity check failed: {e!s}", flush=True)
@@ -243,11 +243,13 @@ def reexport_variant(variant: str,
                 r.coreml_partition_pct = cml["coreml"]["coreml_partition_pct"]
                 r.coreml_mean_latency_sec = cml["coreml"]["mean_latency_sec"]
                 r.cpu_only_mean_latency_sec = cml["cpu"]["mean_latency_sec"]
-                print(f"[{variant}]   coreml loaded={r.coreml_loaded} "
-                      f"part%={r.coreml_partition_pct} "
-                      f"cml_lat={r.coreml_mean_latency_sec}s "
-                      f"cpu_lat={r.cpu_only_mean_latency_sec}s",
-                      flush=True)
+                print(
+                    f"[{variant}]   coreml loaded={r.coreml_loaded} "
+                    f"part%={r.coreml_partition_pct} "
+                    f"cml_lat={r.coreml_mean_latency_sec}s "
+                    f"cpu_lat={r.cpu_only_mean_latency_sec}s",
+                    flush=True,
+                )
             except Exception as e:
                 r.error = (r.error or "") + f" | coreml: {e!s}"[:200]
 
@@ -271,34 +273,41 @@ def _load_fixture() -> np.ndarray | None:
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
-    p.add_argument("--models", nargs="*",
-                   default=list(config.DEMUCS_MODELS.keys()),
-                   choices=list(config.DEMUCS_MODELS.keys()))
+    p.add_argument(
+        "--models",
+        nargs="*",
+        default=list(config.DEMUCS_MODELS.keys()),
+        choices=list(config.DEMUCS_MODELS.keys()),
+    )
     p.add_argument("--skip-parity", action="store_true")
     p.add_argument("--skip-coreml", action="store_true")
     args = p.parse_args(argv)
 
     fixture = _load_fixture()
     if fixture is None:
-        print("warning: no v0/tests/fixtures/short_loop.wav — skipping parity",
-              file=sys.stderr)
+        print("warning: no v0/tests/fixtures/short_loop.wav — skipping parity", file=sys.stderr)
 
     all_results: list[ReexportResult] = []
     for variant in args.models:
         try:
             all_results += reexport_variant(
-                variant, fixture,
+                variant,
+                fixture,
                 skip_parity=args.skip_parity or fixture is None,
                 skip_coreml=args.skip_coreml,
             )
         except Exception as e:
             print(f"[{variant}] FAILED: {e!s}", file=sys.stderr)
             traceback.print_exc()
-            all_results.append(ReexportResult(
-                variant=variant, head_index=-1,
-                dynamic_path="", static_path="",
-                error=f"variant: {type(e).__name__}: {e!s}"[:600],
-            ))
+            all_results.append(
+                ReexportResult(
+                    variant=variant,
+                    head_index=-1,
+                    dynamic_path="",
+                    static_path="",
+                    error=f"variant: {type(e).__name__}: {e!s}"[:600],
+                )
+            )
 
     # Persist report.
     out_dir = config.A0_STATE_DIR

--- a/v0/src/A0/tests/conftest.py
+++ b/v0/src/A0/tests/conftest.py
@@ -3,9 +3,9 @@ Shared test fixtures — kept light so CI doesn't need to download torch
 reference models. Every test here runs in under a second and uses only
 numpy + onnx (no torch, no transformers, no demucs).
 """
+
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -27,6 +27,7 @@ def _ensure_v0_package(monkeypatch, tmp_path):
     in-memory via `sys.modules` monkey-patching.
     """
     import types
+
     if "v0" not in sys.modules:
         v0 = types.ModuleType("v0")
         v0.__path__ = [str(REPO_ROOT / "v0")]

--- a/v0/src/A0/tests/test_config.py
+++ b/v0/src/A0/tests/test_config.py
@@ -1,4 +1,5 @@
 """Smoke tests for A0 config + parity constants."""
+
 from __future__ import annotations
 
 from v0.src.A0 import config
@@ -23,13 +24,11 @@ def test_opset_supports_stft():
 
 
 def test_paths_are_under_repo_root():
-    for p in (config.A0_STATE_DIR, config.BUILD_MODELS_DIR,
-              config.MANIFEST_PATH):
+    for p in (config.A0_STATE_DIR, config.BUILD_MODELS_DIR, config.MANIFEST_PATH):
         assert str(p).startswith(str(config.REPO_ROOT))
 
 
 def test_demucs_models_registry_complete():
     # PIVOT.md names these three as the required export set.
-    assert set(config.DEMUCS_MODELS) == {"htdemucs_ft", "htdemucs_6s",
-                                         "htdemucs"}
+    assert set(config.DEMUCS_MODELS) == {"htdemucs_ft", "htdemucs_6s", "htdemucs"}
     assert config.DEMUCS_MODELS["htdemucs_ft"][2] == "primary"

--- a/v0/src/A0/tests/test_demucs_stft_params.py
+++ b/v0/src/A0/tests/test_demucs_stft_params.py
@@ -4,6 +4,7 @@ Lock the Demucs STFT parameters the external-STFT wrapper must replicate.
 If the upstream `demucs/spec.py` ever changes these, this test explodes and
 Track A knows the C++ STFT kernel needs updating.
 """
+
 from __future__ import annotations
 
 from v0.src.A0 import demucs_export
@@ -25,8 +26,10 @@ def test_stft_params_known_values():
 def test_stft_config_immutable():
     # STFT is a frozen dataclass — ensure no accidental mutation.
     import dataclasses
+
     assert dataclasses.is_dataclass(demucs_export.STFT)
     # Attempting to mutate should raise.
     import pytest
+
     with pytest.raises(dataclasses.FrozenInstanceError):
-        demucs_export.STFT.n_fft = 2048   # type: ignore[misc]
+        demucs_export.STFT.n_fft = 2048  # type: ignore[misc]

--- a/v0/src/A0/tests/test_fixtures.py
+++ b/v0/src/A0/tests/test_fixtures.py
@@ -1,4 +1,5 @@
 """Tests for synthetic audio fixture generation."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -9,7 +10,7 @@ from v0.src.A0 import fixtures
 def test_drum_loop_shape_and_duration():
     fx = fixtures.drum_loop(sr=44_100)
     assert fx.sr == 44_100
-    assert fx.samples.shape[0] == 2        # stereo
+    assert fx.samples.shape[0] == 2  # stereo
     assert fx.seconds == 10.0
     assert fx.samples.dtype == np.float32
 
@@ -30,8 +31,8 @@ def test_fixtures_are_deterministic():
 
 def test_full_mix_has_nonzero_energy():
     fx = fixtures.full_mix(sr=22_050)
-    rms = float(np.sqrt(np.mean(fx.samples ** 2)))
-    assert rms > 0.01   # should be well above noise floor
+    rms = float(np.sqrt(np.mean(fx.samples**2)))
+    assert rms > 0.01  # should be well above noise floor
 
 
 def test_all_fixtures_returns_both():

--- a/v0/src/A0/tests/test_forward_from_spec.py
+++ b/v0/src/A0/tests/test_forward_from_spec.py
@@ -6,6 +6,7 @@ The contract (see ``stemforge/_vendor/demucs_patched.py``): running
 caller-side ``_ispec`` and the canonical post-pad crop must be
 numerically indistinguishable from the upstream ``forward(mix)``.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -35,7 +36,7 @@ def _make_tiny_htdemucs():
         t_layers=1,
         bottom_channels=0,
         samplerate=44100,
-        segment=1,            # 1 s training segment
+        segment=1,  # 1 s training segment
         use_train_segment=True,
     ).eval()
     return model
@@ -97,9 +98,7 @@ def test_forward_from_spec_matches_forward_random_input():
     # Float32 STFT/iSTFT round-trip has a tiny numerical residual; 1e-5 is
     # looser than the 1e-6 headline but still orders of magnitude below the
     # Demucs parity budget of 1e-3.
-    assert max_abs < 1e-5, (
-        f"forward vs forward_from_spec parity failed: max_abs={max_abs:.3e}"
-    )
+    assert max_abs < 1e-5, f"forward vs forward_from_spec parity failed: max_abs={max_abs:.3e}"
 
 
 def test_forward_from_spec_matches_forward_training_length_input():
@@ -113,8 +112,7 @@ def test_forward_from_spec_matches_forward_training_length_input():
     got = _apply_external_spec(model, mix)
     max_abs = (ref - got).abs().max().item()
     assert max_abs < 1e-5, (
-        f"forward vs forward_from_spec parity failed (no pad): "
-        f"max_abs={max_abs:.3e}"
+        f"forward vs forward_from_spec parity failed (no pad): max_abs={max_abs:.3e}"
     )
 
 
@@ -137,9 +135,10 @@ def test_forward_from_spec_cac_matches_forward_from_spec():
         zout_from_cac = unpack_cac(zout_cac)
 
     # Time branch must be exact (no packing involved).
-    assert torch.allclose(xt_ref, xt_cac, atol=0.0), \
-        f"time branch differs: max_abs={(xt_ref-xt_cac).abs().max()}"
+    assert torch.allclose(xt_ref, xt_cac, atol=0.0), (
+        f"time branch differs: max_abs={(xt_ref - xt_cac).abs().max()}"
+    )
     # Freq branch: complex → CAC → complex round-trip must be bit-exact.
-    assert torch.allclose(zout_ref, zout_from_cac, atol=1e-6), \
-        (f"freq branch differs: max_abs="
-         f"{(zout_ref - zout_from_cac).abs().max()}")
+    assert torch.allclose(zout_ref, zout_from_cac, atol=1e-6), (
+        f"freq branch differs: max_abs={(zout_ref - zout_from_cac).abs().max()}"
+    )

--- a/v0/src/A0/tests/test_fp16.py
+++ b/v0/src/A0/tests/test_fp16.py
@@ -1,4 +1,5 @@
 """Tests for the fp16 null-test harness (no ONNX inference needed)."""
+
 from __future__ import annotations
 
 import math
@@ -46,6 +47,6 @@ def test_null_test_passes_on_quiet_perturbation():
 
 def test_null_test_shape_mismatch_raises():
     import pytest
+
     with pytest.raises(ValueError):
-        fp16.null_test(np.zeros(10), np.zeros(11),
-                       model_name="x", fixture="y")
+        fp16.null_test(np.zeros(10), np.zeros(11), model_name="x", fixture="y")

--- a/v0/src/A0/tests/test_manifest.py
+++ b/v0/src/A0/tests/test_manifest.py
@@ -1,12 +1,10 @@
 """Tests for manifest writer — uses a trivial synthetic ONNX model."""
+
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
-import numpy as np
 import onnx
-import pytest
 from onnx import TensorProto, helper
 
 from v0.src.A0 import manifest
@@ -61,13 +59,16 @@ def test_write_and_load_roundtrip(tmp_path, monkeypatch):
     _make_toy_onnx(p)
     monkeypatch.setattr(manifest.config, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(manifest.config, "BUILD_MODELS_DIR", tmp_path)
-    monkeypatch.setattr(manifest.config, "MANIFEST_PATH",
-                        tmp_path / "manifest.json")
+    monkeypatch.setattr(manifest.config, "MANIFEST_PATH", tmp_path / "manifest.json")
     entry = manifest.build_entry(
-        p, torch_ref_checkpoint="x",
-        max_abs_err=0.0, max_rel_err=0.0,
-        precision="fp32", coreml_ep_supported=False,
-        cpu_fallback_ops=[], optimized_cache=None,
+        p,
+        torch_ref_checkpoint="x",
+        max_abs_err=0.0,
+        max_rel_err=0.0,
+        precision="fp32",
+        coreml_ep_supported=False,
+        cpu_fallback_ops=[],
+        optimized_cache=None,
     )
     manifest.write({"toy": entry})
     loaded = manifest.load()

--- a/v0/src/A0/tests/test_progress.py
+++ b/v0/src/A0/tests/test_progress.py
@@ -1,4 +1,5 @@
 """Tests for the progress.ndjson / artifacts / done.flag writers."""
+
 from __future__ import annotations
 
 import json
@@ -8,8 +9,7 @@ from v0.src.A0 import progress
 
 def test_emit_appends_ndjson_line(tmp_path, monkeypatch):
     monkeypatch.setattr(progress.config, "A0_STATE_DIR", tmp_path)
-    monkeypatch.setattr(progress.config, "STATE_PROGRESS_NDJSON",
-                        tmp_path / "progress.ndjson")
+    monkeypatch.setattr(progress.config, "STATE_PROGRESS_NDJSON", tmp_path / "progress.ndjson")
     progress.emit("phase1", 25.0, "hello", model="ast")
     progress.emit("phase2", 75.0, "world", model="clap")
     lines = (tmp_path / "progress.ndjson").read_text().splitlines()
@@ -25,11 +25,8 @@ def test_emit_appends_ndjson_line(tmp_path, monkeypatch):
 
 def test_write_done_flag_json(tmp_path, monkeypatch):
     monkeypatch.setattr(progress.config, "A0_STATE_DIR", tmp_path)
-    monkeypatch.setattr(progress.config, "STATE_DONE_FLAG",
-                        tmp_path / "done.flag")
-    progress.write_done_flag("feat/v0-A0-onnx",
-                             ["v0/build/models/manifest.json"],
-                             notes="test run")
+    monkeypatch.setattr(progress.config, "STATE_DONE_FLAG", tmp_path / "done.flag")
+    progress.write_done_flag("feat/v0-A0-onnx", ["v0/build/models/manifest.json"], notes="test run")
     doc = json.loads((tmp_path / "done.flag").read_text())
     assert doc["branch"] == "feat/v0-A0-onnx"
     assert "completed_at" in doc
@@ -39,8 +36,7 @@ def test_write_done_flag_json(tmp_path, monkeypatch):
 
 def test_write_blocker(tmp_path, monkeypatch):
     monkeypatch.setattr(progress.config, "A0_STATE_DIR", tmp_path)
-    monkeypatch.setattr(progress.config, "STATE_BLOCKER_MD",
-                        tmp_path / "blocker.md")
+    monkeypatch.setattr(progress.config, "STATE_BLOCKER_MD", tmp_path / "blocker.md")
     progress.write_blocker("stft-failure", "body text here")
     contents = (tmp_path / "blocker.md").read_text()
     assert "A0 blocker — stft-failure" in contents
@@ -49,9 +45,9 @@ def test_write_blocker(tmp_path, monkeypatch):
 
 def test_timer_records_to_perf(tmp_path, monkeypatch):
     perf = tmp_path / "perf.json"
-    with progress.Timer("stage-A", perf_path=perf, fixture="drum") as t:
+    with progress.Timer("stage-A", perf_path=perf, fixture="drum"):
         pass
-    with progress.Timer("stage-B", perf_path=perf) as t:
+    with progress.Timer("stage-B", perf_path=perf):
         pass
     doc = json.loads(perf.read_text())
     stages = doc["stages"]

--- a/v0/src/A0/validate.py
+++ b/v0/src/A0/validate.py
@@ -10,6 +10,7 @@ Usage:
     python -m v0.src.A0.validate                 # validate all models in manifest
     python -m v0.src.A0.validate --model ast     # validate one
 """
+
 from __future__ import annotations
 
 import argparse
@@ -19,8 +20,7 @@ from pathlib import Path
 
 import numpy as np
 
-from . import (ast_export, clap_export, config, demucs_export, fixtures,
-               manifest, progress)
+from . import ast_export, clap_export, config, demucs_export, fixtures, manifest, progress
 
 
 def _validate_demucs(manifest_entries: dict) -> list[dict]:
@@ -36,15 +36,16 @@ def _validate_demucs(manifest_entries: dict) -> list[dict]:
     for variant in variants:
         # Collect head entries (multi-head bags have *_headN keys;
         # single-model bags have the variant as the key directly).
-        head_entries = [entry for key, entry in manifest_entries.items()
-                        if key == variant or key.startswith(f"{variant}_head")]
+        head_entries = [
+            entry
+            for key, entry in manifest_entries.items()
+            if key == variant or key.startswith(f"{variant}_head")
+        ]
         if not head_entries:
             continue
 
         onnx_paths: list[Path] = []
-        for entry in sorted(
-                head_entries,
-                key=lambda e: e.get("bag_head_index", 0)):
+        for entry in sorted(head_entries, key=lambda e: e.get("bag_head_index", 0)):
             p = Path(entry["path"])
             if not p.is_absolute():
                 p = config.REPO_ROOT / p
@@ -59,27 +60,29 @@ def _validate_demucs(manifest_entries: dict) -> list[dict]:
         per_fx = []
         primary_pass = True
         for fx in fixtures.all_fixtures():
-            p = demucs_export.validate_head(
-                bag, onnx_paths, fx.samples, fx.name, variant, seg)
+            p = demucs_export.validate_head(bag, onnx_paths, fx.samples, fx.name, variant, seg)
             per_fx.append(p.as_dict())
             if fx.name == "full_mix_30s":
                 primary_pass &= p.passed
-            progress.emit("validate.demucs", 50,
-                          f"{variant} {fx.name}: "
-                          f"rms={p.residual_rms_dbfs:+.1f}dBFS "
-                          f"pass={p.passed}")
-        results.append({
-            "model": variant,
-            "passed": primary_pass,
-            "fixtures": per_fx,
-            "heads": [str(p.relative_to(config.REPO_ROOT))
-                      for p in onnx_paths],
-        })
+            progress.emit(
+                "validate.demucs",
+                50,
+                f"{variant} {fx.name}: rms={p.residual_rms_dbfs:+.1f}dBFS pass={p.passed}",
+            )
+        results.append(
+            {
+                "model": variant,
+                "passed": primary_pass,
+                "fixtures": per_fx,
+                "heads": [str(p.relative_to(config.REPO_ROOT)) for p in onnx_paths],
+            }
+        )
     return results
 
 
 def _validate_ast(onnx_path: Path) -> dict:
     import librosa
+
     results = {"model": "ast_audioset", "fixtures": [], "passed": True}
     for fx in fixtures.all_fixtures():
         mono = fx.samples.mean(axis=0).astype(np.float32)
@@ -87,14 +90,18 @@ def _validate_ast(onnx_path: Path) -> dict:
         p = ast_export.validate(onnx_path, y16, fx.name)
         results["fixtures"].append(p.as_dict())
         results["passed"] &= p.passed
-        progress.emit("validate.ast", 50,
-                      f"{fx.name}: labels_match={p.labels_match} "
-                      f"max_diff={p.max_logit_diff:.4e} pass={p.passed}")
+        progress.emit(
+            "validate.ast",
+            50,
+            f"{fx.name}: labels_match={p.labels_match} "
+            f"max_diff={p.max_logit_diff:.4e} pass={p.passed}",
+        )
     return results
 
 
 def _validate_clap(onnx_path: Path) -> dict:
     import librosa
+
     results = {"model": "clap_htsat_unfused", "fixtures": [], "passed": True}
     for fx in fixtures.all_fixtures():
         mono = fx.samples.mean(axis=0).astype(np.float32)
@@ -102,15 +109,13 @@ def _validate_clap(onnx_path: Path) -> dict:
         p = clap_export.validate(onnx_path, y48, fx.name)
         results["fixtures"].append(p.as_dict())
         results["passed"] &= p.passed
-        progress.emit("validate.clap", 50,
-                      f"{fx.name}: cos={p.cosine:.6f} pass={p.passed}")
+        progress.emit("validate.clap", 50, f"{fx.name}: cos={p.cosine:.6f} pass={p.passed}")
     return results
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="A0 parity validation")
-    parser.add_argument("--model", choices=("ast", "clap", "demucs", "all"),
-                        default="all")
+    parser.add_argument("--model", choices=("ast", "clap", "demucs", "all"), default="all")
     args = parser.parse_args(argv or sys.argv[1:])
 
     man = manifest.load()

--- a/v0/src/als-builder/builder.py
+++ b/v0/src/als-builder/builder.py
@@ -40,9 +40,7 @@ except ImportError as exc:  # pragma: no cover - import error path
 try:
     from lxml import etree as ET
 except ImportError as exc:  # pragma: no cover
-    raise SystemExit(
-        "als-builder requires lxml. `uv pip install lxml`."
-    ) from exc
+    raise SystemExit("als-builder requires lxml. `uv pip install lxml`.") from exc
 
 from colors import hex_to_color_index  # noqa: E402 — local module
 
@@ -184,9 +182,7 @@ def build_stock_device(device_name: str, params: dict[str, Any]) -> ET._Element:
 # --------------------------------------------------------------------- #
 
 
-def build_vst3_missing_placeholder(
-    device_name: str, params: dict[str, Any]
-) -> ET._Element:
+def build_vst3_missing_placeholder(device_name: str, params: dict[str, Any]) -> ET._Element:
     """Emit a Live-compatible missing-plugin placeholder.
 
     Live 12 renders sets with unrecognized VST3 UIDs as a visible
@@ -357,9 +353,7 @@ def build_device_chain(
 # --------------------------------------------------------------------- #
 
 
-def _find_template_track(
-    root: ET._Element, kind: str
-) -> ET._Element | None:
+def _find_template_track(root: ET._Element, kind: str) -> ET._Element | None:
     """Find a single <AudioTrack> or <MidiTrack> in the skeleton to clone."""
     if kind == "audio":
         return root.find(".//AudioTrack")
@@ -390,9 +384,7 @@ def _synthesize_track(kind: str) -> ET._Element:
     return t
 
 
-def clone_track(
-    root: ET._Element, kind: str
-) -> ET._Element:
+def clone_track(root: ET._Element, kind: str) -> ET._Element:
     """Deep-copy a skeleton track of the given kind, or synthesize one."""
     template = _find_template_track(root, kind)
     if template is not None:
@@ -489,9 +481,7 @@ def build(
         track_el = clone_track(root, kind)
         _set_name(track_el, track_spec["name"])
         _set_color_index(track_el, track_spec["color"])
-        build_device_chain(
-            track_el, track_spec.get("chain", []), vst3_lookup
-        )
+        build_device_chain(track_el, track_spec.get("chain", []), vst3_lookup)
         tracks_container.append(track_el)
 
     # Fresh IDs for the whole document.
@@ -499,9 +489,7 @@ def build(
 
     # Write gzipped.
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    xml_bytes = ET.tostring(
-        tree, xml_declaration=True, encoding="UTF-8", standalone=False
-    )
+    xml_bytes = ET.tostring(tree, xml_declaration=True, encoding="UTF-8", standalone=False)
     with gzip.open(output_path, "wb") as f:
         f.write(xml_bytes)
 

--- a/v0/src/als-builder/tests/test_build.py
+++ b/v0/src/als-builder/tests/test_build.py
@@ -121,9 +121,7 @@ def test_build_track_names_match_yaml(fake_skeleton, output_path):
     tree = _read_als(output_path)
     root = tree.getroot()
     tracks = root.findall(".//LiveSet/Tracks/")
-    actual_names = [
-        t.find("./Name/EffectiveName").get("Value") for t in tracks
-    ]
+    actual_names = [t.find("./Name/EffectiveName").get("Value") for t in tracks]
     assert actual_names == expected_names
 
 
@@ -142,10 +140,7 @@ def test_build_track_colors_match_palette_index(fake_skeleton, output_path):
 def test_build_track_kinds_match_yaml(fake_skeleton, output_path):
     build(skeleton_path=fake_skeleton, output_path=output_path)
     spec = load_tracks_spec()
-    expected_tags = [
-        "AudioTrack" if t["type"] == "audio" else "MidiTrack"
-        for t in spec["tracks"]
-    ]
+    expected_tags = ["AudioTrack" if t["type"] == "audio" else "MidiTrack" for t in spec["tracks"]]
 
     tree = _read_als(output_path)
     root = tree.getroot()
@@ -157,15 +152,11 @@ def test_build_track_kinds_match_yaml(fake_skeleton, output_path):
 def test_build_ids_are_unique(fake_skeleton, output_path):
     build(skeleton_path=fake_skeleton, output_path=output_path)
     tree = _read_als(output_path)
-    ids = [
-        el.get("Id") for el in tree.getroot().iter() if el.get("Id") is not None
-    ]
+    ids = [el.get("Id") for el in tree.getroot().iter() if el.get("Id") is not None]
     assert len(ids) == len(set(ids)), "Id collisions in output"
 
 
-def test_build_first_track_has_compressor_with_yaml_params(
-    fake_skeleton, output_path
-):
+def test_build_first_track_has_compressor_with_yaml_params(fake_skeleton, output_path):
     # tracks.yaml drums_raw: threshold_db: -18, ratio: 4
     build(skeleton_path=fake_skeleton, output_path=output_path)
     tree = _read_als(output_path)

--- a/v0/src/als-builder/tests/test_device_fragments.py
+++ b/v0/src/als-builder/tests/test_device_fragments.py
@@ -40,9 +40,7 @@ def test_compressor_params_applied():
 
 
 def test_reverb_decay_converted_to_ms():
-    elem = build_stock_device(
-        "Reverb", {"decay_sec": 6.0, "diffusion": 0.95}
-    )
+    elem = build_stock_device("Reverb", {"decay_sec": 6.0, "diffusion": 0.95})
     # 6.0 s → 6000 ms, but it's an integer-ish float → "6000"
     assert elem.find("./DecayTime/Manual").get("Value") == "6000"
     assert elem.find("./Diffusion/Manual").get("Value") == "0.95"
@@ -54,9 +52,7 @@ def test_utility_gain():
 
 
 def test_simpler_slice_mode():
-    elem = build_stock_device(
-        "Simpler", {"mode": "slice", "warp": "off"}
-    )
+    elem = build_stock_device("Simpler", {"mode": "slice", "warp": "off"})
     assert elem.find("./Playback/PlayMode/Manual").get("Value") == "2"
     assert elem.find("./Player/Warping/Manual").get("Value") == "false"
 

--- a/v0/src/maxpat-builder/amxd_pack.py
+++ b/v0/src/maxpat-builder/amxd_pack.py
@@ -59,7 +59,9 @@ def _u32_be(value: int) -> bytes:
     return struct.pack(">I", value)
 
 
-def _build_patch_chunk(patcher_json: str, embed_files: list[tuple[str, bytes]] | None = None) -> bytes:
+def _build_patch_chunk(
+    patcher_json: str, embed_files: list[tuple[str, bytes]] | None = None
+) -> bytes:
     """Encode patch JSON + optional embedded JS resources into the ptch body.
 
     M4L project-type devices (device_type=7) embed JS files after the JSON
@@ -165,9 +167,13 @@ def unpack_amxd(path: str | Path) -> dict[str, Any]:
         # not fatal — log and continue
         pass
 
-    # Expect 'iiii' at offset 8
-    if raw[8:12] != AAAA_SENTINEL:
-        raise ValueError(f"missing iiii sentinel at offset 8: {raw[8:12]!r}")
+    # Offset 8 carries the device-class sentinel: aaaa (audio effect),
+    # mmmm (midi effect), or iiii (instrument). Accept any known one —
+    # the old check hardcoded `aaaa` and rejected real instrument/builder
+    # .amxd files (e.g. the StemForgeTemplateBuilder reference, which is
+    # `iiii`).
+    if raw[8:12] not in set(DEVICE_CLASS_SENTINEL.values()):
+        raise ValueError(f"unknown device-class sentinel at offset 8: {raw[8:12]!r}")
 
     # Expect 'meta' at offset 12
     if raw[12:16] != META_TAG:
@@ -177,9 +183,7 @@ def unpack_amxd(path: str | Path) -> dict[str, Any]:
 
     ptch_off = 20 + meta_len
     if raw[ptch_off : ptch_off + 4] != PTCH_TAG:
-        raise ValueError(
-            f"missing ptch tag at offset {ptch_off}: {raw[ptch_off:ptch_off + 4]!r}"
-        )
+        raise ValueError(f"missing ptch tag at offset {ptch_off}: {raw[ptch_off : ptch_off + 4]!r}")
     ptch_len = struct.unpack_from("<I", raw, ptch_off + 4)[0]
     ptch_body = raw[ptch_off + 8 : ptch_off + 8 + ptch_len]
 

--- a/v0/src/maxpat-builder/build_amxd.py
+++ b/v0/src/maxpat-builder/build_amxd.py
@@ -59,8 +59,7 @@ def main(argv: list[str] | None = None) -> int:
         import subprocess
 
         injector = (
-            Path(__file__).resolve().parents[2]
-            / ".." / "tools" / "inject_build_manifest.py"
+            Path(__file__).resolve().parents[2] / ".." / "tools" / "inject_build_manifest.py"
         ).resolve()
         if injector.is_file():
             cp = subprocess.run(

--- a/v0/src/maxpat-builder/receiver_builder.py
+++ b/v0/src/maxpat-builder/receiver_builder.py
@@ -13,11 +13,12 @@ import json
 from pathlib import Path
 
 
-def _box(obj_id, maxclass, rect, *, numinlets=1, numoutlets=0,
-         outlettype=None, extras=None):
+def _box(obj_id, maxclass, rect, *, numinlets=1, numoutlets=0, outlettype=None, extras=None):
     body = {
-        "id": obj_id, "maxclass": maxclass,
-        "numinlets": numinlets, "numoutlets": numoutlets,
+        "id": obj_id,
+        "maxclass": maxclass,
+        "numinlets": numinlets,
+        "numoutlets": numoutlets,
         "patching_rect": list(rect),
     }
     if outlettype:
@@ -37,32 +38,55 @@ def build_receiver(stem_name: str) -> dict:
     lines = []
 
     # Receive note events as "note <pitch> <velocity>" messages
-    boxes.append(_box(
-        "obj-recv", "newobj", (20, 20, 120, 22),
-        numinlets=0, numoutlets=1, outlettype=[""],
-        extras={"text": f"receive {send_name}"},
-    ))
+    boxes.append(
+        _box(
+            "obj-recv",
+            "newobj",
+            (20, 20, 120, 22),
+            numinlets=0,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": f"receive {send_name}"},
+        )
+    )
 
     # midiformat converts "note pitch velocity" to raw MIDI bytes
-    boxes.append(_box(
-        "obj-midiformat", "newobj", (20, 50, 100, 22),
-        numinlets=6, numoutlets=1, outlettype=["int"],
-        extras={"text": "midiformat"},
-    ))
+    boxes.append(
+        _box(
+            "obj-midiformat",
+            "newobj",
+            (20, 50, 100, 22),
+            numinlets=6,
+            numoutlets=1,
+            outlettype=["int"],
+            extras={"text": "midiformat"},
+        )
+    )
     lines.append(_line("obj-recv", 0, "obj-midiformat", 0))
 
     # midiout sends properly formatted MIDI downstream to the Drum Rack
-    boxes.append(_box(
-        "obj-midiout", "newobj", (20, 80, 80, 22),
-        numinlets=1, numoutlets=0,
-        extras={"text": "midiout"},
-    ))
+    boxes.append(
+        _box(
+            "obj-midiout",
+            "newobj",
+            (20, 80, 80, 22),
+            numinlets=1,
+            numoutlets=0,
+            extras={"text": "midiout"},
+        )
+    )
     lines.append(_line("obj-midiformat", 0, "obj-midiout", 0))
 
     return {
         "patcher": {
             "fileversion": 1,
-            "appversion": {"major": 9, "minor": 0, "revision": 8, "architecture": "x64", "modernui": 1},
+            "appversion": {
+                "major": 9,
+                "minor": 0,
+                "revision": 8,
+                "architecture": "x64",
+                "modernui": 1,
+            },
             "classnamespace": "box",
             "rect": [100, 100, 300, 150],
             "openinpresentation": 0,
@@ -71,14 +95,26 @@ def build_receiver(stem_name: str) -> dict:
             "boxes": boxes,
             "lines": lines,
             "project": {
-                "version": 1, "creationdate": 3590052493, "modificationdate": 3590052493,
-                "viewrect": [0, 0, 300, 500], "autoorganize": 1, "hideprojectwindow": 1,
-                "showdependencies": 1, "autolocalize": 0,
+                "version": 1,
+                "creationdate": 3590052493,
+                "modificationdate": 3590052493,
+                "viewrect": [0, 0, 300, 500],
+                "autoorganize": 1,
+                "hideprojectwindow": 1,
+                "showdependencies": 1,
+                "autolocalize": 0,
                 "contents": {"patchers": {}, "code": {}},
-                "layout": {}, "searchpath": {}, "detailsvisible": 0,
-                "amxdtype": 1835361645, "readonly": 0, "devpathtype": 0, "devpath": ".",
+                "layout": {},
+                "searchpath": {},
+                "detailsvisible": 0,
+                "amxdtype": 1835361645,
+                "readonly": 0,
+                "devpathtype": 0,
+                "devpath": ".",
                 # 1835361645 = 0x6D6D6D6D = b'mmmm' = MIDI effect
-                "sortmode": 0, "viewmode": 0, "includepackages": 0,
+                "sortmode": 0,
+                "viewmode": 0,
+                "includepackages": 0,
             },
             "autosave": 0,
         }
@@ -87,6 +123,7 @@ def build_receiver(stem_name: str) -> dict:
 
 if __name__ == "__main__":
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from amxd_pack import pack_amxd
 
@@ -106,9 +143,12 @@ if __name__ == "__main__":
         pack_amxd(patcher, str(amxd_path), device_type=1, device_class="midi")
 
         # Install to MIDI Effects
-        install_dir = Path.home() / "Music/Ableton/User Library/Presets/MIDI Effects/Max MIDI Effect"
+        install_dir = (
+            Path.home() / "Music/Ableton/User Library/Presets/MIDI Effects/Max MIDI Effect"
+        )
         install_dir.mkdir(parents=True, exist_ok=True)
         import shutil
+
         shutil.copy2(amxd_path, install_dir / f"{name}.amxd")
 
         print(f"  {name}: built + installed")

--- a/v0/src/maxpat-builder/router_builder.py
+++ b/v0/src/maxpat-builder/router_builder.py
@@ -15,8 +15,7 @@ from pathlib import Path
 from typing import Any
 
 
-def _box(obj_id, maxclass, rect, *, numinlets=1, numoutlets=0,
-         outlettype=None, extras=None):
+def _box(obj_id, maxclass, rect, *, numinlets=1, numoutlets=0, outlettype=None, extras=None):
     body = {
         "id": obj_id,
         "maxclass": maxclass,
@@ -47,71 +46,113 @@ def build_router_patcher() -> dict[str, Any]:
 
     # --- MIDI input → JS router → MIDI output ---
     # Simple chain: midiin sends raw bytes to JS, JS remaps and outputs to midiout
-    boxes.append(_box(
-        "obj-midiin", "newobj", (20, 20, 80, 22),
-        numinlets=1, numoutlets=1, outlettype=["int"],
-        extras={"text": "midiin"},
-    ))
+    boxes.append(
+        _box(
+            "obj-midiin",
+            "newobj",
+            (20, 20, 80, 22),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=["int"],
+            extras={"text": "midiin"},
+        )
+    )
 
-    boxes.append(_box(
-        "obj-router", "newobj", (20, 60, 280, 22),
-        numinlets=1, numoutlets=1,
-        outlettype=["int"],
-        extras={
-            "text": "js stemforge_quadrant_router.js",
-            "saved_object_attributes": {
-                "filename": "stemforge_quadrant_router.js",
-                "parameter_enable": 0,
+    boxes.append(
+        _box(
+            "obj-router",
+            "newobj",
+            (20, 60, 280, 22),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=["int"],
+            extras={
+                "text": "js stemforge_quadrant_router.js",
+                "saved_object_attributes": {
+                    "filename": "stemforge_quadrant_router.js",
+                    "parameter_enable": 0,
+                },
             },
-        },
-    ))
+        )
+    )
     lines.append(_line("obj-midiin", 0, "obj-router", 0))
 
     # Single outlet → midiout → downstream Instrument Rack splits by key zone
     # Q1 (drums): notes 36-51, Q2 (bass): 52-67, Q3 (vocals): 68-83, Q4 (other): 84-99
-    boxes.append(_box(
-        "obj-midiout", "newobj", (20, 100, 80, 22),
-        numinlets=1, numoutlets=0,
-        extras={"text": "midiout"},
-    ))
+    boxes.append(
+        _box(
+            "obj-midiout",
+            "newobj",
+            (20, 100, 80, 22),
+            numinlets=1,
+            numoutlets=0,
+            extras={"text": "midiout"},
+        )
+    )
     lines.append(_line("obj-router", 0, "obj-midiout", 0))
 
     # --- Loadbang → colorize pads ---
-    boxes.append(_box(
-        "obj-loadbang", "newobj", (300, 20, 60, 22),
-        numinlets=1, numoutlets=1, outlettype=["bang"],
-        extras={"text": "loadbang"},
-    ))
-    boxes.append(_box(
-        "obj-colorize-msg", "message", (300, 50, 60, 22),
-        numinlets=2, numoutlets=1, outlettype=[""],
-        extras={"text": "colorize"},
-    ))
+    boxes.append(
+        _box(
+            "obj-loadbang",
+            "newobj",
+            (300, 20, 60, 22),
+            numinlets=1,
+            numoutlets=1,
+            outlettype=["bang"],
+            extras={"text": "loadbang"},
+        )
+    )
+    boxes.append(
+        _box(
+            "obj-colorize-msg",
+            "message",
+            (300, 50, 60, 22),
+            numinlets=2,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": "colorize"},
+        )
+    )
     lines.append(_line("obj-loadbang", 0, "obj-colorize-msg", 0))
     lines.append(_line("obj-colorize-msg", 0, "obj-router", 0))
 
     # --- Debug: test mapping ---
-    boxes.append(_box(
-        "obj-test-msg", "message", (300, 80, 40, 22),
-        numinlets=2, numoutlets=1, outlettype=[""],
-        extras={"text": "test"},
-    ))
+    boxes.append(
+        _box(
+            "obj-test-msg",
+            "message",
+            (300, 80, 40, 22),
+            numinlets=2,
+            numoutlets=1,
+            outlettype=[""],
+            extras={"text": "test"},
+        )
+    )
     lines.append(_line("obj-test-msg", 0, "obj-router", 0))
 
     # --- Diagnostic ---
-    boxes.append(_box(
-        "obj-diag", "newobj", (300, 110, 200, 22),
-        numinlets=1, numoutlets=0,
-        extras={"text": "print [QuadrantRouter-loaded]"},
-    ))
+    boxes.append(
+        _box(
+            "obj-diag",
+            "newobj",
+            (300, 110, 200, 22),
+            numinlets=1,
+            numoutlets=0,
+            extras={"text": "print [QuadrantRouter-loaded]"},
+        )
+    )
     lines.append(_line("obj-loadbang", 0, "obj-diag", 0))
 
     patcher = {
         "patcher": {
             "fileversion": 1,
             "appversion": {
-                "major": 9, "minor": 0, "revision": 8,
-                "architecture": "x64", "modernui": 1,
+                "major": 9,
+                "minor": 0,
+                "revision": 8,
+                "architecture": "x64",
+                "modernui": 1,
             },
             "classnamespace": "box",
             "rect": [100, 100, 500, 300],

--- a/v0/src/maxpat-builder/tests/test_amxd_pack.py
+++ b/v0/src/maxpat-builder/tests/test_amxd_pack.py
@@ -65,8 +65,9 @@ def test_repack_of_reference_opens_as_same_patcher(tmp_path):
     # are placed differently), so we don't compare bytes. What must be true
     # is: reparse → patcher struct equal.
     parsed = unpack_amxd(REFERENCE_AMXD)
-    repacked = pack_amxd(parsed["patcher"], tmp_path / "round.amxd",
-                         device_type=parsed["device_type"])
+    repacked = pack_amxd(
+        parsed["patcher"], tmp_path / "round.amxd", device_type=parsed["device_type"]
+    )
     re_parsed = unpack_amxd(repacked)
     assert re_parsed["patcher"] == parsed["patcher"]
     assert re_parsed["device_type"] == parsed["device_type"]

--- a/v0/src/maxpat-builder/tests/test_bridge_js_parses_events.py
+++ b/v0/src/maxpat-builder/tests/test_bridge_js_parses_events.py
@@ -86,52 +86,57 @@ def _run_bridge(lines: list[str]) -> list[list]:
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_progress_event_emits_pct_and_phase():
-    calls = _run_bridge([json.dumps({
-        "event": "progress", "phase": "splitting", "pct": 42
-    })])
+    calls = _run_bridge([json.dumps({"event": "progress", "phase": "splitting", "pct": 42})])
     assert calls == [["progress", 42, "splitting"]]
 
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_stem_event_emits_name_and_path():
-    calls = _run_bridge([json.dumps({
-        "event": "stem", "name": "drums",
-        "path": "/tmp/drums.wav", "size_bytes": 1234
-    })])
+    calls = _run_bridge(
+        [
+            json.dumps(
+                {"event": "stem", "name": "drums", "path": "/tmp/drums.wav", "size_bytes": 1234}
+            )
+        ]
+    )
     assert calls == [["stem", "drums", "/tmp/drums.wav", 1234]]
 
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_bpm_event_emits_value():
-    calls = _run_bridge([json.dumps({
-        "event": "bpm", "bpm": 128.5, "beat_count": 512
-    })])
+    calls = _run_bridge([json.dumps({"event": "bpm", "bpm": 128.5, "beat_count": 512})])
     assert calls == [["bpm", 128.5, 512]]
 
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_slice_dir_event_emits_triple():
-    calls = _run_bridge([json.dumps({
-        "event": "slice_dir", "stem": "drums",
-        "dir": "/tmp/drums_beats", "count": 32
-    })])
+    calls = _run_bridge(
+        [
+            json.dumps(
+                {"event": "slice_dir", "stem": "drums", "dir": "/tmp/drums_beats", "count": 32}
+            )
+        ]
+    )
     assert calls == [["slice_dir", "drums", "/tmp/drums_beats", 32]]
 
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_complete_event_emits_manifest():
-    calls = _run_bridge([json.dumps({
-        "event": "complete", "manifest": "/tmp/stems.json",
-        "bpm": 120, "stem_count": 4
-    })])
+    calls = _run_bridge(
+        [
+            json.dumps(
+                {"event": "complete", "manifest": "/tmp/stems.json", "bpm": 120, "stem_count": 4}
+            )
+        ]
+    )
     assert calls == [["complete", "/tmp/stems.json", 120, 4]]
 
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_error_event_emits_phase_and_message():
-    calls = _run_bridge([json.dumps({
-        "event": "error", "phase": "splitting", "message": "ORT crash"
-    })])
+    calls = _run_bridge(
+        [json.dumps({"event": "error", "phase": "splitting", "message": "ORT crash"})]
+    )
     assert calls == [["error", "splitting", "ORT crash"]]
 
 
@@ -149,9 +154,9 @@ def test_unknown_event_is_dropped():
 
 @pytest.mark.skipif(not _node_available(), reason="node not installed")
 def test_started_event_surfaces_as_progress_zero():
-    calls = _run_bridge([json.dumps({
-        "event": "started", "track": "t", "audio": "/a.wav", "output_dir": "/o"
-    })])
+    calls = _run_bridge(
+        [json.dumps({"event": "started", "track": "t", "audio": "/a.wav", "output_dir": "/o"})]
+    )
     assert calls == [["progress", 0, "starting"]]
 
 
@@ -161,8 +166,7 @@ def test_stream_of_events_preserves_order():
         json.dumps({"event": "progress", "phase": "loading_model", "pct": 5}),
         json.dumps({"event": "progress", "phase": "splitting", "pct": 50}),
         json.dumps({"event": "bpm", "bpm": 128, "beat_count": 256}),
-        json.dumps({"event": "complete", "manifest": "/m.json",
-                    "bpm": 128, "stem_count": 4}),
+        json.dumps({"event": "complete", "manifest": "/m.json", "bpm": 128, "stem_count": 4}),
     ]
     calls = _run_bridge(lines)
     assert [c[0] for c in calls] == ["progress", "progress", "bpm", "complete"]

--- a/v0/src/maxpat-builder/tests/test_builder.py
+++ b/v0/src/maxpat-builder/tests/test_builder.py
@@ -108,11 +108,7 @@ def test_pick_source_button_present(boxes):
 def test_pick_source_wired_to_loader(boxes, line_pairs):
     """Pick source button → [message pickSource] → js sf_lom_loader."""
     msg = next(
-        (
-            b
-            for b in boxes
-            if b.get("maxclass") == "message" and b.get("text") == "pickSource"
-        ),
+        (b for b in boxes if b.get("maxclass") == "message" and b.get("text") == "pickSource"),
         None,
     )
     assert msg is not None, "missing [message pickSource] box"
@@ -136,12 +132,8 @@ def test_primary_button_wired_via_messnamed(boxes, line_pairs):
     `primary-btn-label` and `primary-btn-enabled`; the patcher must have
     `[r primary-btn-label]` → prepend set → primary btn, and
     `[r primary-btn-enabled]` → prepend active → primary btn."""
-    label_recv = next(
-        (b for b in boxes if b.get("text") == "r primary-btn-label"), None
-    )
-    enabled_recv = next(
-        (b for b in boxes if b.get("text") == "r primary-btn-enabled"), None
-    )
+    label_recv = next((b for b in boxes if b.get("text") == "r primary-btn-label"), None)
+    enabled_recv = next((b for b in boxes if b.get("text") == "r primary-btn-enabled"), None)
     assert label_recv is not None, "missing [r primary-btn-label]"
     assert enabled_recv is not None, "missing [r primary-btn-enabled]"
     # Both must route through a prepend → primary btn.
@@ -155,11 +147,7 @@ def test_primary_click_wired_to_loader(boxes, line_pairs):
     """Primary button click → [message primary] → js sf_lom_loader. The
     loader's `primary()` function dispatches by sniffer type."""
     msg = next(
-        (
-            b
-            for b in boxes
-            if b.get("maxclass") == "message" and b.get("text") == "primary"
-        ),
+        (b for b in boxes if b.get("maxclass") == "message" and b.get("text") == "primary"),
         None,
     )
     assert msg is not None, "missing [message primary] box"
@@ -178,9 +166,7 @@ def test_footer_status_text_receives_sf_status(boxes, line_pairs):
     BUTTON that rejects `set <text>` with `bad arguments for message
     "set"` (caught during first UAT round).
     """
-    txt = next(
-        (b for b in boxes if b.get("varname") == "sf_status_text"), None
-    )
+    txt = next((b for b in boxes if b.get("varname") == "sf_status_text"), None)
     assert txt is not None, "missing footer sf_status_text"
     assert txt["maxclass"] == "live.comment", (
         "status widget must be live.comment — live.text rejects `set <text>`"
@@ -217,16 +203,12 @@ def test_picker_dialog_wired_from_messnamed_receiver(boxes, line_pairs):
     quirk that triggered `patchcord outlet out of range`. The HFS→POSIX
     conversion now happens in applyPickedSource() in JS.
     """
-    recv = next(
-        (b for b in boxes if b.get("text") == "r sf-open-source-dialog"), None
-    )
+    recv = next((b for b in boxes if b.get("text") == "r sf-open-source-dialog"), None)
     assert recv is not None, "missing [r sf-open-source-dialog]"
     assert (recv["id"], "obj-sf-picker-dialog") in line_pairs
     # opendialog wires directly to [prepend applyPickedSource] — no regex.
     assert ("obj-sf-picker-dialog", "obj-sf-picker-dialog-prepend") in line_pairs
-    prep = next(
-        (b for b in boxes if b.get("id") == "obj-sf-picker-dialog-prepend"), None
-    )
+    prep = next((b for b in boxes if b.get("id") == "obj-sf-picker-dialog-prepend"), None)
     assert prep is not None
     assert prep.get("text") == "prepend applyPickedSource"
     assert ("obj-sf-picker-dialog-prepend", "obj-sf-lom-loader") in line_pairs
@@ -252,11 +234,7 @@ def test_commit_button_present_and_wired(boxes, line_pairs):
     assert btn.get("text") == "COMMIT"
 
     msg = next(
-        (
-            b
-            for b in boxes
-            if b.get("maxclass") == "message" and b.get("text") == "commit"
-        ),
+        (b for b in boxes if b.get("maxclass") == "message" and b.get("text") == "commit"),
         None,
     )
     assert msg is not None, "missing [message commit] box"
@@ -275,11 +253,7 @@ def test_bounce_button_present_and_wired(boxes, line_pairs):
     assert btn.get("text") == "BOUNCE"
 
     msg = next(
-        (
-            b
-            for b in boxes
-            if b.get("maxclass") == "message" and b.get("text") == "bounceCuration"
-        ),
+        (b for b in boxes if b.get("maxclass") == "message" and b.get("text") == "bounceCuration"),
         None,
     )
     assert msg is not None, "missing [message bounceCuration] box"
@@ -326,11 +300,7 @@ def test_anchor_button_present_and_wired(boxes, line_pairs):
     assert btn.get("text") == "ANCH"
 
     msg = next(
-        (
-            b
-            for b in boxes
-            if b.get("maxclass") == "message" and b.get("text") == "reAnchor"
-        ),
+        (b for b in boxes if b.get("maxclass") == "message" and b.get("text") == "reAnchor"),
         None,
     )
     assert msg is not None, "missing [message reAnchor] box"
@@ -342,13 +312,9 @@ def test_anchor_go_wire_routes_into_locator_anchor(boxes, line_pairs):
     """[r sf-anchor-go] → [prepend anchor] → [js sf_locator_anchor]. JS
     `reAnchor()` emits `messnamed("sf-anchor-go", forgeDir)`; the receiver
     here makes the forge dir become the first argument to anchor()."""
-    recv = next(
-        (b for b in boxes if b.get("text", "") == "r sf-anchor-go"), None
-    )
+    recv = next((b for b in boxes if b.get("text", "") == "r sf-anchor-go"), None)
     assert recv is not None, "missing [r sf-anchor-go]"
-    prep = next(
-        (b for b in boxes if b.get("text", "") == "prepend anchor"), None
-    )
+    prep = next((b for b in boxes if b.get("text", "") == "prepend anchor"), None)
     assert prep is not None, "missing [prepend anchor]"
 
     assert (recv["id"], prep["id"]) in line_pairs
@@ -394,8 +360,7 @@ def test_picker_and_verb_layout_snapshot(boxes):
         got = found[varname]
         for key, value in want.items():
             assert got.get(key) == value, (
-                f"snapshot widget {varname}.{key}: got {got.get(key)!r}, "
-                f"expected {value!r}"
+                f"snapshot widget {varname}.{key}: got {got.get(key)!r}, expected {value!r}"
             )
 
 
@@ -407,9 +372,7 @@ def test_no_legacy_preset_or_source_umenus(boxes):
     they were the user-visible dropdowns that the new picker replaces."""
     for varname in ("sf_preset_menu", "sf_source_menu"):
         match = next((b for b in boxes if b.get("varname") == varname), None)
-        assert match is None, (
-            f"legacy umenu {varname!r} found — Configurator v1 §3.1 removes it"
-        )
+        assert match is None, f"legacy umenu {varname!r} found — Configurator v1 §3.1 removes it"
     # Belt-and-braces: no umenu objects at all in the patcher (the loaders
     # may still scan, but their outputs are no longer rendered).
     umenus = [b for b in boxes if b.get("maxclass") == "umenu"]
@@ -424,9 +387,7 @@ def test_no_legacy_v8ui_event_route(boxes):
         (b for b in boxes if b.get("text", "").startswith("route preset_click")),
         None,
     )
-    assert legacy_route is None, (
-        "legacy v8ui-event route table found — must be removed (P0-5)"
-    )
+    assert legacy_route is None, "legacy v8ui-event route table found — must be removed (P0-5)"
 
 
 def test_no_commit_click_dead_wire(boxes):
@@ -456,11 +417,9 @@ def test_no_legacy_forge_click_or_other_routes(boxes):
         "arrangement_load_click",
     )
     for b in boxes:
-        text = (b.get("text", "") or "")
+        text = b.get("text", "") or ""
         for needle in legacy_strings:
-            assert needle not in text, (
-                f"legacy token {needle!r} found in box {b.get('id')!r}"
-            )
+            assert needle not in text, f"legacy token {needle!r} found in box {b.get('id')!r}"
 
 
 # ── Modular JS objects ───────────────────────────────────────────────────────
@@ -648,7 +607,6 @@ def test_audio_passthrough_present(boxes, line_pairs):
 
 def test_no_live_slider_progress_bar(boxes):
     """v0.1.0 removed the live.slider progress bar — v8ui draws its own."""
-    texts = _texts(boxes)
     assert not any("StemForge Progress" in str(b) for b in boxes), (
         "old progress-bar live.slider should be gone"
     )
@@ -712,9 +670,7 @@ def test_http_maxurl_object_present(boxes):
     fire 3+ times back-to-back) don't block one another.
     """
     maxurl_boxes = [b for b in boxes if b.get("text", "").startswith("maxurl")]
-    assert len(maxurl_boxes) == 1, (
-        f"expected exactly one [maxurl] object; got {len(maxurl_boxes)}"
-    )
+    assert len(maxurl_boxes) == 1, f"expected exactly one [maxurl] object; got {len(maxurl_boxes)}"
     text = maxurl_boxes[0]["text"]
     assert "@verbosity 0" in text, f"maxurl missing @verbosity 0: {text!r}"
     # Thread count is the first positional arg after "maxurl".
@@ -722,8 +678,7 @@ def test_http_maxurl_object_present(boxes):
     assert tokens[0] == "maxurl"
     threads = int(tokens[1]) if len(tokens) > 1 and tokens[1].isdigit() else 1
     assert threads >= 2, (
-        f"maxurl thread count must be >=2 so concurrent bounce posts don't "
-        f"block; got {threads}"
+        f"maxurl thread count must be >=2 so concurrent bounce posts don't block; got {threads}"
     )
 
 
@@ -759,19 +714,14 @@ def test_http_request_dict_messages_match_js_convention(boxes, dict_name):
     matching JS change silently breaks the post.
     """
     expected = f"dictionary {dict_name}"
-    msgs = [
-        b for b in boxes
-        if b.get("maxclass") == "message" and b.get("text", "") == expected
-    ]
+    msgs = [b for b in boxes if b.get("maxclass") == "message" and b.get("text", "") == expected]
     assert msgs, f"missing message box with text {expected!r}"
 
 
 def test_http_request_chain_wired(line_pairs, boxes):
     """End-to-end wire: each `[r sf-…]` → `[message dictionary …]` → `[maxurl]`."""
     by_text = {b.get("text", ""): b["id"] for b in boxes}
-    maxurl_id = next(
-        b["id"] for b in boxes if b.get("text", "").startswith("maxurl")
-    )
+    maxurl_id = next(b["id"] for b in boxes if b.get("text", "").startswith("maxurl"))
     pairs = [
         ("r sf-commit-send", f"dictionary {HTTP_REQ_DICT_COMMIT}"),
         ("r sf-bounce-progress", f"dictionary {HTTP_REQ_DICT_BOUNCE_PROGRESS}"),
@@ -780,12 +730,8 @@ def test_http_request_chain_wired(line_pairs, boxes):
     for recv_text, msg_text in pairs:
         recv_id = by_text[recv_text]
         msg_id = by_text[msg_text]
-        assert (recv_id, msg_id) in line_pairs, (
-            f"missing wire: [{recv_text}] → [{msg_text}]"
-        )
-        assert (msg_id, maxurl_id) in line_pairs, (
-            f"missing wire: [{msg_text}] → [maxurl]"
-        )
+        assert (recv_id, msg_id) in line_pairs, f"missing wire: [{recv_text}] → [{msg_text}]"
+        assert (msg_id, maxurl_id) in line_pairs, f"missing wire: [{msg_text}] → [maxurl]"
 
 
 def test_http_response_routed_to_loader(line_pairs, boxes):
@@ -797,21 +743,14 @@ def test_http_response_routed_to_loader(line_pairs, boxes):
     from the C2 handoff).
     """
     by_text = {b.get("text", ""): b["id"] for b in boxes}
-    maxurl_id = next(
-        b["id"] for b in boxes if b.get("text", "").startswith("maxurl")
-    )
+    maxurl_id = next(b["id"] for b in boxes if b.get("text", "").startswith("maxurl"))
     route_id = by_text["route dictionary"]
     prepend_id = by_text["prepend onHttpResponse"]
     loader_id = next(
-        b["id"] for b in boxes
-        if b.get("text", "").startswith("js stemforge_loader.v0.js")
+        b["id"] for b in boxes if b.get("text", "").startswith("js stemforge_loader.v0.js")
     )
-    assert (maxurl_id, route_id) in line_pairs, (
-        "maxurl outlet 0 must feed [route dictionary]"
-    )
+    assert (maxurl_id, route_id) in line_pairs, "maxurl outlet 0 must feed [route dictionary]"
     assert (route_id, prepend_id) in line_pairs, (
         "[route dictionary] outlet 0 must feed [prepend onHttpResponse]"
     )
-    assert (prepend_id, loader_id) in line_pairs, (
-        "[prepend onHttpResponse] must feed the JS loader"
-    )
+    assert (prepend_id, loader_id) in line_pairs, "[prepend onHttpResponse] must feed the JS loader"

--- a/v0/src/stemforge_curate_bars.py
+++ b/v0/src/stemforge_curate_bars.py
@@ -15,6 +15,7 @@ Usage:
 Input:  directory with drums.wav, bass.wav, vocals.wav, other.wav
 Output: curated/ subdirectory with N bars per stem + updated stems.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -32,7 +33,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from stemforge.slicer import detect_bpm_and_beats, slice_at_bars, group_bars_into_phrases
-from stemforge.beat_align import find_best_downbeat_offset, apply_downbeat_offset, filter_ghost_beats
+from stemforge.beat_align import (
+    find_best_downbeat_offset,
+    apply_downbeat_offset,
+    filter_ghost_beats,
+)
 from stemforge.curator import curate, section_stratified_select
 from stemforge.config import load_curation_config, CurationConfig
 from stemforge.curation_schema import (
@@ -40,9 +45,13 @@ from stemforge.curation_schema import (
     build_curation_block,
     CurationSchemaConfig,
 )
-from stemforge.oneshot import extract_oneshots, extract_kicks_from_bass, select_diverse_oneshots, extract_drum_oneshots_via_larsnet
+from stemforge.oneshot import (
+    extract_oneshots,
+    extract_kicks_from_bass,
+    select_diverse_oneshots,
+    extract_drum_oneshots_via_larsnet,
+)
 from stemforge.drum_classifier import classify_and_assign, arrange_drum_pads
-from stemforge.layout import build_stems_layout, layout_to_manifest
 
 
 STEM_NAMES = ["drums", "bass", "vocals", "other"]
@@ -198,9 +207,7 @@ def _reslice_with_padding(
     sr = info.samplerate
     stem_duration = float(info.duration)
 
-    raw_start_in_stem = max(
-        0.0, float(first_downbeat_sec) + (bar_idx - 1) * bar_duration_sec
-    )
+    raw_start_in_stem = max(0.0, float(first_downbeat_sec) + (bar_idx - 1) * bar_duration_sec)
     raw_end_in_stem = min(stem_duration, raw_start_in_stem + phrase_bars * bar_duration_sec)
 
     pad_sec = float(pad_bars_yaml) * bar_duration_sec
@@ -222,9 +229,7 @@ def _reslice_with_padding(
     start_frame = max(0, int(round(window_start_sec * sr)))
     stop_frame = min(info.frames, int(round(window_end_sec * sr)))
     if stop_frame <= start_frame:
-        raise ValueError(
-            f"Empty slice window for bar {bar_idx} in {source_stem_path.name}"
-        )
+        raise ValueError(f"Empty slice window for bar {bar_idx} in {source_stem_path.name}")
 
     data, _ = sf.read(
         str(source_stem_path),
@@ -264,9 +269,13 @@ def _detect_reference_onsets(
     musical downbeats.
     """
     import librosa
+
     y, sr = librosa.load(str(reference_wav), sr=target_sr, mono=True)
     onset_frames = librosa.onset.onset_detect(
-        y=y, sr=sr, units="frames", backtrack=True,
+        y=y,
+        sr=sr,
+        units="frames",
+        backtrack=True,
     )
     return librosa.frames_to_time(onset_frames, sr=sr)
 
@@ -308,8 +317,7 @@ def _reextract_slice(
             f.seek(start_frame)
             data = f.read(n_frames, always_2d=True)
         if data.shape[0] < n_frames:
-            pad = np.zeros((n_frames - data.shape[0], data.shape[1]),
-                           dtype=data.dtype)
+            pad = np.zeros((n_frames - data.shape[0], data.shape[1]), dtype=data.dtype)
             data = np.concatenate([data, pad], axis=0)
         sf.write(str(dst_path), data, sr, subtype="PCM_24")
         return True
@@ -327,11 +335,15 @@ def _trim_wav_to_first_onset(wav_path: Path, threshold_ms: float = 30.0) -> bool
     trim it and zero-pad the tail. Returns True if the file was modified.
     """
     import librosa
+
     info = sf.info(str(wav_path))
     target_sr = info.samplerate
     y_mono, _ = librosa.load(str(wav_path), sr=target_sr, mono=True)
     onset_frames = librosa.onset.onset_detect(
-        y=y_mono, sr=target_sr, units="samples", backtrack=True,
+        y=y_mono,
+        sr=target_sr,
+        units="samples",
+        backtrack=True,
     )
     if len(onset_frames) == 0:
         return False
@@ -368,8 +380,7 @@ def _normalize_wav_duration(wav_path: Path, target_sec: float) -> None:
     if data.shape[0] > target_frames:
         data = data[:target_frames]
     elif data.shape[0] < target_frames:
-        pad = np.zeros((target_frames - data.shape[0], data.shape[1]),
-                       dtype=data.dtype)
+        pad = np.zeros((target_frames - data.shape[0], data.shape[1]), dtype=data.dtype)
         data = np.concatenate([data, pad], axis=0)
     sf.write(str(wav_path), data, sr, subtype="PCM_24")
 
@@ -387,7 +398,10 @@ def _parse_phrase_index(filename: str) -> int | None:
 
 
 def _first_bar_idx_for_phrase(
-    bar_dir: Path, stem_name: str, phrase_bars: int, phrase_idx: int,
+    bar_dir: Path,
+    stem_name: str,
+    phrase_bars: int,
+    phrase_idx: int,
 ) -> int | None:
     """Resolve phrase idx (1-based) → bar-grid idx of its first underlying bar.
 
@@ -436,21 +450,41 @@ def run(
     # `--pipeline` together. Believer-bug regression 2026-05-06.
     if _pipeline_injects_processing_config(pipeline) and layout_mode != "production":
         if json_events:
-            emit({"event": "progress", "phase": "config", "pct": 0,
-                  "message": (f"--pipeline injects processing_config; "
-                              f"overriding layout_mode {layout_mode!r} -> 'production' "
-                              f"so the M4L loadSong() path triggers")})
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "config",
+                    "pct": 0,
+                    "message": (
+                        f"--pipeline injects processing_config; "
+                        f"overriding layout_mode {layout_mode!r} -> 'production' "
+                        f"so the M4L loadSong() path triggers"
+                    ),
+                }
+            )
         layout_mode = "production"
 
     is_loops_only = layout_mode == "loops-only"
     is_production = layout_mode == "production"
 
     if is_loops_only and json_events:
-        emit({"event": "progress", "phase": "config", "pct": 0,
-              "message": "loops-only mode: 16 bar loops per stem, no one-shots"})
+        emit(
+            {
+                "event": "progress",
+                "phase": "config",
+                "pct": 0,
+                "message": "loops-only mode: 16 bar loops per stem, no one-shots",
+            }
+        )
     if is_production and json_events:
-        emit({"event": "progress", "phase": "config", "pct": 0,
-              "message": "production mode: 16 loops per stem + drum one-shots"})
+        emit(
+            {
+                "event": "progress",
+                "phase": "config",
+                "pct": 0,
+                "message": "production mode: 16 loops per stem + drum one-shots",
+            }
+        )
 
     if not stems:
         if json_events:
@@ -458,12 +492,14 @@ def run(
         raise FileNotFoundError(f"No stems found in {stems_dir}")
 
     if json_events:
-        emit({
-            "event": "progress",
-            "phase": "slicing",
-            "pct": 0,
-            "message": f"Slicing {len(stems)} stems into bars (time sig: {time_sig}/4)",
-        })
+        emit(
+            {
+                "event": "progress",
+                "phase": "slicing",
+                "pct": 0,
+                "message": f"Slicing {len(stems)} stems into bars (time sig: {time_sig}/4)",
+            }
+        )
 
     # Step 1: Detect BPM and beats.
     #
@@ -504,9 +540,7 @@ def run(
         bpm = manifest_tempo["bpm"]
         first_downbeat_sec = manifest_tempo["first_downbeat_sec"]
         # Use the longest stem as the duration anchor for grid synthesis.
-        max_duration = max(
-            float(sf.info(str(p)).duration) for p in stems.values()
-        )
+        max_duration = max(float(sf.info(str(p)).duration) for p in stems.values())
         beat_times, downbeat_times = _synthesize_beat_grid(
             bpm=bpm,
             first_downbeat_sec=first_downbeat_sec,
@@ -514,17 +548,19 @@ def run(
             time_sig=time_sig,
         )
         if json_events:
-            emit({
-                "event": "progress",
-                "phase": "alignment",
-                "pct": 2,
-                "message": (
-                    f"using stems.json tempo: bpm={bpm:.2f}, "
-                    f"first_downbeat={first_downbeat_sec:.4f}s "
-                    f"(source: {manifest_tempo['source']}) — "
-                    f"{len(beat_times)} beats, {len(downbeat_times)} downbeats"
-                ),
-            })
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "alignment",
+                    "pct": 2,
+                    "message": (
+                        f"using stems.json tempo: bpm={bpm:.2f}, "
+                        f"first_downbeat={first_downbeat_sec:.4f}s "
+                        f"(source: {manifest_tempo['source']}) — "
+                        f"{len(beat_times)} beats, {len(downbeat_times)} downbeats"
+                    ),
+                }
+            )
     else:
         # No usable stems.json — fall back to in-process detection.
         # Always get librosa beats as baseline (fast, reliable on drums).
@@ -532,6 +568,7 @@ def run(
 
         try:
             from stemforge.beat_detect import detect_beats_and_downbeats
+
             bt_source = source_audio or bpm_source
             bt_bpm, bt_beats, bt_downbeats = detect_beats_and_downbeats(bt_source)
 
@@ -545,9 +582,7 @@ def run(
                 )
                 bt_bar_durs = np.diff(bt_downbeats)
                 bt_cv = (
-                    bt_bar_durs[:-1].std() / bt_bar_durs[:-1].mean()
-                    if len(bt_bar_durs) > 2
-                    else 1
+                    bt_bar_durs[:-1].std() / bt_bar_durs[:-1].mean() if len(bt_bar_durs) > 2 else 1
                 )
 
                 if bt_cv < lib_cv:
@@ -556,11 +591,23 @@ def run(
                     downbeat_times = bt_downbeats
                     if json_events:
                         src_label = "full mix" if source_audio else "drums stem"
-                        emit({"event": "progress", "phase": "alignment", "pct": 2,
-                              "message": f"beat-this ({src_label}): {len(downbeat_times)} downbeats, CV {bt_cv*100:.1f}% (librosa was {lib_cv*100:.1f}%)"})
+                        emit(
+                            {
+                                "event": "progress",
+                                "phase": "alignment",
+                                "pct": 2,
+                                "message": f"beat-this ({src_label}): {len(downbeat_times)} downbeats, CV {bt_cv * 100:.1f}% (librosa was {lib_cv * 100:.1f}%)",
+                            }
+                        )
                 elif json_events:
-                    emit({"event": "progress", "phase": "alignment", "pct": 2,
-                          "message": f"beat-this CV {bt_cv*100:.1f}% > librosa {lib_cv*100:.1f}%, using librosa"})
+                    emit(
+                        {
+                            "event": "progress",
+                            "phase": "alignment",
+                            "pct": 2,
+                            "message": f"beat-this CV {bt_cv * 100:.1f}% > librosa {lib_cv * 100:.1f}%, using librosa",
+                        }
+                    )
         except ImportError:
             pass
 
@@ -593,8 +640,14 @@ def run(
                 if downbeat_offset > 0:
                     corrections.append(f"shifted {downbeat_offset} beat(s)")
                 if json_events:
-                    emit({"event": "progress", "phase": "alignment", "pct": 2,
-                          "message": f"beat grid corrected: {', '.join(corrections)} (CV {original_cv*100:.1f}%→{corrected_cv*100:.1f}%)"})
+                    emit(
+                        {
+                            "event": "progress",
+                            "phase": "alignment",
+                            "pct": 2,
+                            "message": f"beat grid corrected: {', '.join(corrections)} (CV {original_cv * 100:.1f}%→{corrected_cv * 100:.1f}%)",
+                        }
+                    )
 
     if json_events:
         emit({"event": "bpm", "bpm": bpm, "beat_count": len(beat_times)})
@@ -637,12 +690,14 @@ def run(
 
         pct = int(((i + 1) / len(stems)) * 50)  # slicing = 0-50%
         if json_events:
-            emit({
-                "event": "progress",
-                "phase": "slicing",
-                "pct": pct,
-                "message": f"{stem_name}: {len(bar_paths)} bars",
-            })
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "slicing",
+                    "pct": pct,
+                    "message": f"{stem_name}: {len(bar_paths)} bars",
+                }
+            )
 
     # Step 3: Per-stem phrase grouping + curation
     # Each stem gets its own phrase_bars and strategy from the config.
@@ -663,6 +718,7 @@ def run(
     # not explicitly forwarded.
     if is_loops_only or is_production:
         import dataclasses as _dc
+
         for s in stem_configs:
             sc = stem_configs[s]
             os_count = 8 if (is_production and s == "drums") else 0
@@ -679,9 +735,7 @@ def run(
     # In loops-only mode, always use per-stem curation — mirroring from drums
     # causes silent bars in non-drum stems (e.g. vocal bars from instrumental sections).
     all_same_phrase = (
-        len(phrase_bars_set) == 1
-        and next(iter(phrase_bars_set)) == 1
-        and not is_loops_only
+        len(phrase_bars_set) == 1 and next(iter(phrase_bars_set)) == 1 and not is_loops_only
     )
 
     curated_manifest = {
@@ -715,6 +769,7 @@ def run(
 
         # Build temp pool with only common-range bars
         import tempfile
+
         curation_pool = Path(tempfile.mkdtemp(prefix="sf_curate_"))
         common_bar_paths = []
         for bf in sorted(curation_bar_dir.glob(f"{curation_source}_bar_*.wav")):
@@ -725,16 +780,21 @@ def run(
                 common_bar_paths.append(dst)
 
         if json_events:
-            emit({
-                "event": "progress",
-                "phase": "curating",
-                "pct": 55,
-                "message": f"Selecting {n_bars} from {curation_source} ({len(common_bar_paths)} mirrorable)",
-            })
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "curating",
+                    "pct": 55,
+                    "message": f"Selecting {n_bars} from {curation_source} ({len(common_bar_paths)} mirrorable)",
+                }
+            )
 
         selected_paths = curate(
-            curation_pool, n_bars=n_bars, strategy=sc.strategy,
-            rms_floor=sc.rms_floor, crest_min=sc.crest_min,
+            curation_pool,
+            n_bars=n_bars,
+            strategy=sc.strategy,
+            rms_floor=sc.rms_floor,
+            crest_min=sc.crest_min,
             content_density_min=sc.content_density_min,
             distance_weights=sc.distance_weights,
         )
@@ -752,10 +812,14 @@ def run(
                 selected_indices.append(int(m.group(1)))
 
         if json_events:
-            emit({
-                "event": "progress", "phase": "curating", "pct": 70,
-                "message": f"Selected {len(selected_indices)} bars, mirroring across stems",
-            })
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "curating",
+                    "pct": 70,
+                    "message": f"Selected {len(selected_indices)} bars, mirroring across stems",
+                }
+            )
 
         # Mirror across all stems — v1: padded re-slice from source stem
         # per selected bar. Analysis ran on exact-bar WAVs; padding is
@@ -808,16 +872,19 @@ def run(
                         "phrase_bars": 1,
                         "file": str(dst),
                     }
-                    entry.update(build_curation_block(
-                        dst, phrase_bars=1,
-                        time_sig_numerator=time_sig,
-                        stem_schema=stem_schema,
-                        bpm=bpm,
-                        pad_bars_applied=reslice["pad_bars_applied"],
-                        bar_duration_sec=bar_duration_sec,
-                        ts_num=time_sig,
-                        raw_start_sec=reslice["raw_start_sec"],
-                    ))
+                    entry.update(
+                        build_curation_block(
+                            dst,
+                            phrase_bars=1,
+                            time_sig_numerator=time_sig,
+                            stem_schema=stem_schema,
+                            bpm=bpm,
+                            pad_bars_applied=reslice["pad_bars_applied"],
+                            bar_duration_sec=bar_duration_sec,
+                            ts_num=time_sig,
+                            raw_start_sec=reslice["raw_start_sec"],
+                        )
+                    )
                 else:
                     # Fallback: copy exact-bar WAV (v0 behaviour)
                     shutil.copy2(src, dst)
@@ -827,12 +894,15 @@ def run(
                         "phrase_bars": 1,
                         "file": str(dst),
                     }
-                    entry.update(build_curation_block(
-                        dst, phrase_bars=1,
-                        time_sig_numerator=time_sig,
-                        stem_schema=stem_schema,
-                        bpm=bpm,
-                    ))
+                    entry.update(
+                        build_curation_block(
+                            dst,
+                            phrase_bars=1,
+                            time_sig_numerator=time_sig,
+                            stem_schema=stem_schema,
+                            bpm=bpm,
+                        )
+                    )
                 stem_bars.append(entry)
             curated_manifest["stems"][stem_name] = stem_bars
 
@@ -854,12 +924,24 @@ def run(
             try:
                 ref_onsets = _detect_reference_onsets(ref_path)
                 if json_events:
-                    emit({"event": "progress", "phase": "curating", "pct": 88,
-                          "message": f"alignment: detected {len(ref_onsets)} onsets on {ref_stem_name} stem"})
+                    emit(
+                        {
+                            "event": "progress",
+                            "phase": "curating",
+                            "pct": 88,
+                            "message": f"alignment: detected {len(ref_onsets)} onsets on {ref_stem_name} stem",
+                        }
+                    )
             except Exception as e:
                 if json_events:
-                    emit({"event": "progress", "phase": "curating", "pct": 88,
-                          "message": f"alignment: ref-onset detection failed: {e}"})
+                    emit(
+                        {
+                            "event": "progress",
+                            "phase": "curating",
+                            "pct": 88,
+                            "message": f"alignment: ref-onset detection failed: {e}",
+                        }
+                    )
                 ref_onsets = None
 
         # ── Per-stem mode: each stem curated independently with its own phrase_bars ──
@@ -873,8 +955,11 @@ def run(
                 phrase_dir = stems_dir / f"{stem_name}_phrases"
                 if phrase_dir.exists():
                     shutil.rmtree(phrase_dir)
-                phrase_paths = group_bars_into_phrases(
-                    bar_dir, stem_name, sc.phrase_bars, output_dir=stems_dir,
+                group_bars_into_phrases(
+                    bar_dir,
+                    stem_name,
+                    sc.phrase_bars,
+                    output_dir=stems_dir,
                 )
                 curation_dir = phrase_dir
                 file_pattern = f"{stem_name}_phrase_*.wav"
@@ -887,39 +972,49 @@ def run(
             n_available = len(list(curation_dir.glob(file_pattern)))
 
             if json_events:
-                emit({
-                    "event": "progress",
-                    "phase": "curating",
-                    "pct": 55 + int((si / len(stem_bar_dirs)) * 35),
-                    "message": f"{stem_name}: selecting {sc.loop_count} {item_label}s from {n_available}",
-                })
+                emit(
+                    {
+                        "event": "progress",
+                        "phase": "curating",
+                        "pct": 55 + int((si / len(stem_bar_dirs)) * 35),
+                        "message": f"{stem_name}: selecting {sc.loop_count} {item_label}s from {n_available}",
+                    }
+                )
 
             # Detect song structure if any selection path needs it: melodic
             # mode (section-stratified) OR section-main-alt strategy.
             song_structure = None
             needs_structure = (
-                (sc.bottom_mode == "melodic" and sc.midi_extract)
-                or sc.strategy == "section-main-alt"
-            )
+                sc.bottom_mode == "melodic" and sc.midi_extract
+            ) or sc.strategy == "section-main-alt"
             if needs_structure:
                 try:
                     from stemforge.segmenter import detect_song_structure
+
                     song_structure = detect_song_structure(
                         stems.get(stem_name, next(iter(stems.values()))),
-                        beat_times=beat_times, bpm=bpm, time_sig=time_sig,
+                        beat_times=beat_times,
+                        bpm=bpm,
+                        time_sig=time_sig,
                     )
                     if json_events and song_structure.boundaries_bars:
-                        emit({
-                            "event": "progress",
-                            "phase": "curating",
-                            "pct": 55 + int((si / len(stem_bar_dirs)) * 35),
-                            "message": f"{stem_name}: form={song_structure.form}, selecting across sections",
-                        })
+                        emit(
+                            {
+                                "event": "progress",
+                                "phase": "curating",
+                                "pct": 55 + int((si / len(stem_bar_dirs)) * 35),
+                                "message": f"{stem_name}: form={song_structure.form}, selecting across sections",
+                            }
+                        )
                 except Exception:
                     pass  # fall back to regular curation
 
-            if (song_structure and song_structure.boundaries_bars
-                and sc.bottom_mode == "melodic" and sc.midi_extract):
+            if (
+                song_structure
+                and song_structure.boundaries_bars
+                and sc.bottom_mode == "melodic"
+                and sc.midi_extract
+            ):
                 selected = section_stratified_select(
                     curation_dir,
                     n_bars=sc.loop_count,
@@ -961,11 +1056,15 @@ def run(
                     if 0.5 * expected_dur <= d <= 1.5 * expected_dur:
                         kept.append(s)
                     elif json_events:
-                        emit({
-                            "event": "progress", "phase": "curating", "pct": 90,
-                            "message": f"{stem_name}: dropped {s.name} "
-                                       f"(duration {d:.2f}s vs expected {expected_dur:.2f}s)"
-                        })
+                        emit(
+                            {
+                                "event": "progress",
+                                "phase": "curating",
+                                "pct": 90,
+                                "message": f"{stem_name}: dropped {s.name} "
+                                f"(duration {d:.2f}s vs expected {expected_dur:.2f}s)",
+                            }
+                        )
                 selected = kept
 
             stem_bars = []
@@ -986,7 +1085,10 @@ def run(
                 phrase_idx = _parse_phrase_index(src.name)
                 if phrase_idx is not None:
                     first_bar_idx = _first_bar_idx_for_phrase(
-                        bar_dir, stem_name, sc.phrase_bars, phrase_idx,
+                        bar_dir,
+                        stem_name,
+                        sc.phrase_bars,
+                        phrase_idx,
                     )
                 else:
                     first_bar_idx = _parse_bar_index(src.name)
@@ -1015,16 +1117,19 @@ def run(
                         "phrase_bars": sc.phrase_bars,
                         "file": str(dst),
                     }
-                    entry.update(build_curation_block(
-                        dst, phrase_bars=sc.phrase_bars,
-                        time_sig_numerator=time_sig,
-                        stem_schema=stem_schema,
-                        bpm=bpm,
-                        pad_bars_applied=reslice["pad_bars_applied"],
-                        bar_duration_sec=bar_duration_sec,
-                        ts_num=time_sig,
-                        raw_start_sec=reslice["raw_start_sec"],
-                    ))
+                    entry.update(
+                        build_curation_block(
+                            dst,
+                            phrase_bars=sc.phrase_bars,
+                            time_sig_numerator=time_sig,
+                            stem_schema=stem_schema,
+                            bpm=bpm,
+                            pad_bars_applied=reslice["pad_bars_applied"],
+                            bar_duration_sec=bar_duration_sec,
+                            ts_num=time_sig,
+                            raw_start_sec=reslice["raw_start_sec"],
+                        )
+                    )
                 else:
                     target_dur = _bar_dur_for_filter * float(sc.phrase_bars or 1)
                     used_alignment = False
@@ -1045,10 +1150,15 @@ def run(
                     ):
                         nominal_start = float(first_bar_idx - 1) * bar_duration_sec
                         snapped_start = _snap_to_nearest_onset(
-                            nominal_start, ref_onsets, max_offset_sec=0.150,
+                            nominal_start,
+                            ref_onsets,
+                            max_offset_sec=0.150,
                         )
                         if _reextract_slice(
-                            source_stem_path, dst, snapped_start, target_dur,
+                            source_stem_path,
+                            dst,
+                            snapped_start,
+                            target_dur,
                         ):
                             used_alignment = True
 
@@ -1066,8 +1176,14 @@ def run(
                             _normalize_wav_duration(dst, target_dur)
                         except Exception as e:
                             if json_events:
-                                emit({"event": "progress", "phase": "curating", "pct": 92,
-                                      "message": f"normalize {dst.name} failed: {e}"})
+                                emit(
+                                    {
+                                        "event": "progress",
+                                        "phase": "curating",
+                                        "pct": 92,
+                                        "message": f"normalize {dst.name} failed: {e}",
+                                    }
+                                )
 
                     # Optional: trim to first onset for performance/key mode
                     # (rotate audio so first transient sits at sample 0; pad
@@ -1080,8 +1196,14 @@ def run(
                             )
                         except Exception as e:
                             if json_events:
-                                emit({"event": "progress", "phase": "curating", "pct": 93,
-                                      "message": f"trim-to-onset {dst.name} failed: {e}"})
+                                emit(
+                                    {
+                                        "event": "progress",
+                                        "phase": "curating",
+                                        "pct": 93,
+                                        "message": f"trim-to-onset {dst.name} failed: {e}",
+                                    }
+                                )
 
                     entry = {
                         "position": position + 1,
@@ -1089,12 +1211,15 @@ def run(
                         "phrase_bars": sc.phrase_bars,
                         "file": str(dst),
                     }
-                    entry.update(build_curation_block(
-                        dst, phrase_bars=sc.phrase_bars,
-                        time_sig_numerator=time_sig,
-                        stem_schema=stem_schema,
-                        bpm=bpm,
-                    ))
+                    entry.update(
+                        build_curation_block(
+                            dst,
+                            phrase_bars=sc.phrase_bars,
+                            time_sig_numerator=time_sig,
+                            stem_schema=stem_schema,
+                            bpm=bpm,
+                        )
+                    )
                 stem_bars.append(entry)
 
             curated_manifest["stems"][stem_name] = stem_bars
@@ -1103,8 +1228,14 @@ def run(
     # loops-only: skip all one-shots
     # production: only extract drum one-shots
     if is_loops_only and json_events:
-        emit({"event": "progress", "phase": "oneshots", "pct": 80,
-              "message": "loops-only mode: skipping one-shot extraction"})
+        emit(
+            {
+                "event": "progress",
+                "phase": "oneshots",
+                "pct": 80,
+                "message": "loops-only mode: skipping one-shot extraction",
+            }
+        )
 
     for stem_name, stem_path in stems.items():
         if is_loops_only:
@@ -1116,23 +1247,31 @@ def run(
             continue
 
         if json_events:
-            emit({
-                "event": "progress",
-                "phase": "oneshots",
-                "pct": 80,
-                "message": f"{stem_name}: extracting one-shots",
-            })
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "oneshots",
+                    "pct": 80,
+                    "message": f"{stem_name}: extracting one-shots",
+                }
+            )
 
         # Extract one-shots — try LarsNet first for drums (clean sub-stem separation)
         os_profiles = []
         if stem_name == "drums":
             from stemforge.drum_separator import is_available as _larsnet_ok
+
             if _larsnet_ok():
                 if json_events:
-                    emit({"event": "progress", "phase": "oneshots", "pct": 81,
-                          "message": "drums: using LarsNet sub-stem separation (kick/snare/hihat/toms/cymbals)"})
-                os_profiles = extract_drum_oneshots_via_larsnet(
-                    stem_path, curated_root, config=sc)
+                    emit(
+                        {
+                            "event": "progress",
+                            "phase": "oneshots",
+                            "pct": 81,
+                            "message": "drums: using LarsNet sub-stem separation (kick/snare/hihat/toms/cymbals)",
+                        }
+                    )
+                os_profiles = extract_drum_oneshots_via_larsnet(stem_path, curated_root, config=sc)
 
         if not os_profiles:
             # Fallback: spectral heuristic extraction
@@ -1181,12 +1320,15 @@ def run(
             }
             # Oneshots have no fixed phrase_bars — pass None so beat_pos_end is
             # derived from BPM + duration.
-            entry.update(build_curation_block(
-                dst, phrase_bars=None,
-                time_sig_numerator=time_sig,
-                stem_schema=stem_schema,
-                bpm=bpm,
-            ))
+            entry.update(
+                build_curation_block(
+                    dst,
+                    phrase_bars=None,
+                    time_sig_numerator=time_sig,
+                    stem_schema=stem_schema,
+                    bpm=bpm,
+                )
+            )
             oneshot_entries.append(entry)
 
         # Upgrade manifest stem entry to v2 format (loops + oneshots)
@@ -1200,12 +1342,14 @@ def run(
             existing["oneshots"] = oneshot_entries
 
         if json_events:
-            emit({
-                "event": "progress",
-                "phase": "oneshots",
-                "pct": 85,
-                "message": f"{stem_name}: {len(oneshot_entries)} one-shots selected",
-            })
+            emit(
+                {
+                    "event": "progress",
+                    "phase": "oneshots",
+                    "pct": 85,
+                    "message": f"{stem_name}: {len(oneshot_entries)} one-shots selected",
+                }
+            )
 
     # Normalize all stems to {loops, oneshots} shape — stems that skipped
     # oneshot extraction (loops-only mode, or non-drum stems in production
@@ -1220,6 +1364,7 @@ def run(
     # Embed processing config (pipeline targets) into manifest for M4L loader
     if pipeline and pipeline.exists():
         import yaml
+
         pipeline_data = yaml.safe_load(pipeline.read_text())
         if "stems" in pipeline_data:
             curated_manifest["processing_config"] = pipeline_data["stems"]
@@ -1240,9 +1385,7 @@ def run(
     if main_manifest.exists():
         main_data = json.loads(main_manifest.read_text())
         # Count items per stem from the manifest we just built
-        bars_per_stem = max(
-            (len(v) for v in curated_manifest["stems"].values()), default=0
-        )
+        bars_per_stem = max((len(v) for v in curated_manifest["stems"].values()), default=0)
         main_data["curated"] = {
             "manifest": str(manifest_path),
             "n_bars": n_bars,
@@ -1263,19 +1406,23 @@ def run(
     items_per_stem = {k: _count_items(v) for k, v in curated_manifest["stems"].items()}
 
     if json_events:
-        emit({
-            "event": "progress",
-            "phase": "curating",
-            "pct": 95,
-            "message": f"Curated {total_items} items across {len(stems)} stems",
-        })
-        emit({
-            "event": "curated",
-            "manifest": str(manifest_path),
-            "items_per_stem": items_per_stem,
-            "stems": list(stems.keys()),
-            "bpm": bpm,
-        })
+        emit(
+            {
+                "event": "progress",
+                "phase": "curating",
+                "pct": 95,
+                "message": f"Curated {total_items} items across {len(stems)} stems",
+            }
+        )
+        emit(
+            {
+                "event": "curated",
+                "manifest": str(manifest_path),
+                "items_per_stem": items_per_stem,
+                "stems": list(stems.keys()),
+                "bpm": bpm,
+            }
+        )
 
     return manifest_path
 
@@ -1342,16 +1489,18 @@ def reslice_curated_from_anchor(
     bar_duration_sec = 60.0 / new_bpm * time_sig_numerator
 
     if json_events:
-        emit({
-            "event": "progress",
-            "phase": "reslice",
-            "pct": 0,
-            "message": (
-                f"reslicing curated loops at new anchor: bpm={new_bpm:.2f}, "
-                f"first_downbeat={new_first_downbeat:.4f}s, "
-                f"bar_duration={bar_duration_sec:.4f}s"
-            ),
-        })
+        emit(
+            {
+                "event": "progress",
+                "phase": "reslice",
+                "pct": 0,
+                "message": (
+                    f"reslicing curated loops at new anchor: bpm={new_bpm:.2f}, "
+                    f"first_downbeat={new_first_downbeat:.4f}s, "
+                    f"bar_duration={bar_duration_sec:.4f}s"
+                ),
+            }
+        )
 
     # Locate source stem WAVs for re-extraction.
     stems_by_name = find_stems(stems_dir)
@@ -1377,12 +1526,14 @@ def reslice_curated_from_anchor(
         source_stem_path = stems_by_name.get(stem_name)
         if source_stem_path is None or not source_stem_path.exists():
             if json_events:
-                emit({
-                    "event": "progress",
-                    "phase": "reslice",
-                    "pct": int((n_done / max(total_loops, 1)) * 100),
-                    "message": f"{stem_name}: no source stem on disk; skipping {len(loops)} loops",
-                })
+                emit(
+                    {
+                        "event": "progress",
+                        "phase": "reslice",
+                        "pct": int((n_done / max(total_loops, 1)) * 100),
+                        "message": f"{stem_name}: no source stem on disk; skipping {len(loops)} loops",
+                    }
+                )
             n_skipped += len(loops)
             continue
 
@@ -1411,12 +1562,14 @@ def reslice_curated_from_anchor(
                 )
             except ValueError as e:
                 if json_events:
-                    emit({
-                        "event": "progress",
-                        "phase": "reslice",
-                        "pct": int((n_done / max(total_loops, 1)) * 100),
-                        "message": f"{stem_name} bar {bar_idx}: {e}; skipping",
-                    })
+                    emit(
+                        {
+                            "event": "progress",
+                            "phase": "reslice",
+                            "pct": int((n_done / max(total_loops, 1)) * 100),
+                            "message": f"{stem_name} bar {bar_idx}: {e}; skipping",
+                        }
+                    )
                 n_skipped += 1
                 continue
 
@@ -1454,48 +1607,65 @@ def reslice_curated_from_anchor(
     # longest source stem so it reflects the new grid.
     curated["bpm"] = new_bpm
     if stems_by_name:
-        max_duration = max(
-            float(sf.info(str(p)).duration) for p in stems_by_name.values()
-        )
+        max_duration = max(float(sf.info(str(p)).duration) for p in stems_by_name.values())
         curated["beat_count"] = int(max_duration * new_bpm / 60.0)
 
     manifest_path.write_text(json.dumps(curated, indent=2))
 
     if json_events:
-        emit({
-            "event": "resliced",
-            "manifest": str(manifest_path),
-            "loops_resliced": n_done,
-            "loops_skipped": n_skipped,
-            "bpm": new_bpm,
-            "first_downbeat_sec": new_first_downbeat,
-        })
+        emit(
+            {
+                "event": "resliced",
+                "manifest": str(manifest_path),
+                "loops_resliced": n_done,
+                "loops_skipped": n_skipped,
+                "bpm": new_bpm,
+                "first_downbeat_sec": new_first_downbeat,
+            }
+        )
 
     return manifest_path
 
 
 def main():
     ap = argparse.ArgumentParser(description="Bar-slice + curate stems from a split session")
-    ap.add_argument("--stems-dir", required=True, type=Path,
-                    help="Directory containing drums.wav, bass.wav, etc.")
-    ap.add_argument("--n-bars", type=int, default=16,
-                    help="Number of bars to select per stem (default: 16)")
-    ap.add_argument("--strategy", default="max-diversity",
-                    choices=["max-diversity", "rhythm-taxonomy", "sectional"])
-    ap.add_argument("--time-sig", type=int, default=4,
-                    help="Time signature numerator (default: 4)")
-    ap.add_argument("--json-events", action="store_true",
-                    help="Emit NDJSON events on stdout")
-    ap.add_argument("--curation", type=Path, default=None,
-                    help="Curation config YAML (default: pipelines/curation.yaml)")
-    ap.add_argument("--pipeline", type=Path, default=None,
-                    help="Processing pipeline YAML to embed in manifest (e.g. pipelines/production_idm.yaml)")
-    ap.add_argument("--reslice-only", action="store_true",
-                    help="Skip bar-slicing + curation. Just rewrite the existing "
-                         "curated/<stem>/bar_NNN.wav files at the current "
-                         "stems.json anchor (BPM + first_downbeat). Used by "
-                         "`stemforge re-anchor` to keep curated loops in sync "
-                         "without re-running diversity selection or LarsNet.")
+    ap.add_argument(
+        "--stems-dir",
+        required=True,
+        type=Path,
+        help="Directory containing drums.wav, bass.wav, etc.",
+    )
+    ap.add_argument(
+        "--n-bars", type=int, default=16, help="Number of bars to select per stem (default: 16)"
+    )
+    ap.add_argument(
+        "--strategy",
+        default="max-diversity",
+        choices=["max-diversity", "rhythm-taxonomy", "sectional"],
+    )
+    ap.add_argument("--time-sig", type=int, default=4, help="Time signature numerator (default: 4)")
+    ap.add_argument("--json-events", action="store_true", help="Emit NDJSON events on stdout")
+    ap.add_argument(
+        "--curation",
+        type=Path,
+        default=None,
+        help="Curation config YAML (default: pipelines/curation.yaml)",
+    )
+    ap.add_argument(
+        "--pipeline",
+        type=Path,
+        default=None,
+        help="Processing pipeline YAML to embed in manifest (e.g. pipelines/production_idm.yaml)",
+    )
+    ap.add_argument(
+        "--reslice-only",
+        action="store_true",
+        help="Skip bar-slicing + curation. Just rewrite the existing "
+        "curated/<stem>/bar_NNN.wav files at the current "
+        "stems.json anchor (BPM + first_downbeat). Used by "
+        "`stemforge re-anchor` to keep curated loops in sync "
+        "without re-running diversity selection or LarsNet.",
+    )
     args = ap.parse_args()
 
     if args.reslice_only:

--- a/v0/tests/conftest.py
+++ b/v0/tests/conftest.py
@@ -5,6 +5,7 @@ Fixture resolution is designed to be tolerant across development stages:
 - Amxd / Als: in-tree only; skip if absent so upstream gaps don't fail G.
 - Schema / yaml: always read from interfaces/ — required.
 """
+
 from __future__ import annotations
 
 import json
@@ -60,8 +61,7 @@ def als_path() -> Path:
     p = V0 / "build" / "StemForge.als"
     if not p.exists():
         pytest.skip(
-            "StemForge.als not built yet — skeleton.als asset pending "
-            "(see v0/state/D/blocker.md)"
+            "StemForge.als not built yet — skeleton.als asset pending (see v0/state/D/blocker.md)"
         )
     return p
 
@@ -82,12 +82,14 @@ def ndjson_schema() -> dict:
 @pytest.fixture(scope="session")
 def tracks_yaml() -> dict:
     import yaml
+
     return yaml.safe_load((V0 / "interfaces" / "tracks.yaml").read_text())
 
 
 @pytest.fixture(scope="session")
 def device_yaml() -> dict:
     import yaml
+
     return yaml.safe_load((V0 / "interfaces" / "device.yaml").read_text())
 
 

--- a/v0/tests/fixtures/generate_loop.py
+++ b/v0/tests/fixtures/generate_loop.py
@@ -21,6 +21,7 @@ Usage (regenerate from scratch; DO NOT overwrite committed short_loop.wav):
 
 Track G does not call this at test time — it uses the committed WAV.
 """
+
 from __future__ import annotations
 
 import sys
@@ -35,7 +36,9 @@ NUM_BEATS = 8  # 2 bars at 4/4
 TARGET_DURATION_SEC = 10.0  # A-validator committed a 10s loop
 
 
-def render_loop(sr: int = SAMPLE_RATE, bpm: int = BPM, duration_sec: float = TARGET_DURATION_SEC) -> np.ndarray:
+def render_loop(
+    sr: int = SAMPLE_RATE, bpm: int = BPM, duration_sec: float = TARGET_DURATION_SEC
+) -> np.ndarray:
     """Render a mono float32 drum-like loop."""
     beat_sec = 60.0 / bpm
     base_dur = NUM_BEATS * beat_sec  # 4.0s @ 120 BPM

--- a/v0/tests/test_als.py
+++ b/v0/tests/test_als.py
@@ -9,6 +9,7 @@ We parse with the stdlib ``xml.etree`` rather than adding an ``lxml``
 dependency — the checks here are structural (tag names, string matches) and
 don't need lxml's extra features.
 """
+
 from __future__ import annotations
 
 import gzip
@@ -17,6 +18,7 @@ from pathlib import Path
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
+
 
 def _parse_als(als_path: Path) -> ET.ElementTree:
     with gzip.open(als_path, "rb") as f:
@@ -59,6 +61,7 @@ def _find_track_by_name(tree: ET.ElementTree, name: str):
 
 # ── tests ──────────────────────────────────────────────────────────────────
 
+
 def test_als_exists(als_path: Path) -> None:
     """File is present (else skipped) and is large enough to be real."""
     assert als_path.exists()
@@ -84,8 +87,7 @@ def test_als_has_expected_tracks(als_path: Path, tracks_yaml: dict) -> None:
     names = _track_names(tree)
     missing = [t["name"] for t in tracks_yaml["tracks"] if t["name"] not in names]
     assert not missing, (
-        f"tracks from tracks.yaml missing in .als: {missing}. "
-        f"Names seen: {sorted(names)}"
+        f"tracks from tracks.yaml missing in .als: {missing}. Names seen: {sorted(names)}"
     )
 
 

--- a/v0/tests/test_amxd.py
+++ b/v0/tests/test_amxd.py
@@ -11,6 +11,7 @@ These tests parse the built .amxd container and confirm:
 We reuse the Track C container reader (``v0/src/maxpat-builder/amxd_pack.py``)
 rather than re-implementing the format. conftest adds it to ``sys.path``.
 """
+
 from __future__ import annotations
 
 import json
@@ -18,10 +19,9 @@ import struct
 from pathlib import Path
 from typing import Iterable
 
-import pytest
-
 
 # ── helpers ────────────────────────────────────────────────────────────────
+
 
 def _walk_boxes(patcher: dict) -> Iterable[dict]:
     """Yield every ``box`` dict under ``patcher.boxes[].box`` recursively.
@@ -51,6 +51,7 @@ def _expected_box_id(yaml_id: str) -> str:
 
 
 # ── tests ──────────────────────────────────────────────────────────────────
+
 
 def test_amxd_exists(amxd_path: Path) -> None:
     """Built device is present and at least 1KB (rules out empty/truncated)."""
@@ -86,9 +87,7 @@ def test_amxd_references_bridge_js(amxd_path: Path) -> None:
     # Full-text search on the serialized patcher is robust to wherever the
     # filename ends up (node.script filename arg, inspector data, etc).
     blob = json.dumps(parsed["patcher"])
-    assert "stemforge_bridge.v0.js" in blob, (
-        "patcher does not reference stemforge_bridge.v0.js"
-    )
+    assert "stemforge_bridge.v0.js" in blob, "patcher does not reference stemforge_bridge.v0.js"
 
 
 def test_amxd_ui_matches_device_yaml(amxd_path: Path, device_yaml: dict) -> None:

--- a/v0/tests/test_arrangement_reader.py
+++ b/v0/tests/test_arrangement_reader.py
@@ -8,6 +8,7 @@ The JS suite exercises ``v0/src/m4l-js/sf_arrangement_reader.js`` (the
 arrangement-view → snapshot.json reader) under a Node-vm sandbox with
 mock LiveAPI/File so no Max install or Ableton instance is required.
 """
+
 from __future__ import annotations
 
 import shutil

--- a/v0/tests/test_binary.py
+++ b/v0/tests/test_binary.py
@@ -13,6 +13,7 @@ These tests run the binary against a committed test fixture
 
 All tests skip cleanly if the binary is not resolvable — A gates G at runtime.
 """
+
 from __future__ import annotations
 
 import json
@@ -27,7 +28,10 @@ TIMEOUT_SEC = 600  # Demucs on CPU takes ~20s per 10s of audio; leave headroom.
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
-def _run_split(binary: Path, wav: Path, out: Path, json_events: bool = True) -> subprocess.CompletedProcess:
+
+def _run_split(
+    binary: Path, wav: Path, out: Path, json_events: bool = True
+) -> subprocess.CompletedProcess:
     # CLI flag is --out (see v0/src/A/cli/main.cpp).
     cmd = [str(binary), "split", str(wav), "--out", str(out)]
     if json_events:
@@ -73,6 +77,7 @@ def _type_name(v) -> str:
 
 # ── tests ──────────────────────────────────────────────────────────────────
 
+
 def test_binary_version(binary_path: Path) -> None:
     """Binary supports --version and exits 0."""
     proc = subprocess.run(
@@ -82,7 +87,7 @@ def test_binary_version(binary_path: Path) -> None:
         timeout=30,
     )
     assert proc.returncode == 0, f"stderr={proc.stderr!r}"
-    assert (proc.stdout.strip() or proc.stderr.strip()), "no version output"
+    assert proc.stdout.strip() or proc.stderr.strip(), "no version output"
 
 
 def test_binary_emits_valid_ndjson(
@@ -104,8 +109,7 @@ def test_binary_emits_valid_ndjson(
     for i, evt in enumerate(events):
         errors = list(validator.iter_errors(evt))
         assert not errors, (
-            f"event #{i} ({evt.get('event')!r}) failed schema: "
-            f"{[e.message for e in errors]}"
+            f"event #{i} ({evt.get('event')!r}) failed schema: {[e.message for e in errors]}"
         )
 
 

--- a/v0/tests/test_pkg_install.py
+++ b/v0/tests/test_pkg_install.py
@@ -25,6 +25,7 @@ Run:
    uv run pytest v0/tests/test_pkg_install.py -v
    STEMFORGE_INSTALL_E2E=1 uv run pytest v0/tests/test_pkg_install.py -v
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -42,9 +43,7 @@ REPO = Path(__file__).resolve().parents[2]
 V0 = REPO / "v0"
 PKG_PATH = V0 / "build" / "StemForge-0.0.0.pkg"
 PKG_MIN_BYTES = 100 * 1024 * 1024  # 100 MB floor; real pkg is ~409 MB.
-FUSED_ONNX_SHA256 = (
-    "71828190efe191a622f9c9273471de1458fe0e108f277872d43c5c81cbe29ce9"
-)
+FUSED_ONNX_SHA256 = "71828190efe191a622f9c9273471de1458fe0e108f277872d43c5c81cbe29ce9"
 PKGUTIL = "/usr/sbin/pkgutil"
 
 
@@ -218,8 +217,7 @@ def test_user_staging_has_manifest(user_staging: Path) -> None:
     assert manifest_path.is_file(), f"{manifest_path} missing"
     data = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert "models" in data, (
-        f"manifest.json is missing top-level 'models' key. "
-        f"Keys present: {sorted(data.keys())}"
+        f"manifest.json is missing top-level 'models' key. Keys present: {sorted(data.keys())}"
     )
 
 
@@ -270,6 +268,7 @@ def test_user_staging_has_als(user_staging: Path) -> None:
     assert als.stat().st_size > 512, f"implausibly small: {als.stat().st_size}"
     import gzip
     import xml.etree.ElementTree as ET
+
     with gzip.open(als, "rb") as f:
         tree = ET.parse(f)
     root_tag = tree.getroot().tag.rsplit("}", 1)[-1]
@@ -314,10 +313,7 @@ E2E_ENV_VAR = "STEMFORGE_INSTALL_E2E"
 
 @pytest.mark.skipif(
     os.environ.get(E2E_ENV_VAR) != "1",
-    reason=(
-        f"tier-2 e2e install test is gated on {E2E_ENV_VAR}=1 "
-        "(requires sudo + takes ~1 min)"
-    ),
+    reason=(f"tier-2 e2e install test is gated on {E2E_ENV_VAR}=1 (requires sudo + takes ~1 min)"),
 )
 def test_pkg_installs_end_to_end(pkg_path: Path, tmp_path: Path) -> None:
     """W4 tier-2 — `sudo installer` into a throwaway root + run the binary.
@@ -331,9 +327,12 @@ def test_pkg_installs_end_to_end(pkg_path: Path, tmp_path: Path) -> None:
 
     install = subprocess.run(
         [
-            "sudo", "installer",
-            "-pkg", str(pkg_path),
-            "-target", str(tmproot),
+            "sudo",
+            "installer",
+            "-pkg",
+            str(pkg_path),
+            "-target",
+            str(tmproot),
         ],
         capture_output=True,
         text=True,

--- a/v0/tests/validate-ndjson.py
+++ b/v0/tests/validate-ndjson.py
@@ -7,6 +7,7 @@ Used by the Track A self-test:
         | jq -c 'select(.event)' \
         | python v0/tests/validate-ndjson.py
 """
+
 from __future__ import annotations
 
 import json
@@ -16,12 +17,10 @@ from pathlib import Path
 try:
     import jsonschema
 except ImportError:  # pragma: no cover
-    print("jsonschema not installed — run `uv pip install jsonschema`",
-          file=sys.stderr)
+    print("jsonschema not installed — run `uv pip install jsonschema`", file=sys.stderr)
     sys.exit(2)
 
-SCHEMA_PATH = (Path(__file__).resolve().parents[1]
-               / "interfaces" / "ndjson.schema.json")
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "interfaces" / "ndjson.schema.json"
 
 
 def main() -> int:


### PR DESCRIPTION
Hardening pass so `main` is a clean, verified baseline to branch from.

## Changes (all in `v0/`)

**1. Fix the 2 long-standing `test_amxd_pack` failures.** `unpack_amxd` validated offset 8 against only the `aaaa` (audio-effect) device-class sentinel, so it rejected real instrument/builder `.amxd` files — the `StemForgeTemplateBuilder` reference is `iiii`. Now accepts any known sentinel (`aaaa`/`mmmm`/`iiii`).

**2. Lint-clean `v0/`.** `ruff check --fix` (22 unused imports, 5 empty f-strings), 4 unused variables removed by hand, and `ruff format` (51 files). `v0/` now passes `ruff check` + `ruff format --check`.

## Verification

- **Full suite: 1359 passed, 0 failed** (previously 1356 passed / 9 failed — the amxd_pack pair + venv extras).
- CI scope (`stemforge/` + `tests/`) untouched — no behavior changes there.
- All changes confined to `v0/`.

Note: the ~1500 ruff figure quoted earlier was inflated by the 48 agent worktrees; real `v0/` debt was 31 errors + 51 files to format, all resolved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)